### PR TITLE
feat(voice): add voice notes with recording, transcription, and LLM editing

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -406,6 +406,47 @@
     .import-dropzone:hover,
     .import-dropzone.dragover { border-color: var(--accent); color: var(--text); }
     .import-dropzone a { color: var(--accent); }
+
+    /* ── Voice recorder + note editor ── */
+    .voice-recorder {
+      display: flex; align-items: center; gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+    .record-btn {
+      background: var(--surface); color: var(--accent);
+      border: 2px solid var(--accent); border-radius: 50%;
+      width: 56px; height: 56px; cursor: pointer;
+      font-family: inherit; font-size: 0.75rem; font-weight: bold;
+      transition: all 0.2s;
+    }
+    .record-btn:hover { background: var(--accent); color: #fff; }
+    .record-btn.recording {
+      background: var(--error); border-color: var(--error); color: #fff;
+      animation: pulse 1.5s infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { transform: scale(1); }
+      50% { transform: scale(1.08); }
+    }
+    .record-status { font-size: 0.8rem; color: var(--muted); }
+    .transcript-box {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 6px; padding: 0.75rem;
+      font-size: 0.85rem; color: var(--muted);
+      min-height: 3rem; white-space: pre-wrap;
+    }
+    .note-textarea {
+      width: 100%; min-height: 120px;
+      font-family: inherit; font-size: 0.85rem;
+      background: var(--surface); color: var(--text);
+      border: 1px solid var(--border); border-radius: 6px;
+      padding: 0.75rem; resize: vertical;
+    }
+    .note-textarea:focus { outline: none; border-color: var(--accent); }
+    .note-actions {
+      display: flex; gap: 0.5rem; margin-top: 0.75rem;
+      justify-content: flex-end;
+    }
     @keyframes shimmer {
       0% { background-position: 200% 0; }
       100% { background-position: -200% 0; }
@@ -447,6 +488,7 @@
   <nav id="tabs">
     <button class="active" data-tab="feed">Feed</button>
     <button data-tab="recent">Recent</button>
+    <button data-tab="notes">Notes</button>
     <button data-tab="search">Search</button>
     <button data-tab="sources">Sources</button>
     <button data-tab="stats">Stats</button>
@@ -482,6 +524,26 @@
                placeholder="Search your knowledge base..." autocomplete="off">
       </div>
       <div class="item-list" id="search-list"></div>
+    </div>
+
+    <!-- Notes tab -->
+    <div class="tab-content" id="tab-notes">
+      <div class="voice-recorder">
+        <button class="record-btn" id="record-btn" onclick="toggleRecording()">Record</button>
+        <span class="record-status" id="record-status"></span>
+      </div>
+      <div id="note-editor" style="display:none">
+        <label style="font-size:0.8rem;color:var(--muted);display:block;margin-bottom:0.25rem">Original Transcript</label>
+        <div class="transcript-box" id="original-transcript"></div>
+        <label style="font-size:0.8rem;color:var(--muted);display:block;margin:0.75rem 0 0.25rem">Edited Note</label>
+        <textarea class="note-textarea" id="edited-note" placeholder="Edit your note here..."></textarea>
+        <div class="note-actions">
+          <button class="sync-btn" onclick="refineWithLLM()" id="refine-btn">Refine with AI</button>
+          <button class="btn-save" onclick="saveVoiceNote()">Save</button>
+        </div>
+      </div>
+      <h3 style="margin-top:1.5rem;font-size:0.85rem;color:var(--muted)">Saved Notes</h3>
+      <div class="item-list" id="notes-list"></div>
     </div>
 
     <!-- Recent tab -->
@@ -545,6 +607,13 @@
       <input type="text" id="s-host">
       <label for="s-port">Server port</label>
       <input type="number" id="s-port">
+      <hr style="border-color:var(--border);margin:0.75rem 0">
+      <label for="s-llm-url">LLM proxy URL</label>
+      <input type="text" id="s-llm-url" placeholder="http://localhost:4000">
+      <label for="s-llm-model">LLM model</label>
+      <input type="text" id="s-llm-model" placeholder="claude-sonnet-4-20250514">
+      <label for="s-llm-prompt">Refine prompt</label>
+      <textarea id="s-llm-prompt" style="width:100%;min-height:60px;font-family:inherit;font-size:0.8rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:0.4rem 0.6rem;resize:vertical" placeholder="Clean up this voice note..."></textarea>
       <div class="modal-actions">
         <button class="btn-cancel" onclick="closeSettings()">Cancel</button>
         <button class="btn-save" onclick="saveSettingsForm()">Save</button>
@@ -559,7 +628,10 @@
     /* ── Settings ── */
     const IS_TAURI = window.__TAURI_INTERNALS__ !== undefined;
     const SETTINGS_KEY = 'lestash-settings';
-    const DEFAULT_SETTINGS = { host: 'pop-mini.monkey-ladon.ts.net', port: 8444 };
+    const DEFAULT_SETTINGS = {
+      host: 'pop-mini.monkey-ladon.ts.net', port: 8444,
+      llmUrl: '', llmModel: '', llmPrompt: '',
+    };
 
     let settings = loadSettings();
 
@@ -584,6 +656,9 @@
     function openSettings() {
       document.getElementById('s-host').value = settings.host;
       document.getElementById('s-port').value = settings.port;
+      document.getElementById('s-llm-url').value = settings.llmUrl || '';
+      document.getElementById('s-llm-model').value = settings.llmModel || '';
+      document.getElementById('s-llm-prompt').value = settings.llmPrompt || '';
       document.getElementById('settings-modal').classList.add('open');
     }
 
@@ -595,6 +670,9 @@
       saveSettings({
         host: document.getElementById('s-host').value || DEFAULT_SETTINGS.host,
         port: parseInt(document.getElementById('s-port').value) || DEFAULT_SETTINGS.port,
+        llmUrl: document.getElementById('s-llm-url').value,
+        llmModel: document.getElementById('s-llm-model').value,
+        llmPrompt: document.getElementById('s-llm-prompt').value,
       });
       closeSettings();
       showToast('Settings saved — reloading...', 'ok');
@@ -633,6 +711,7 @@
       if (tab === 'feed' && feedItems.length === 0) loadFeed();
       if (tab === 'recent') loadRecent();
       if (tab === 'search') document.getElementById('search-input').focus();
+      if (tab === 'notes') loadSavedNotes();
       if (tab === 'sources') loadSources();
       if (tab === 'stats') loadStats();
     });
@@ -916,6 +995,220 @@
         showToast(`Sync failed: ${e.message}`, 'error');
         btn.disabled = false;
         btn.textContent = 'Sync';
+      }
+    }
+
+    /* ── Voice Notes ── */
+    let isRecording = false;
+    let recognition = null;
+    let currentTranscript = '';
+    let refineResult = null;
+
+    function toggleRecording() {
+      if (isRecording) stopRecording();
+      else startRecording();
+    }
+
+    function startRecording() {
+      const btn = document.getElementById('record-btn');
+      const status = document.getElementById('record-status');
+      const editor = document.getElementById('note-editor');
+
+      if (IS_TAURI && tauriInvoke) {
+        // Tauri: use whisper-rs (Phase 3)
+        tauriInvoke('start_recording').then(() => {
+          isRecording = true;
+          btn.classList.add('recording');
+          btn.textContent = 'Stop';
+          status.textContent = 'Recording...';
+        }).catch(e => {
+          showToast('Recording not available: ' + e, 'error');
+          // Fall back to Web Speech API
+          startWebSpeech();
+        });
+      } else {
+        startWebSpeech();
+      }
+    }
+
+    function startWebSpeech() {
+      const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (!SpeechRecognition) {
+        showToast('Speech recognition not supported in this browser', 'error');
+        return;
+      }
+
+      const btn = document.getElementById('record-btn');
+      const status = document.getElementById('record-status');
+
+      recognition = new SpeechRecognition();
+      recognition.continuous = true;
+      recognition.interimResults = true;
+      recognition.lang = 'en-US';
+
+      currentTranscript = '';
+      let interimText = '';
+
+      recognition.onresult = (e) => {
+        let final = '';
+        let interim = '';
+        for (let i = 0; i < e.results.length; i++) {
+          if (e.results[i].isFinal) {
+            final += e.results[i][0].transcript + ' ';
+          } else {
+            interim += e.results[i][0].transcript;
+          }
+        }
+        currentTranscript = final.trim();
+        interimText = interim;
+        status.textContent = currentTranscript
+          ? `${currentTranscript.split(' ').length} words`
+          : (interim ? 'Listening...' : 'Speak now...');
+      };
+
+      recognition.onerror = (e) => {
+        if (e.error !== 'no-speech') {
+          showToast('Speech error: ' + e.error, 'error');
+        }
+      };
+
+      recognition.onend = () => {
+        if (isRecording) recognition.start(); // restart if still recording
+      };
+
+      recognition.start();
+      isRecording = true;
+      btn.classList.add('recording');
+      btn.textContent = 'Stop';
+      status.textContent = 'Speak now...';
+    }
+
+    function stopRecording() {
+      const btn = document.getElementById('record-btn');
+      const status = document.getElementById('record-status');
+      const editor = document.getElementById('note-editor');
+
+      isRecording = false;
+      btn.classList.remove('recording');
+      btn.textContent = 'Record';
+
+      if (recognition) {
+        recognition.onend = null; // prevent restart
+        recognition.stop();
+        recognition = null;
+      }
+
+      if (IS_TAURI && tauriInvoke) {
+        tauriInvoke('stop_recording');
+      }
+
+      if (currentTranscript) {
+        document.getElementById('original-transcript').textContent = currentTranscript;
+        document.getElementById('edited-note').value = currentTranscript;
+        editor.style.display = '';
+        status.textContent = `${currentTranscript.split(' ').length} words captured`;
+        refineResult = null;
+      } else {
+        status.textContent = 'No speech detected';
+      }
+    }
+
+    // Listen for Tauri STT events (Phase 3)
+    if (IS_TAURI && typeof tauriListen === 'function') {
+      tauriListen('stt-transcription', (event) => {
+        currentTranscript = event.payload;
+        const status = document.getElementById('record-status');
+        status.textContent = `${currentTranscript.split(' ').length} words`;
+      });
+    }
+
+    async function refineWithLLM() {
+      const text = document.getElementById('original-transcript').textContent;
+      if (!text) return;
+
+      const btn = document.getElementById('refine-btn');
+      btn.disabled = true;
+      btn.textContent = 'Refining...';
+
+      try {
+        const body = { text };
+        if (settings.llmPrompt) body.prompt = settings.llmPrompt;
+        if (settings.llmModel) body.model = settings.llmModel;
+
+        const data = await api('/api/voice/refine', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+
+        document.getElementById('edited-note').value = data.refined_text;
+        refineResult = data;
+        showToast('Transcript refined', 'ok');
+      } catch (e) {
+        showToast('Refine failed: ' + e.message, 'error');
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Refine with AI';
+      }
+    }
+
+    async function saveVoiceNote() {
+      const original = document.getElementById('original-transcript').textContent;
+      const edited = document.getElementById('edited-note').value.trim();
+      if (!original && !edited) { showToast('Nothing to save', 'error'); return; }
+
+      const content = edited || original;
+      const metadata = { original_transcript: original };
+      if (edited && edited !== original) {
+        metadata.edited_text = edited;
+      }
+      if (refineResult) {
+        metadata.edit_prompt = refineResult.prompt_used;
+        metadata.edit_model = refineResult.model_used;
+      }
+      metadata.whisper_model = IS_TAURI ? 'whisper-rs' : 'web-speech-api';
+
+      try {
+        await api('/api/items', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            source_type: 'voice',
+            source_id: 'voice-' + Date.now(),
+            content: content,
+            is_own_content: true,
+            metadata: metadata,
+          }),
+        });
+        showToast('Voice note saved', 'ok');
+
+        // Reset editor
+        document.getElementById('note-editor').style.display = 'none';
+        document.getElementById('original-transcript').textContent = '';
+        document.getElementById('edited-note').value = '';
+        document.getElementById('record-status').textContent = '';
+        currentTranscript = '';
+        refineResult = null;
+        loadSavedNotes();
+      } catch (e) {
+        showToast('Save failed: ' + e.message, 'error');
+      }
+    }
+
+    async function loadSavedNotes() {
+      const list = document.getElementById('notes-list');
+      list.innerHTML = renderSkeletons(3);
+      try {
+        const data = await api('/api/items?source=voice&limit=20');
+        list.innerHTML = '';
+        if (data.items.length === 0) {
+          list.innerHTML = '<div class="empty-state">No voice notes yet. Hit Record to start.</div>';
+          return;
+        }
+        data.items.forEach(item => list.appendChild(renderCard(item)));
+      } catch (e) {
+        list.innerHTML = '';
+        showToast('Failed to load notes: ' + e.message, 'error');
       }
     }
 

