### PR TITLE
feat(deploy): add scheduled sync via systemd timer

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SERVICE=lestash-server.service
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEST="$HOME/.config/systemd/user"
 
 mkdir -p "$DEST"
-cp "$SCRIPT_DIR/$SERVICE" "$DEST/$SERVICE"
+
+# Deploy server
+cp "$SCRIPT_DIR/lestash-server.service" "$DEST/"
+
+# Deploy sync timer
+cp "$SCRIPT_DIR/lestash-sync.service" "$DEST/"
+cp "$SCRIPT_DIR/lestash-sync.timer" "$DEST/"
 
 systemctl --user daemon-reload
-systemctl --user enable --now "$SERVICE"
 
-echo "Deployed $SERVICE"
-systemctl --user status "$SERVICE" --no-pager
+# Enable and start server
+systemctl --user enable --now lestash-server.service
+
+# Enable and start sync timer
+systemctl --user enable --now lestash-sync.timer
+
+echo "Deployed services:"
+systemctl --user status lestash-server.service --no-pager || true
+echo ""
+systemctl --user list-timers lestash-sync.timer --no-pager

--- a/deploy/lestash-sync.service
+++ b/deploy/lestash-sync.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=LeStash sync all sources
+
+[Service]
+Type=oneshot
+ExecStart=/home/linuxbrew/.linuxbrew/bin/uv run --project %h/Projects/thompsonson/lestash lestash sources sync --all
+WorkingDirectory=%h/Projects/thompsonson/lestash

--- a/deploy/lestash-sync.timer
+++ b/deploy/lestash-sync.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Sync LeStash sources every 6 hours
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=6h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/justfile
+++ b/justfile
@@ -98,6 +98,18 @@ server-logs:
 server-restart:
     systemctl --user restart lestash-server
 
+# Show sync timer status
+sync-status:
+    systemctl --user list-timers lestash-sync.timer --no-pager
+
+# View sync logs
+sync-logs:
+    journalctl --user -u lestash-sync -n 50 --no-pager
+
+# Trigger a sync now (without waiting for timer)
+sync-now:
+    systemctl --user start lestash-sync.service
+
 # Deploy systemd service
 deploy:
     bash deploy/install.sh


### PR DESCRIPTION
## Summary

Automatic sync of all sources every 6 hours via systemd timer. Zero code changes — just deployment files.

## Files

| File | Purpose |
|------|---------|
| `deploy/lestash-sync.service` | Oneshot service: `lestash sources sync --all` |
| `deploy/lestash-sync.timer` | Triggers every 6h, first run 5min after boot, persistent |
| `deploy/install.sh` | Updated to deploy both server and sync timer |
| `justfile` | New recipes: `sync-status`, `sync-logs`, `sync-now` |

## Usage

```bash
just deploy        # Install server + sync timer
just sync-status   # Show next scheduled sync
just sync-logs     # View recent sync output
just sync-now      # Trigger immediate sync
```

## Verified

- [x] Timer deployed and running on pop-mini
- [x] First sync completed: microblog +155, linkedin +183
- [x] Results visible in Sources tab sync log
- [x] `systemctl --user list-timers` shows next run