### PR TITLE
feat(microblog): add mentions and conversations support

### DIFF
--- a/packages/lestash-microblog/src/lestash_microblog/client.py
+++ b/packages/lestash-microblog/src/lestash_microblog/client.py
@@ -7,6 +7,7 @@ from typing import Any
 import httpx
 
 MICROPUB_ENDPOINT = "https://micro.blog/micropub"
+MICROBLOG_API_BASE = "https://micro.blog"
 
 
 def get_config_dir() -> Path:
@@ -190,6 +191,97 @@ class MicropubClient:
             offset += limit
 
         return all_posts
+
+    def _api_get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Make a GET request to the Micro.blog JSON Feed API.
+
+        Args:
+            path: API path (e.g., "/posts/mentions").
+            params: Optional query parameters.
+
+        Returns:
+            Response JSON data.
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails.
+        """
+        url = f"{MICROBLOG_API_BASE}{path}"
+        response = self._client.get(url, params=params)
+        response.raise_for_status()
+        return response.json()
+
+    def get_mentions(
+        self,
+        count: int = 20,
+        before_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch mentions (replies from others) via JSON Feed API.
+
+        Args:
+            count: Maximum number of items to fetch.
+            before_id: Fetch items before this ID (for pagination).
+
+        Returns:
+            List of JSON Feed items.
+        """
+        params: dict[str, Any] = {"count": count}
+        if before_id is not None:
+            params["before_id"] = before_id
+
+        result = self._api_get("/posts/mentions", params)
+        return result.get("items", [])
+
+    def get_all_mentions(
+        self,
+        count: int = 100,
+        max_items: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch all mentions with cursor-based pagination.
+
+        Args:
+            count: Number of items per request.
+            max_items: Maximum total items to fetch (None for all).
+
+        Returns:
+            List of all JSON Feed mention items.
+        """
+        all_items: list[dict[str, Any]] = []
+
+        before_id = None
+        while True:
+            items = self.get_mentions(count=count, before_id=before_id)
+            if not items:
+                break
+
+            all_items.extend(items)
+
+            if max_items is not None and len(all_items) >= max_items:
+                all_items = all_items[:max_items]
+                break
+
+            if len(items) < count:
+                break
+
+            # Use the last item's _microblog.id for cursor
+            last = items[-1]
+            last_id = last.get("_microblog", {}).get("id") or last.get("id")
+            if last_id is None:
+                break
+            before_id = int(last_id)
+
+        return all_items
+
+    def get_conversation(self, post_id: str) -> list[dict[str, Any]]:
+        """Fetch a full conversation thread via JSON Feed API.
+
+        Args:
+            post_id: Micro.blog post ID.
+
+        Returns:
+            List of JSON Feed items in the thread.
+        """
+        result = self._api_get("/posts/conversation", {"id": post_id})
+        return result.get("items", [])
 
     def verify_token(self) -> dict[str, Any]:
         """Verify the token is valid by fetching config.

--- a/packages/lestash-microblog/src/lestash_microblog/source.py
+++ b/packages/lestash-microblog/src/lestash_microblog/source.py
@@ -193,6 +193,106 @@ def post_to_item(entry: dict[str, Any], is_own: bool = True) -> ItemCreate:
     )
 
 
