### PR TITLE
feat(ci): add rolling dev-desktop releases and install script

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -74,7 +74,7 @@ jobs:
   release:
     needs: build-desktop
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
     steps:
       - uses: actions/download-artifact@v7
         with:
@@ -88,6 +88,42 @@ jobs:
           ls -la release-files/
 
       - name: Upload to tagged release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           files: release-files/*
+
+      - name: Set build timestamp
+        if: github.ref == 'refs/heads/main'
+        run: echo "BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_ENV"
+
+      - name: Delete old dev-desktop release
+        if: github.ref == 'refs/heads/main'
+        run: gh release delete dev-desktop --yes --cleanup-tag 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+
+      - name: Create dev-desktop release
+        if: github.ref == 'refs/heads/main'
+        run: |
+          gh release create dev-desktop \
+            --title "Dev Desktop Build — ${{ env.BUILD_TIME }}" \
+            --prerelease \
+            --notes "$(cat <<'EOF'
+          Rolling desktop build from `main`.
+
+          **Built:** ${{ env.BUILD_TIME }}
+          **Commit:** [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+
+          ## Install
+
+          **macOS:** Download `.dmg`, open, drag to Applications
+          **Linux (Debian/Ubuntu):** `sudo dpkg -i lestash_*.deb`
+          **Linux (AppImage):** `chmod +x lestash_*.AppImage && ./lestash_*.AppImage`
+          EOF
+          )" \
+            release-files/*
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -16,19 +16,36 @@ This is born from not having access to LinkedIn posts that are over a year old (
 - **API server** - HTTPS REST API for accessing your knowledge base from any device
 - **Desktop app** - Tauri v2 cross-platform app (macOS, Linux) with browser fallback
 
-## Installation
+## Install
+
+### Desktop App
+
+Download the latest build from [Releases](../../releases):
+
+| Platform | Format | Install |
+|----------|--------|---------|
+| **macOS** | `.dmg` | Open, drag to Applications |
+| **Linux** | `.deb` | `sudo dpkg -i lestash_*.deb` |
+| **Linux** | `.AppImage` | `chmod +x lestash_*.AppImage && ./lestash_*.AppImage` |
+
+Or use the install script (requires [gh CLI](https://cli.github.com/)):
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/thompsonson/lestash/main/scripts/install-desktop.sh)
+```
+
+### Browser
+
+No install needed — browse to your server URL (e.g., `https://pop-mini:8444/`).
+
+### CLI (from source)
 
 Requires Python 3.12+ and [uv](https://docs.astral.sh/uv/).
 
 ```bash
-# Clone the repository
 git clone git@github.com:thompsonson/lestash.git
 cd lestash
-
-# Install dependencies (including dev tools like just)
 uv sync --dev
-
-# Verify installation
 uv run lestash --help
 ```
 

--- a/scripts/install-desktop.sh
+++ b/scripts/install-desktop.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="thompsonson/lestash"
+RELEASE="dev-desktop"
+
+# Allow override: ./install-desktop.sh v1.12.0
+if [ "${1:-}" != "" ]; then
+  RELEASE="$1"
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "LeStash Desktop Installer"
+echo "========================="
+echo "Release: $RELEASE"
+
+# Check gh CLI
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: gh CLI required. Install from https://cli.github.com/"
+  exit 1
+fi
+
+OS=$(uname -s)
+case "$OS" in
+  Darwin)
+    echo "Detected: macOS"
+    echo "Downloading latest .dmg..."
+    gh release download "$RELEASE" --repo "$REPO" --pattern "*.dmg" --dir "$TMPDIR" --clobber
+
+    DMG=$(ls "$TMPDIR"/*.dmg 2>/dev/null | head -1)
+    if [ -z "$DMG" ]; then
+      echo "Error: No .dmg found in release"
+      exit 1
+    fi
+
+    echo "Mounting $(basename "$DMG")..."
+    hdiutil attach "$DMG" -nobrowse -quiet
+
+    VOLUME=$(ls -d /Volumes/lestash* 2>/dev/null | head -1)
+    if [ -z "$VOLUME" ]; then
+      echo "Error: Could not find mounted volume"
+      exit 1
+    fi
+
+    echo "Installing to /Applications..."
+    rm -rf /Applications/lestash.app
+    cp -R "$VOLUME/lestash.app" /Applications/
+    hdiutil detach "$VOLUME" -quiet
+
+    echo ""
+    echo "Installed: /Applications/lestash.app"
+    echo "Run:       open /Applications/lestash.app"
+    ;;
+
+  Linux)
+    echo "Detected: Linux"
+    if command -v dpkg >/dev/null 2>&1; then
+      echo "Downloading latest .deb..."
+      gh release download "$RELEASE" --repo "$REPO" --pattern "*.deb" --dir "$TMPDIR" --clobber
+
+      DEB=$(ls "$TMPDIR"/*.deb 2>/dev/null | head -1)
+      if [ -z "$DEB" ]; then
+        echo "Error: No .deb found in release"
+        exit 1
+      fi
+
+      echo "Installing $(basename "$DEB")..."
+      sudo dpkg -i "$DEB"
+      echo ""
+      echo "Installed. Run: lestash-app"
+    else
+      echo "Downloading latest .AppImage..."
+      gh release download "$RELEASE" --repo "$REPO" --pattern "*.AppImage" --dir "$TMPDIR" --clobber
+
+      APPIMAGE=$(ls "$TMPDIR"/*.AppImage 2>/dev/null | head -1)
+      if [ -z "$APPIMAGE" ]; then
+        echo "Error: No .AppImage found in release"
+        exit 1
+      fi
+
+      DEST="$HOME/.local/bin/lestash.AppImage"
+      mkdir -p "$(dirname "$DEST")"
+      cp "$APPIMAGE" "$DEST"
+      chmod +x "$DEST"
+      echo ""
+      echo "Installed: $DEST"
+      echo "Run:       $DEST"
+    fi
+    ;;
+
+  *)
+    echo "Unsupported OS: $OS"
+    exit 1
+    ;;
+esac
+
+echo "Done!"


### PR DESCRIPTION
## Summary

- **Rolling dev releases** — every push to main creates a `dev-desktop` pre-release on GitHub Releases with `.dmg`, `.AppImage`, `.deb` artifacts
- **Install script** — `scripts/install-desktop.sh` detects OS, downloads correct artifact via `gh` CLI, installs
- **Updated README** — install instructions for desktop app, browser, and CLI

## How it works

On push to main:
1. macOS + Linux builds run in parallel (existing)
2. New `release` job collects artifacts
3. Deletes old `dev-desktop` release
4. Creates new `dev-desktop` pre-release with all binaries

On tagged release (`v*`):
- Uploads to the tagged GitHub Release (existing, unchanged)

## Install on Mac

```bash
# One-liner
bash <(curl -s https://raw.githubusercontent.com/thompsonson/lestash/main/scripts/install-desktop.sh)

# Or manually
bash scripts/install-desktop.sh           # latest dev build
bash scripts/install-desktop.sh v1.12.0   # specific version
```

## Test plan

- [ ] CI builds on this branch (Python tests)
- [ ] After merge: desktop build triggers, `dev-desktop` release created with artifacts
- [ ] `gh release view dev-desktop` shows `.dmg` and `.AppImage`
- [ ] Install script works on macOS