--- a/packages/lestash-server/src/lestash_server/app.py
+++ b/packages/lestash-server/src/lestash_server/app.py
@@ -7,7 +7,7 @@ from fastapi.staticfiles import StaticFiles
 from lestash_server import __version__
 from lestash_server.deps import get_db
 from lestash_server.models import HealthResponse
-from lestash_server.routes import imports, items, profiles, sources, stats
+from lestash_server.routes import imports, items, profiles, sources, stats, voice
 
 
 def create_app(static_dir: str | None = None) -> FastAPI:
@@ -50,6 +50,7 @@ def create_app(static_dir: str | None = None) -> FastAPI:
     app.include_router(profiles.router)
     app.include_router(stats.router)
     app.include_router(imports.router)
+    app.include_router(voice.router)
 
     @app.get("/api/health", response_model=HealthResponse)
     def health():

--- a/packages/lestash-server/src/lestash_server/models.py
+++ b/packages/lestash-server/src/lestash_server/models.py
@@ -100,6 +100,22 @@ class ImportResponse(BaseModel):
     errors: list[str]
 
 
+class RefineRequest(BaseModel):
+    """Request to refine a transcript via LLM."""
+
+    text: str
+    prompt: str | None = None
+    model: str | None = None
+
+
+class RefineResponse(BaseModel):
+    """Response from LLM refinement."""
+
+    refined_text: str
+    model_used: str
+    prompt_used: str
+
+
 class HealthResponse(BaseModel):
     """Server health check."""
 

