### PR TITLE
feat(ui): add subtype filtering and Recent Activity tab

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -372,6 +372,25 @@
     }
     .skeleton-line.short { width: 40%; }
     .skeleton-line.medium { width: 70%; }
+
+    /* ── Subtype filters ── */
+    .subtype-filters {
+      display: flex; gap: 0.5rem; flex-wrap: wrap;
+      width: 100%; margin-top: 0.25rem;
+    }
+    .subtype-filters label {
+      font-size: 0.75rem; color: var(--muted);
+      display: flex; align-items: center; gap: 0.2rem;
+      cursor: pointer;
+    }
+    .subtype-filters input[type="checkbox"] { accent-color: var(--accent); }
+
+    /* ── Recent summary ── */
+    .recent-summary {
+      font-size: 0.85rem; color: var(--muted);
+      margin-bottom: 0.75rem;
+    }
+    .recent-summary strong { color: var(--accent); }
     @keyframes shimmer {
       0% { background-position: 200% 0; }
       100% { background-position: -200% 0; }
@@ -392,6 +411,7 @@
       .modal { width: 95%; max-width: none; }
       .source-table th:nth-child(2),
       .source-table td:nth-child(2) { display: none; }
+      .subtype-filters label { min-height: 44px; }
     }
   </style>
 </head>
@@ -411,6 +431,7 @@
   <!-- Tabs -->
   <nav id="tabs">
     <button class="active" data-tab="feed">Feed</button>
+    <button data-tab="recent">Recent</button>
     <button data-tab="search">Search</button>
     <button data-tab="sources">Sources</button>
     <button data-tab="stats">Stats</button>
@@ -427,6 +448,13 @@
         <label style="font-size:0.8rem;display:flex;align-items:center;gap:0.3rem;color:var(--muted)">
           <input type="checkbox" id="feed-own"> Own
         </label>
+        <div class="subtype-filters" id="subtype-filters">
+          <label><input type="checkbox" value="post" checked> Posts</label>
+          <label><input type="checkbox" value="comment" checked> Comments</label>
+          <label><input type="checkbox" value="reaction"> Reactions</label>
+          <label><input type="checkbox" value="invitation"> Invitations</label>
+          <label><input type="checkbox" value="message"> Messages</label>
+        </div>
       </div>
       <div class="item-list" id="feed-list"></div>
       <button class="load-more" id="feed-more" onclick="loadMoreFeed()" style="display:none">Load more</button>
@@ -439,6 +467,20 @@
                placeholder="Search your knowledge base..." autocomplete="off">
       </div>
       <div class="item-list" id="search-list"></div>
+    </div>
+
+    <!-- Recent tab -->
+    <div class="tab-content" id="tab-recent">
+      <div class="filters">
+        <select id="recent-period">
+          <option value="6">Last 6 hours</option>
+          <option value="24" selected>Last 24 hours</option>
+          <option value="168">Last 7 days</option>
+          <option value="720">Last 30 days</option>
+        </select>
+      </div>
+      <div class="recent-summary" id="recent-summary"></div>
+      <div class="item-list" id="recent-list"></div>
     </div>
 
     <!-- Sources tab -->
@@ -560,6 +602,7 @@
       const tab = e.target.dataset.tab;
       document.getElementById(`tab-${tab}`).classList.add('active');
       if (tab === 'feed' && feedItems.length === 0) loadFeed();
+      if (tab === 'recent') loadRecent();
       if (tab === 'search') document.getElementById('search-input').focus();
       if (tab === 'sources') loadSources();
       if (tab === 'stats') loadStats();
@@ -657,6 +700,10 @@
         if (source) url += `&source=${encodeURIComponent(source)}`;
         if (own) url += `&own=true`;
 
+        // Subtype exclusions
+        const excluded = getExcludedSubtypes();
+        if (excluded) url += `&exclude_subtype=${encodeURIComponent(excluded)}`;
+
         const data = await api(url);
 
         if (!append) list.innerHTML = '';
@@ -684,6 +731,79 @@
 
     document.getElementById('feed-source').addEventListener('change', () => loadFeed());
     document.getElementById('feed-own').addEventListener('change', () => loadFeed());
