### PR TITLE
fix(ci): enable display_report for claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          display_report: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

Enable `display_report: true` in the claude-code-review workflow so Claude always posts a summary comment on PRs — even when no issues are found.

Previously, with `display_report: false` (the default), Claude would review the code silently and only post inline comments when it found issues. This made it unclear whether the review actually ran.