--- a/packages/lestash-server/src/lestash_server/routes/voice.py
+++ b/packages/lestash-server/src/lestash_server/routes/voice.py
@@ -1,0 +1,92 @@
+"""Voice note endpoints — LLM refinement and audio upload."""
+
+import logging
+import os
+import time
+from pathlib import Path
+
+import httpx
+from fastapi import APIRouter, HTTPException, UploadFile
+
+from lestash_server.models import RefineRequest, RefineResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/voice", tags=["voice"])
+
+DEFAULT_PROMPT = (
+    "Clean up this voice note transcript. Fix grammar, remove filler words "
+    "(um, uh, like, you know), improve punctuation, and organize into clear "
+    "paragraphs. Maintain the original meaning and tone. Return only the "
+    "cleaned text, no commentary."
+)
+
+
+def _get_llm_url() -> str:
+    return os.environ.get("LESTASH_LLM_URL", "http://localhost:4000")
+
+
+@router.post("/refine", response_model=RefineResponse)
+def refine_transcript(body: RefineRequest):
+    """Refine a transcript using an LLM via OpenAI-compatible API."""
+    llm_url = _get_llm_url()
+    prompt = body.prompt or DEFAULT_PROMPT
+    model = body.model or os.environ.get("LESTASH_LLM_MODEL", "claude-sonnet-4-20250514")
+
+    try:
+        resp = httpx.post(
+            f"{llm_url}/chat/completions",
+            json={
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": prompt},
+                    {"role": "user", "content": body.text},
+                ],
+                "temperature": 0.3,
+            },
+            timeout=60.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        refined = data["choices"][0]["message"]["content"]
+        model_used = data.get("model", model)
+
+        return RefineResponse(
+            refined_text=refined,
+            model_used=model_used,
+            prompt_used=prompt,
+        )
+    except httpx.ConnectError:
+        raise HTTPException(
+            status_code=503,
+            detail=f"LLM proxy not reachable at {llm_url}. "
+            "Configure LESTASH_LLM_URL or start LiteLLM proxy.",
+        ) from None
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"LLM proxy error: {e.response.status_code} {e.response.text[:200]}",
+        ) from None
+    except (KeyError, IndexError) as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Unexpected LLM response format: {e}",
+        ) from None
+
+
+@router.post("/upload")
+async def upload_audio(file: UploadFile):
+    """Upload raw audio file to cache directory."""
+    data = await file.read()
+    if len(data) > 50 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="File too large (max 50MB)")
+
+    cache_dir = Path.home() / ".config" / "lestash" / "cache" / "voice"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = f"voice-{int(time.time())}-{file.filename or 'recording.wav'}"
+    filepath = cache_dir / filename
+    filepath.write_bytes(data)
+
+    return {"path": f"voice/{filename}", "size": len(data)}