+def json_feed_item_to_item(
+    item: dict[str, Any],
+    is_own: bool = False,
+    conversation_id: str | None = None,
+) -> ItemCreate:
+    """Convert a Micro.blog JSON Feed item to ItemCreate.
+
+    JSON Feed items have a different structure from Micropub h-entries.
+    This handles the /posts/mentions and /posts/conversation format.
+
+    Args:
+        item: JSON Feed item dict.
+        is_own: Whether this is the user's own content.
+        conversation_id: Optional conversation thread identifier.
+
+    Returns:
+        ItemCreate object for storage.
+    """
+    url = item.get("url")
+    content = item.get("content_text") or item.get("content_html", "")
+    published = item.get("date_published")
+    created_at = parse_datetime(published)
+
+    # Use URL as source_id to align with h-entry dedup
+    source_id = url
+
+    # Extract author info
+    author_data = item.get("author", {})
+    author_name = author_data.get("name") if isinstance(author_data, dict) else None
+    author_url = author_data.get("url") if isinstance(author_data, dict) else None
+
+    # Extract _microblog extension
+    microblog = item.get("_microblog", {})
+    author_microblog = author_data.get("_microblog", {}) if isinstance(author_data, dict) else {}
+
+    # Build metadata
+    metadata: dict[str, Any] = {}
+
+    if microblog.get("id"):
+        metadata["microblog_id"] = microblog["id"]
+    if microblog.get("is_mention"):
+        metadata["is_mention"] = True
+    if microblog.get("in_reply_to"):
+        metadata["in_reply_to"] = [microblog["in_reply_to"]]
+    if author_name:
+        metadata["author_name"] = author_name
+    if author_url:
+        metadata["author_url"] = author_url
+    if author_microblog.get("username"):
+        metadata["author_username"] = author_microblog["username"]
+    if conversation_id:
+        metadata["conversation_id"] = conversation_id
+
+    return ItemCreate(
+        source_type="microblog",
+        source_id=source_id,
+        url=url,
+        title=None,  # JSON Feed microblog posts are short-form
+        content=content,
+        author=author_name,
+        created_at=created_at,
+        is_own_content=is_own,
+        metadata=metadata if metadata else None,
+    )
+
+
+def _upsert_item(conn, item: ItemCreate) -> int:
+    """Insert or update an item in the database.
+
+    Returns:
+        1 if a row was affected, 0 otherwise.
+    """
+    metadata_json = json.dumps(item.metadata) if item.metadata else None
+    cursor = conn.execute(
+        """
+        INSERT INTO items (
+            source_type, source_id, url, title, content,
+            author, created_at, is_own_content, metadata
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(source_type, source_id) DO UPDATE SET
+            content = excluded.content,
+            title = excluded.title,
+            author = excluded.author,
+            metadata = excluded.metadata
+        """,
+        (
+            item.source_type,
+            item.source_id,
+            item.url,
+            item.title,
+            item.content,
+            item.author,
+            item.created_at,
+            item.is_own_content,
+            metadata_json,
+        ),
+    )
+    return 1 if cursor.rowcount > 0 else 0
+
+
 class MicroblogSource(SourcePlugin):
     """Micro.blog source plugin."""
 
@@ -277,18 +377,39 @@ class MicroblogSource(SourcePlugin):
                 int | None,
                 typer.Option("--max", "-m", help="Maximum total posts to sync"),
             ] = None,
+            mentions: Annotated[
+                bool,
+                typer.Option("--mentions/--no-mentions", help="Sync mentions"),
+            ] = False,
+            conversations: Annotated[
+                bool,
+                typer.Option(
+                    "--conversations/--no-conversations",
+                    help="Sync conversation threads for your posts",
+                ),
+            ] = False,
+            sync_all: Annotated[
+                bool,
+                typer.Option("--all", help="Sync posts, mentions, and conversations"),
+            ] = False,
         ) -> None:
             """Sync your Micro.blog posts to the knowledge base.
 
-            Fetches all your posts from Micro.blog and stores them locally.
-            Uses saved credentials from 'lestash microblog auth'.
+            Fetches your posts from Micro.blog and stores them locally.
+            Use --mentions to also fetch replies from others, --conversations
+            to fetch full threads, or --all for everything.
 
             Example:
                 lestash microblog sync
-                lestash microblog sync --max 50
+                lestash microblog sync --mentions
+                lestash microblog sync --all
             """
             from lestash.core.config import Config
             from lestash.core.database import get_connection
+
+            if sync_all:
+                mentions = True
+                conversations = True
 
             # Check for token
             token = load_token()
@@ -299,10 +420,12 @@ class MicroblogSource(SourcePlugin):
             try:
                 from lestash_microblog.client import create_client
 
-                console.print("[dim]Syncing posts from Micro.blog...[/dim]")
+                config = Config.load()
+                items_added = 0
 
-                with create_client(token) as client:
-                    # Fetch all posts
+                with create_client(token) as client, get_connection(config) as conn:
+                    # Phase 1: Sync own posts
+                    console.print("[dim]Syncing posts from Micro.blog...[/dim]")
                     posts = client.get_all_posts(
                         limit=limit,
                         destination=destination,
@@ -310,53 +433,90 @@ class MicroblogSource(SourcePlugin):
                     )
                     console.print(f"[dim]Found {len(posts)} posts[/dim]")
 