+
+    /* ── Subtype filters ── */
+    const SUBTYPE_STORAGE_KEY = 'lestash-subtype-filters';
+
+    function getExcludedSubtypes() {
+      const checks = document.querySelectorAll('#subtype-filters input[type="checkbox"]');
+      const excluded = [];
+      checks.forEach(cb => { if (!cb.checked) excluded.push(cb.value); });
+      return excluded.join(',');
+    }
+
+    function saveSubtypeFilters() {
+      const checks = document.querySelectorAll('#subtype-filters input[type="checkbox"]');
+      const state = {};
+      checks.forEach(cb => { state[cb.value] = cb.checked; });
+      localStorage.setItem(SUBTYPE_STORAGE_KEY, JSON.stringify(state));
+    }
+
+    function loadSubtypeFilters() {
+      try {
+        const raw = localStorage.getItem(SUBTYPE_STORAGE_KEY);
+        if (!raw) return;
+        const state = JSON.parse(raw);
+        document.querySelectorAll('#subtype-filters input[type="checkbox"]').forEach(cb => {
+          if (cb.value in state) cb.checked = state[cb.value];
+        });
+      } catch {}
+    }
+
+    loadSubtypeFilters();
+    document.getElementById('subtype-filters').addEventListener('change', () => {
+      saveSubtypeFilters();
+      loadFeed();
+    });
+
+    /* ── Recent Activity ── */
+    async function loadRecent() {
+      const list = document.getElementById('recent-list');
+      const summary = document.getElementById('recent-summary');
+      const hours = parseInt(document.getElementById('recent-period').value);
+
+      list.innerHTML = renderSkeletons(5);
+      summary.textContent = '';
+
+      try {
+        const since = new Date(Date.now() - hours * 3600000).toISOString();
+        const data = await api(`/api/items?since=${encodeURIComponent(since)}&limit=100`);
+
+        list.innerHTML = '';
+
+        if (data.items.length === 0) {
+          list.innerHTML = '<div class="empty-state">No new items in this period</div>';
+          summary.textContent = '';
+          return;
+        }
+
+        // Count by source
+        const counts = {};
+        data.items.forEach(i => {
+          const s = i.source_type;
+          counts[s] = (counts[s] || 0) + 1;
+        });
+        const parts = Object.entries(counts).map(([k, v]) => `${k}: ${v}`);
+        summary.innerHTML = `<strong>${data.items.length}</strong> items synced — ${parts.join(', ')}`;
+
+        data.items.forEach(item => list.appendChild(renderCard(item)));
+      } catch (e) {
+        list.innerHTML = '';
+        showToast(`Failed to load recent items: ${e.message}`, 'error');
+      }
+    }
+
+    document.getElementById('recent-period').addEventListener('change', loadRecent);
 
     /* ── Search ── */
     let searchTimer = null;

--- a/packages/lestash-server/src/lestash_server/routes/items.py
+++ b/packages/lestash-server/src/lestash_server/routes/items.py
@@ -32,16 +32,24 @@ def _enrich_item(conn, item: Item) -> ItemResponse:
     )
 
 
+def _matches_exclude(subtype: str, excludes: set[str]) -> bool:
+    """Check if a subtype matches any exclude term."""
+    return any(ex in subtype for ex in excludes)
+
+
 @router.get("", response_model=ItemListResponse)
 def list_items(
     source: str | None = Query(None, description="Filter by source type"),
     own: bool | None = Query(None, description="Filter own content"),
+    exclude_subtype: str | None = Query(
+        None, description="Comma-separated subtypes to exclude (e.g., reaction,invitation,message)"
+    ),
+    since: str | None = Query(None, description="Only items fetched since this ISO datetime"),
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ):
     """List items with optional filters."""
     with get_db() as conn:
-        # Build count query
         count_query = "SELECT COUNT(*) FROM items WHERE 1=1"
         query = "SELECT * FROM items WHERE 1=1"
         params: list = []
