### PR TITLE
feat(app): add Android APK build workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,102 @@
+name: Android Build
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-apk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,x86_64-linux-android
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: app/src-tauri
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android NDK
+        run: sdkmanager --install "ndk;27.2.12479018"
+
+      - name: Set NDK environment
+        run: |
+          echo "NDK_HOME=$ANDROID_HOME/ndk/27.2.12479018" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.2.12479018" >> "$GITHUB_ENV"
+
+      - name: Install npm dependencies
+        run: npm ci
+        working-directory: app
+
+      - name: Initialize Tauri Android
+        run: npx tauri android init
+        working-directory: app
+
+      - name: Add Android permissions
+        run: |
+          MANIFEST=app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+          sed -i '/<manifest/a\    <uses-permission android:name="android.permission.INTERNET" />' "$MANIFEST"
+
+      - name: Build APK
+        run: npx tauri android build --target aarch64 --target x86_64
+        working-directory: app
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: lestash-android
+          path: app/src-tauri/gen/android/app/build/outputs/apk/**/*.apk
+          if-no-files-found: error
+
+      - name: Upload to tagged release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: app/src-tauri/gen/android/app/build/outputs/apk/universal/release/*.apk
+
+      - name: Set build timestamp
+        if: github.ref == 'refs/heads/main'
+        run: echo "BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_ENV"
+
+      - name: Upload APK to dev-android release
+        if: github.ref == 'refs/heads/main'
+        run: |
+          gh release delete dev-android --yes --cleanup-tag 2>/dev/null || true
+          APK=$(find app/src-tauri/gen/android/app/build/outputs/apk -name '*.apk' -not -name '*-unsigned*' | head -1)
+          if [ -z "$APK" ]; then
+            APK=$(find app/src-tauri/gen/android/app/build/outputs/apk -name '*.apk' | head -1)
+          fi
+          gh release create dev-android \
+            --title "Dev Android Build — ${{ env.BUILD_TIME }}" \
+            --prerelease \
+            --notes "$(cat <<'EOF'
+          Rolling Android build from `main`.
+          Install via [Obtainium](https://obtainium.imranr.dev/) or download the APK directly.
+
+          **Built:** ${{ env.BUILD_TIME }}
+          **Commit:** [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+          EOF
+          )" \
+            "$APK"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Download the latest build from [Releases](../../releases):
 | **macOS** | `.dmg` | Open, drag to Applications |
 | **Linux** | `.deb` | `sudo dpkg -i lestash_*.deb` |
 | **Linux** | `.AppImage` | `chmod +x lestash_*.AppImage && ./lestash_*.AppImage` |
+| **Android** | `.apk` | Install directly or use [Obtainium](https://obtainium.imranr.dev/) for auto-updates |
 
 Or use the install script (requires [gh CLI](https://cli.github.com/)):
 


### PR DESCRIPTION
## Summary

Adds Android APK builds to CI, making LeStash installable on Android phones.

Closes #48

## How it works

- New `.github/workflows/android.yml` — builds APK on every push to main and tags
- Targets: `aarch64-linux-android` + `x86_64-linux-android`
- Creates rolling `dev-android` pre-release for Obtainium auto-updates
- Tagged releases also get APK attached

## Stack

- Java 17 (Temurin)
- Android SDK + NDK 27.2.12479018
- Tauri v2 Android support (`npx tauri android init` + `npx tauri android build`)
- INTERNET permission injected into AndroidManifest.xml

## Obtainium Setup

After first build:
1. Install [Obtainium](https://obtainium.imranr.dev/)
2. Add app: `https://github.com/thompsonson/lestash`
3. Set release filter to `dev-android`
4. Obtainium will auto-update when new builds are pushed

## Test plan

- [x] CI Python tests pass
- [ ] Android build triggers after merge to main
- [ ] APK appears in `dev-android` release
- [ ] APK installs on Android device