-                    # Store in database
-                    config = Config.load()
-                    items_added = 0
+                    current_username = None
+                    for post in posts:
+                        try:
+                            item = post_to_item(post, is_own=True)
+                            items_added += _upsert_item(conn, item)
+                            # Detect current username from own posts
+                            if current_username is None and item.metadata:
+                                current_username = item.metadata.get("author_name")
+                        except Exception as e:
+                            sid = extract_property(post, "url") or extract_property(post, "uid")
+                            logger.warning(f"Failed to process post {sid}: {e}")
 
-                    with get_connection(config) as conn:
-                        for post in posts:
+                    conn.commit()
+                    console.print(f"[green]Synced {items_added} posts[/green]")
+
+                    # Phase 2: Sync mentions
+                    if mentions:
+                        console.print("[dim]Syncing mentions...[/dim]")
+                        mention_items = client.get_all_mentions(count=limit)
+                        console.print(f"[dim]Found {len(mention_items)} mentions[/dim]")
+
+                        mentions_added = 0
+                        for m in mention_items:
                             try:
-                                item = post_to_item(post, is_own=True)
-                                metadata_json = json.dumps(item.metadata) if item.metadata else None
-
-                                cursor = conn.execute(
-                                    """
-                                    INSERT INTO items (
-                                        source_type, source_id, url, title, content,
-                                        author, created_at, is_own_content, metadata
-                                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                                    ON CONFLICT(source_type, source_id) DO UPDATE SET
-                                        content = excluded.content,
-                                        title = excluded.title,
-                                        author = excluded.author,
-                                        metadata = excluded.metadata
-                                    """,
-                                    (
-                                        item.source_type,
-                                        item.source_id,
-                                        item.url,
-                                        item.title,
-                                        item.content,
-                                        item.author,
-                                        item.created_at,
-                                        item.is_own_content,
-                                        metadata_json,
-                                    ),
-                                )
-                                if cursor.rowcount > 0:
-                                    items_added += 1
+                                item = json_feed_item_to_item(m, is_own=False)
+                                mentions_added += _upsert_item(conn, item)
                             except Exception as e:
-                                source_id = extract_property(post, "url") or extract_property(
-                                    post, "uid"
-                                )
-                                logger.warning(f"Failed to process post {source_id}: {e}")
-                                continue
+                                logger.warning(f"Failed to process mention: {e}")
 
                         conn.commit()
+                        items_added += mentions_added
+                        console.print(f"[green]Synced {mentions_added} mentions[/green]")
 
-                logger.info(f"Sync completed: {items_added} items added")
-                console.print(f"[green]Synced {items_added} posts from Micro.blog[/green]")
+                    # Phase 3: Sync conversations
+                    if conversations:
+                        console.print("[dim]Syncing conversations...[/dim]")
+                        convos_added = 0
+                        seen_urls: set[str] = set()
+
+                        # Fetch conversations for mentions that reply to our posts
+                        if not mention_items:
+                            mention_items = client.get_all_mentions(count=limit)
+                        sources = mention_items
+                        for m in sources:
+                            microblog = m.get("_microblog", {})
+                            reply_to = microblog.get("in_reply_to")
+                            post_id = str(microblog.get("id", ""))
+                            if not post_id:
+                                continue
+
+                            try:
+                                thread = client.get_conversation(post_id)
+                                for entry in thread:
+                                    entry_url = entry.get("url", "")
+                                    if entry_url in seen_urls:
+                                        continue
+                                    seen_urls.add(entry_url)
+
+                                    # Determine is_own
+                                    author_mb = (
+                                        entry.get("author", {})
+                                        .get("_microblog", {})
+                                        .get("username", "")
+                                    )
+                                    entry_is_own = (
+                                        current_username is not None
+                                        and author_mb == current_username
+                                    )
+
+                                    item = json_feed_item_to_item(
+                                        entry,
+                                        is_own=entry_is_own,
+                                        conversation_id=reply_to or entry_url,
+                                    )
+                                    convos_added += _upsert_item(conn, item)
+                            except Exception as e:
+                                logger.warning(f"Failed to fetch conversation {post_id}: {e}")
+
+                        conn.commit()
+                        items_added += convos_added
+                        console.print(f"[green]Synced {convos_added} conversation items[/green]")
+
+                logger.info(f"Sync completed: {items_added} total items")
+                console.print(f"[bold green]Total: {items_added} items synced[/bold green]")
 
             except Exception as e:
                 logger.error(f"Sync failed: {e}", exc_info=True)