@@ -56,13 +64,42 @@ def list_items(
             count_query += " AND is_own_content = ?"
             params.append(own)
 
+        if since:
+            query += " AND datetime(fetched_at) >= datetime(?)"
+            count_query += " AND datetime(fetched_at) >= datetime(?)"
+            params.append(since)
+
         total = conn.execute(count_query, params).fetchone()[0]
 
-        query += " ORDER BY datetime(created_at) DESC LIMIT ? OFFSET ?"
-        params.extend([limit, offset])
+        # Sort by fetched_at when filtering recent, otherwise by created_at
+        sort_col = "fetched_at" if since else "created_at"
+        query += f" ORDER BY datetime({sort_col}) DESC"
 
-        rows = conn.execute(query, params).fetchall()
-        items = [_enrich_item(conn, Item.from_row(row)) for row in rows]
+        excludes = set()
+        if exclude_subtype:
+            excludes = {s.strip() for s in exclude_subtype.split(",") if s.strip()}
+
+        if excludes:
+            # Fetch extra rows to account for filtered-out items
+            fetch_limit = limit * 4
+            query += " LIMIT ? OFFSET ?"
+            params.extend([fetch_limit, offset])
+
+            rows = conn.execute(query, params).fetchall()
+            all_enriched = [_enrich_item(conn, Item.from_row(row)) for row in rows]
+            items = [i for i in all_enriched if not _matches_exclude(i.subtype, excludes)]
+
+            # Adjust total to reflect filtering (approximate)
+            if all_enriched:
+                filter_ratio = len(items) / len(all_enriched)
+                total = int(total * filter_ratio)
+
+            items = items[:limit]
+        else:
+            query += " LIMIT ? OFFSET ?"
+            params.extend([limit, offset])
+            rows = conn.execute(query, params).fetchall()
+            items = [_enrich_item(conn, Item.from_row(row)) for row in rows]
 
     return ItemListResponse(items=items, total=total, limit=limit, offset=offset)
 

--- a/packages/lestash-server/tests/test_api.py
+++ b/packages/lestash-server/tests/test_api.py
@@ -89,6 +89,39 @@ class TestItems:
         resp = client.get("/api/items/search")
         assert resp.status_code == 422  # validation error
 
+    def test_list_items_exclude_subtype(self, client):
+        """Excluding 'reaction' should filter out linkedin likes."""
+        resp = client.get("/api/items?exclude_subtype=reaction")
+        data = resp.json()
+        subtypes = [i["subtype"] for i in data["items"]]
+        assert all("reaction" not in s for s in subtypes)
+
+    def test_list_items_exclude_multiple_subtypes(self, client):
+        """Excluding multiple subtypes should filter all of them."""
+        resp = client.get("/api/items?exclude_subtype=reaction,post")
+        data = resp.json()
+        subtypes = [i["subtype"] for i in data["items"]]
+        assert all("reaction" not in s and "post" not in s for s in subtypes)
+
+    def test_list_items_exclude_subtype_default_returns_all(self, client):
+        """No exclude param should return all items."""
+        resp = client.get("/api/items")
+        assert resp.json()["total"] == 5
+
+    def test_list_items_since_filter(self, client):
+        """Since filter should only return recently fetched items."""
+        # All test items were just inserted, so a recent 'since' should find them
+        resp = client.get("/api/items?since=2020-01-01T00:00:00")
+        data = resp.json()
+        assert data["total"] == 5
+
+    def test_list_items_since_far_future(self, client):
+        """Since in the future should return no items."""
+        resp = client.get("/api/items?since=2099-01-01T00:00:00")
+        data = resp.json()
+        assert data["total"] == 0
+        assert len(data["items"]) == 0
+
 
 class TestSources:
     """Test /api/sources endpoints."""


### PR DESCRIPTION
## Summary

Two UI improvements for the web frontend.

Closes #39, closes #42

## Feed Filtering by Subtype (#39)

- **Server**: `exclude_subtype` query parameter on `GET /api/items` — comma-separated subtypes to hide (e.g., `?exclude_subtype=reaction,invitation,message`)
- **Frontend**: Checkbox row below source filter — Posts, Comments, Reactions, Invitations, Messages
- Reactions and invitations unchecked by default for a cleaner feed
- Filter state persisted to localStorage

## Recent Activity Tab (#42)

- **Server**: `since` query parameter on `GET /api/items` — filters by `fetched_at` and sorts by `fetched_at DESC`
- **Frontend**: New "Recent" tab with period selector (6h, 24h, 7d, 30d)
- Shows summary line: "12 items synced — linkedin: 8, microblog: 4"
- Reuses existing item cards

## Test plan

- [x] 25 server tests pass (5 new: exclude_subtype, exclude_multiple, default_all, since_filter, since_future)
- [x] 41 core tests pass
- [x] Lint + format clean