--- a/packages/lestash-server/tests/test_api.py
+++ b/packages/lestash-server/tests/test_api.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+from unittest.mock import MagicMock, patch
 
 
 class TestHealth:
@@ -255,6 +256,87 @@ class TestImport:
             files={"file": ("bad.json", io.BytesIO(data), "application/json")},
         )
         assert resp.status_code == 400
+
+
+class TestVoiceRefine:
+    """Test POST /api/voice/refine endpoint."""
+
+    def test_refine_success(self, client):
+        """Should return refined text from LLM."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "Cleaned up text."}}],
+            "model": "test-model",
+        }
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("lestash_server.routes.voice.httpx.post", return_value=mock_resp):
+            resp = client.post(
+                "/api/voice/refine",
+                json={"text": "um so I was thinking about uh the project"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["refined_text"] == "Cleaned up text."
+        assert data["model_used"] == "test-model"
+        assert "prompt_used" in data
+
+    def test_refine_custom_prompt(self, client):
+        """Should use custom prompt when provided."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "Summarized."}}],
+            "model": "test-model",
+        }
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("lestash_server.routes.voice.httpx.post", return_value=mock_resp) as mock_post:
+            resp = client.post(
+                "/api/voice/refine",
+                json={"text": "some text", "prompt": "Summarize this."},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["prompt_used"] == "Summarize this."
+        call_body = mock_post.call_args[1]["json"]
+        assert call_body["messages"][0]["content"] == "Summarize this."
+
+    def test_refine_llm_unreachable(self, client):
+        """Should return 503 when LLM proxy is unreachable."""
+        with patch(
+            "lestash_server.routes.voice.httpx.post",
+            side_effect=__import__("httpx").ConnectError("Connection refused"),
+        ):
+            resp = client.post("/api/voice/refine", json={"text": "test"})
+
+        assert resp.status_code == 503
+        assert "not reachable" in resp.json()["detail"]
+
+    def test_refine_missing_text(self, client):
+        """Should return 422 when text is missing."""
+        resp = client.post("/api/voice/refine", json={})
+        assert resp.status_code == 422
+
+
+class TestVoiceUpload:
+    """Test POST /api/voice/upload endpoint."""
+
+    def test_upload_audio(self, client, tmp_path, monkeypatch):
+        """Should save audio file and return path."""
+        monkeypatch.setattr("lestash_server.routes.voice.Path.home", lambda: tmp_path)
+
+        resp = client.post(
+            "/api/voice/upload",
+            files={"file": ("test.wav", io.BytesIO(b"fake audio data"), "audio/wav")},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["path"].startswith("voice/")
+        assert data["size"] == len(b"fake audio data")
 
 
 class TestCORS:


### PR DESCRIPTION
## Summary

Voice note capture with recording, transcription, and AI-powered editing. Works in browser now (Web Speech API), with Tauri on-device Whisper planned for Phase 3.

Closes #52, closes #53

## What's New

### Server
- `POST /api/voice/refine` — send transcript to LiteLLM proxy (OpenAI-compatible), returns refined text
- `POST /api/voice/upload` — save raw audio to cache directory
- Configurable via `LESTASH_LLM_URL` and `LESTASH_LLM_MODEL` env vars

### Frontend
- **Notes tab** — record button, transcript display, editable textarea
- **Web Speech API** — browser-native speech recognition (Chrome/Edge)
- **Refine with AI** — calls LLM proxy to clean up transcript
- **Save** — creates item with `source_type: "voice"`, stores original + edited versions separately in metadata
- **Settings** — LLM proxy URL, model, custom refine prompt
- **Saved notes** list below the editor

### Data Model
```json
{
  "source_type": "voice",
  "content": "best version (edited or original)",
  "metadata": {
    "original_transcript": "raw speech output",
    "edited_text": "cleaned up version",
    "edit_prompt": "prompt used",
    "edit_model": "model used",
    "whisper_model": "web-speech-api"
  }
}
```

## Remaining Phases
- #54 — Phase 3: Tauri on-device Whisper (whisper-rs)
- #55 — Phase 4: LiteLLM proxy deployment

## Test plan
- [x] 37 server tests pass (5 new: refine, custom prompt, LLM unreachable, validation, upload)
- [x] 41 core tests pass
- [x] Lint + format clean
- [x] Server deployed, Notes tab visible, refine returns proper 503 without LiteLLM