@@ -431,13 +591,19 @@ class MicroblogSource(SourcePlugin):
         return app
 
     def sync(self, config: dict) -> Iterator[ItemCreate]:
-        """Sync Micro.blog posts.
+        """Sync Micro.blog posts, mentions, and conversations.
 
         Args:
-            config: Plugin configuration (may contain 'destination', 'limit').
+            config: Plugin configuration. Supports keys:
+                - destination: Blog destination UID
+                - limit: Posts per request (default 100)
+                - max_posts: Maximum total posts
+                - mentions: bool, sync mentions (default False)
+                - conversations: bool, sync conversations (default False)
+                - all: bool, sync everything (default False)
 
         Yields:
-            ItemCreate objects for each post.
+            ItemCreate objects for each post/mention/conversation entry.
         """
         from lestash_microblog.client import create_client
 
@@ -446,21 +612,76 @@ class MicroblogSource(SourcePlugin):
             logger.warning("No token found for Micro.blog sync")
             return
 
+        do_mentions = config.get("mentions", False) or config.get("all", False)
+        do_conversations = config.get("conversations", False) or config.get("all", False)
+
         try:
             with create_client(token) as client:
+                # Phase 1: Own posts
                 posts = client.get_all_posts(
                     limit=config.get("limit", 100),
                     destination=config.get("destination"),
                     max_posts=config.get("max_posts"),
                 )
 
+                current_username = None
                 for post in posts:
                     try:
-                        yield post_to_item(post, is_own=True)
+                        item = post_to_item(post, is_own=True)
+                        if current_username is None and item.metadata:
+                            current_username = item.metadata.get("author_name")
+                        yield item
                     except Exception as e:
-                        source_id = extract_property(post, "url") or extract_property(post, "uid")
-                        logger.warning(f"Failed to process post {source_id}: {e}")
-                        continue
+                        sid = extract_property(post, "url") or extract_property(post, "uid")
+                        logger.warning(f"Failed to process post {sid}: {e}")
+
+                # Phase 2: Mentions
+                mention_items = []
+                if do_mentions:
+                    mention_items = client.get_all_mentions(
+                        count=config.get("limit", 100),
+                    )
+                    for m in mention_items:
+                        try:
+                            yield json_feed_item_to_item(m, is_own=False)
+                        except Exception as e:
+                            logger.warning(f"Failed to process mention: {e}")
+
+                # Phase 3: Conversations
+                if do_conversations:
+                    if not mention_items:
+                        mention_items = client.get_all_mentions(
+                            count=config.get("limit", 100),
+                        )
+                    seen_urls: set[str] = set()
+                    for m in mention_items:
+                        microblog = m.get("_microblog", {})
+                        reply_to = microblog.get("in_reply_to")
+                        post_id = str(microblog.get("id", ""))
+                        if not post_id:
+                            continue
+                        try:
+                            thread = client.get_conversation(post_id)
+                            for entry in thread:
+                                entry_url = entry.get("url", "")
+                                if entry_url in seen_urls:
+                                    continue
+                                seen_urls.add(entry_url)
+                                author_mb = (
+                                    entry.get("author", {})
+                                    .get("_microblog", {})
+                                    .get("username", "")
+                                )
+                                entry_is_own = (
+                                    current_username is not None and author_mb == current_username
+                                )
+                                yield json_feed_item_to_item(
+                                    entry,
+                                    is_own=entry_is_own,
+                                    conversation_id=reply_to or entry_url,
+                                )
+                        except Exception as e:
+                            logger.warning(f"Failed to fetch conversation {post_id}: {e}")
 
         except Exception as e:
             logger.error(f"Sync failed: {e}", exc_info=True)

--- a/packages/lestash-microblog/tests/conftest.py
+++ b/packages/lestash-microblog/tests/conftest.py
@@ -97,6 +97,50 @@ def microblog_post_factory():
 
 
 @pytest.fixture
+def json_feed_item_factory():
+    """Factory to create mock Micro.blog JSON Feed items.
+
+    Returns a function that creates items matching the JSON Feed format
+    returned by /posts/mentions and /posts/conversation endpoints.
+    """
+
+    def _create_item(
+        id: str = "123456",
+        url: str = "https://user.micro.blog/2024/01/15/post.html",
+        content_text: str = "Hello world",
+        content_html: str | None = None,
+        date_published: str = "2024-01-15T10:30:00+00:00",
+        author_name: str = "username",
+        author_url: str = "https://micro.blog/username",
+        author_username: str = "username",
+        is_mention: bool = False,
+        in_reply_to: str | None = None,
+    ) -> dict[str, Any]:
+        item: dict[str, Any] = {
+            "id": id,
+            "url": url,
+            "date_published": date_published,
+            "author": {
+                "name": author_name,
+                "url": author_url,
+                "_microblog": {"username": author_username},
+            },
+            "_microblog": {"id": int(id)},
+        }
+        if content_text:
+            item["content_text"] = content_text
+        if content_html:
+            item["content_html"] = content_html
+        if is_mention:
+            item["_microblog"]["is_mention"] = True
+        if in_reply_to:
+            item["_microblog"]["in_reply_to"] = in_reply_to
+        return item
+
+    return _create_item
+
+
+@pytest.fixture
 def mock_micropub_config():
     """Create a mock Micropub config response."""
     return {

--- a/packages/lestash-microblog/tests/test_client.py
+++ b/packages/lestash-microblog/tests/test_client.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 from lestash_microblog.client import (
+    MICROBLOG_API_BASE,
     MICROPUB_ENDPOINT,
     MicropubClient,
     create_client,
@@ -339,6 +340,171 @@ class TestMicropubClientGetAllPosts:
             client.close()
 
         assert posts == []
+
+
+class TestMicropubClientGetMentions:
+    """Test MicropubClient.get_mentions()."""
+
+    def test_get_mentions_returns_items(self, tmp_path, monkeypatch):
+        """Should return list of JSON Feed mention items."""
+        monkeypatch.setattr(
+            "lestash_microblog.client.get_token_path",
+            lambda: tmp_path / "token.json",
+        )
+
+        mention_items = [
+            {
+                "id": "111",
+                "url": "https://other.micro.blog/2024/01/reply.html",
+                "content_text": "Nice post!",
+                "date_published": "2024-01-15T12:00:00+00:00",
+                "author": {"name": "other_user", "url": "https://micro.blog/other_user"},
+                "_microblog": {"id": 111, "is_mention": True},
+            }
+        ]
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"items": mention_items}
+
+        with patch.object(httpx.Client, "get", return_value=mock_response):
+            client = MicropubClient(token="test")
+            mentions = client.get_mentions()
+            client.close()
+
+        assert len(mentions) == 1
+        assert mentions[0]["content_text"] == "Nice post!"
+
+    def test_get_mentions_passes_pagination_params(self, tmp_path, monkeypatch):
+        """Should pass count and before_id parameters."""
+        monkeypatch.setattr(
+            "lestash_microblog.client.get_token_path",
+            lambda: tmp_path / "token.json",
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"items": []}
+
+        with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
+            client = MicropubClient(token="test")
+            client.get_mentions(count=50, before_id=999)
+            client.close()
+
+        call_args = mock_get.call_args
+        assert call_args[1]["params"]["count"] == 50
+        assert call_args[1]["params"]["before_id"] == 999
+
+    def test_get_mentions_uses_api_base_url(self, tmp_path, monkeypatch):
+        """Should use MICROBLOG_API_BASE, not Micropub endpoint."""
+        monkeypatch.setattr(
+            "lestash_microblog.client.get_token_path",
+            lambda: tmp_path / "token.json",
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"items": []}
+
+        with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
+            client = MicropubClient(token="test")
+            client.get_mentions()
+            client.close()
+
+        url = mock_get.call_args[0][0]
+        assert url.startswith(MICROBLOG_API_BASE)
+        assert "/posts/mentions" in url
+
+
+class TestMicropubClientGetAllMentions:
+    """Test MicropubClient.get_all_mentions()."""
+
+    def test_get_all_mentions_paginates(self, tmp_path, monkeypatch):
+        """Should paginate through mentions using before_id."""
+        monkeypatch.setattr(
+            "lestash_microblog.client.get_token_path",
+            lambda: tmp_path / "token.json",
+        )
+
+        page1 = [
+            {"id": str(i), "_microblog": {"id": i}, "content_text": f"M{i}"}
+            for i in range(5, 0, -1)
+        ]
+        page2 = [{"id": str(i), "_microblog": {"id": i}, "content_text": f"M{i}"} for i in range(3)]
+
+        mock_responses = [
+            MagicMock(json=MagicMock(return_value={"items": page1})),
+            MagicMock(json=MagicMock(return_value={"items": page2})),
+        ]
+
+        with patch.object(httpx.Client, "get", side_effect=mock_responses):
+            client = MicropubClient(token="test")
+            mentions = client.get_all_mentions(count=5)
+            client.close()
+
+        assert len(mentions) == 8
+
+    def test_get_all_mentions_respects_max_items(self, tmp_path, monkeypatch):
+        """Should stop at max_items."""
+        monkeypatch.setattr(
+            "lestash_microblog.client.get_token_path",
+            lambda: tmp_path / "token.json",
+        )
+
+        items = [
+            {"id": str(i), "_microblog": {"id": i}, "content_text": f"M{i}"} for i in range(10)
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"items": items}
+
+        with patch.object(httpx.Client, "get", return_value=mock_response):
+            client = MicropubClient(token="test")
+            result = client.get_all_mentions(count=100, max_items=3)
+            client.close()
+
+        assert len(result) == 3
+
+
+class TestMicropubClientGetConversation:
+    """Test MicropubClient.get_conversation()."""
+
+    def test_get_conversation_passes_id(self, tmp_path, monkeypatch):
+        """Should pass post ID as query parameter."""
+        monkeypatch.setattr(
+            "lestash_microblog.client.get_token_path",
+            lambda: tmp_path / "token.json",
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"items": []}
+
+        with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
+            client = MicropubClient(token="test")
+            client.get_conversation("12345")
+            client.close()
+
+        call_args = mock_get.call_args
+        assert call_args[1]["params"]["id"] == "12345"
+
+    def test_get_conversation_returns_thread(self, tmp_path, monkeypatch):
+        """Should return all items in the thread."""
+        monkeypatch.setattr(
+            "lestash_microblog.client.get_token_path",
+            lambda: tmp_path / "token.json",
+        )
+
+        thread = [
+            {"id": "100", "content_text": "Original post"},
+            {"id": "101", "content_text": "Reply to original"},
+            {"id": "102", "content_text": "Reply to reply"},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"items": thread}
+
+        with patch.object(httpx.Client, "get", return_value=mock_response):
+            client = MicropubClient(token="test")
+            result = client.get_conversation("100")
+            client.close()
+
+        assert len(result) == 3
 
 
 class TestCreateClient:

--- a/packages/lestash-microblog/tests/test_extractors.py
+++ b/packages/lestash-microblog/tests/test_extractors.py
@@ -6,6 +6,7 @@ from lestash_microblog.source import (
     extract_content,
     extract_property,
     extract_property_list,
+    json_feed_item_to_item,
     parse_datetime,
     post_to_item,
 )
@@ -301,3 +302,109 @@ class TestPostToItem:
         item = post_to_item(entry)
 
         assert item.source_id == "urn:uuid:12345"
+
+
+class TestJsonFeedItemToItem:
+    """Test json_feed_item_to_item function."""
+
+    def test_basic_conversion(self, json_feed_item_factory):
+        """Should convert a JSON Feed item to ItemCreate."""
+        feed_item = json_feed_item_factory(
+            content_text="Nice post!",
+            url="https://other.micro.blog/2024/01/reply.html",
+            author_name="other_user",
+            date_published="2024-01-15T12:00:00+00:00",
+        )
+
+        item = json_feed_item_to_item(feed_item)
+
+        assert item.source_type == "microblog"
+        assert item.content == "Nice post!"
+        assert item.url == "https://other.micro.blog/2024/01/reply.html"
+        assert item.author == "other_user"
+        assert item.created_at is not None
+        assert item.is_own_content is False
+
+    def test_url_as_source_id(self, json_feed_item_factory):
+        """Should use URL as source_id for dedup with h-entry posts."""
+        feed_item = json_feed_item_factory(
+            url="https://user.micro.blog/2024/01/post.html",
+        )
+
+        item = json_feed_item_to_item(feed_item)
+
+        assert item.source_id == "https://user.micro.blog/2024/01/post.html"
+
+    def test_mention_metadata(self, json_feed_item_factory):
+        """Should store mention metadata."""
+        feed_item = json_feed_item_factory(
+            is_mention=True,
+            in_reply_to="https://user.micro.blog/2024/01/original.html",
+        )
+
+        item = json_feed_item_to_item(feed_item)
+
+        assert item.metadata["is_mention"] is True
+        assert item.metadata["in_reply_to"] == ["https://user.micro.blog/2024/01/original.html"]
+
+    def test_is_own_false_for_mentions(self, json_feed_item_factory):
+        """Should set is_own_content=False by default (for mentions)."""
+        feed_item = json_feed_item_factory()
+
+        item = json_feed_item_to_item(feed_item, is_own=False)
+
+        assert item.is_own_content is False
+
+    def test_is_own_true_for_own_replies(self, json_feed_item_factory):
+        """Should set is_own_content=True when specified."""
+        feed_item = json_feed_item_factory()
+
+        item = json_feed_item_to_item(feed_item, is_own=True)
+
+        assert item.is_own_content is True
+
+    def test_conversation_id(self, json_feed_item_factory):
+        """Should store conversation_id in metadata."""
+        feed_item = json_feed_item_factory()
+
+        item = json_feed_item_to_item(
+            feed_item,
+            conversation_id="https://user.micro.blog/2024/01/thread.html",
+        )
+
+        assert item.metadata["conversation_id"] == "https://user.micro.blog/2024/01/thread.html"
+
+    def test_falls_back_to_content_html(self, json_feed_item_factory):
+        """Should use content_html when content_text is missing."""
+        feed_item = json_feed_item_factory(content_text="", content_html="<p>HTML content</p>")
+
+        item = json_feed_item_to_item(feed_item)
+
+        assert item.content == "<p>HTML content</p>"
+
+    def test_handles_missing_fields(self):
+        """Should handle minimal JSON Feed item gracefully."""
+        feed_item = {"id": "999", "content_text": "Bare item"}
+
+        item = json_feed_item_to_item(feed_item)
+
+        assert item.content == "Bare item"
+        assert item.source_id is None
+        assert item.author is None
+        assert item.created_at is None
+
+    def test_author_username_in_metadata(self, json_feed_item_factory):
+        """Should store author username from _microblog extension."""
+        feed_item = json_feed_item_factory(author_username="testuser")
+
+        item = json_feed_item_to_item(feed_item)
+
+        assert item.metadata["author_username"] == "testuser"
+
+    def test_microblog_id_in_metadata(self, json_feed_item_factory):
+        """Should store microblog numeric ID."""
+        feed_item = json_feed_item_factory(id="42")
+
+        item = json_feed_item_to_item(feed_item)
+
+        assert item.metadata["microblog_id"] == 42


### PR DESCRIPTION
## Summary

Add support for syncing mentions (replies from others) and full conversation threads from Micro.blog, extending the existing posts-only sync.

Closes #10

## Changes

| Area | What |
|------|------|
| **Client** | New JSON Feed API methods: `get_mentions()`, `get_all_mentions()`, `get_conversation()` using `https://micro.blog` base URL with cursor-based pagination |
| **Converter** | `json_feed_item_to_item()` — handles JSON Feed format (separate from Micropub h-entry `post_to_item()`) |
| **CLI flags** | `--mentions`, `--conversations`, `--all` on the sync command |
| **Sync logic** | Three-phase sync: own posts → mentions → conversation threads |
| **Generator** | `sync()` method updated to accept `mentions`, `conversations`, `all` config keys |
| **Helper** | `_upsert_item()` extracted to avoid DB insert duplication |

## New CLI Usage

```bash
# Existing (unchanged)
lestash microblog sync

# Sync mentions (replies from others)
lestash microblog sync --mentions

# Sync conversation threads
lestash microblog sync --conversations

# Sync everything
lestash microblog sync --all
```

## Deduplication

Uses URL as `source_id` for both h-entry and JSON Feed items, so the same post appearing in own-posts sync and in mentions/conversations will UPSERT correctly.

## Test plan

- [x] 105 tests pass (88 existing + 17 new)
- [x] Lint + format clean
- [x] Client tests: mentions API, pagination, conversation fetch, base URL
- [x] Converter tests: basic conversion, metadata, is_own, conversation_id, fallbacks
- [x] Backward compatible: default sync (no flags) behaves identically