### PR TITLE
feat(app): add on-device Whisper transcription via whisper-rs

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -41,7 +41,23 @@ jobs:
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \
-            librsvg2-dev
+            librsvg2-dev \
+            cmake \
+            libclang-dev \
+            libasound2-dev
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install cmake
+
+      - name: Patch whisper.cpp for macOS ARM CI
+        if: runner.os == 'macOS'
+        run: |
+          echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> "$GITHUB_ENV"
+          echo "CMAKE_OSX_DEPLOYMENT_TARGET=11.0" >> "$GITHUB_ENV"
+          cd app && cargo fetch --manifest-path src-tauri/Cargo.toml
+          find ~/.cargo/registry/src -path "*/whisper-rs-sys-*/whisper.cpp/ggml/src/ggml-cpu/CMakeLists.txt" \
+            -exec sed -i '' 's/if (GGML_NATIVE)/if (FALSE) # patched for macOS CI/' {} \;
 
       - name: Install npm dependencies
         run: npm ci

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -10,8 +10,15 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
+whisper-rs = "0.14"
+cpal = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+anyhow = "1"
+dirs-next = "2"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,6 +1,53 @@
+mod stt;
+
+use std::sync::Arc;
+
+struct AppState {
+    stt: Arc<stt::SttEngine>,
+}
+
+#[tauri::command]
+async fn start_recording(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<String, String> {
+    state
+        .stt
+        .start(app)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok("Recording started".into())
+}
+
+#[tauri::command]
+async fn stop_recording(state: tauri::State<'_, AppState>) -> Result<String, String> {
+    state.stt.stop().await;
+    Ok("Recording stopped".into())
+}
+
+#[tauri::command]
+fn get_stt_status(state: tauri::State<'_, AppState>) -> serde_json::Value {
+    let path = stt::model_path();
+    serde_json::json!({
+        "listening": state.stt.is_listening(),
+        "model_exists": path.exists(),
+        "model_path": path.to_string_lossy(),
+    })
+}
+
 pub fn run() {
+    tracing_subscriber::fmt::init();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .manage(AppState {
+            stt: Arc::new(stt::SttEngine::new()),
+        })
+        .invoke_handler(tauri::generate_handler![
+            start_recording,
+            stop_recording,
+            get_stt_status,
+        ])
         .run(tauri::generate_context!())
         .expect("error running lestash");
 }

--- a/app/src-tauri/src/stt.rs
+++ b/app/src-tauri/src/stt.rs
@@ -1,0 +1,239 @@
+use anyhow::{Context, Result};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Emitter};
+use tokio::sync::mpsc;
+use tracing::{error, info, warn};
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+
+const WHISPER_MODEL: &str = "ggml-base.en.bin";
+const SAMPLE_RATE: u32 = 16000;
+const SILENCE_THRESHOLD_MS: u64 = 800;
+const SILENCE_RMS: f32 = 0.01;
+const MIN_AUDIO_SECS: f32 = 0.5;
+const AUDIO_PREALLOC_SECS: usize = 5;
+const MAX_BUFFER_SECS: usize = 30;
+const POLL_INTERVAL_MS: u64 = 100;
+const RMS_WINDOW_DIVISOR: usize = 10;
+
+pub struct SttEngine {
+    listening: Arc<AtomicBool>,
+    stop_tx: tokio::sync::Mutex<Option<mpsc::Sender<()>>>,
+}
+
+impl SttEngine {
+    pub fn new() -> Self {
+        Self {
+            listening: Arc::new(AtomicBool::new(false)),
+            stop_tx: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    pub fn is_listening(&self) -> bool {
+        self.listening.load(Ordering::Relaxed)
+    }
+
+    pub async fn start(&self, app: AppHandle) -> Result<()> {
+        if self.is_listening() {
+            return Ok(());
+        }
+
+        let path = model_path();
+        if !path.exists() {
+            return Err(anyhow::anyhow!(
+                "Whisper model not found at {}. Download ggml-base.en.bin to this location.",
+                path.display()
+            ));
+        }
+
+        let (stop_tx, stop_rx) = mpsc::channel::<()>(1);
+        *self.stop_tx.lock().await = Some(stop_tx);
+        self.listening.store(true, Ordering::Relaxed);
+
+        let listening = self.listening.clone();
+
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = run_stt_loop(app, path, stop_rx, listening.clone()) {
+                error!("STT loop error: {e}");
+            }
+            listening.store(false, Ordering::Relaxed);
+        });
+
+        Ok(())
+    }
+
+    pub async fn stop(&self) {
+        self.listening.store(false, Ordering::Relaxed);
+        if let Some(tx) = self.stop_tx.lock().await.take() {
+            let _ = tx.send(()).await;
+        }
+    }
+}
+
+pub fn model_path() -> PathBuf {
+    let data_dir = dirs_next::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("lestash");
+    data_dir.join(WHISPER_MODEL)
+}
+
+fn run_stt_loop(
+    app: AppHandle,
+    model_path: PathBuf,
+    mut stop_rx: mpsc::Receiver<()>,
+    listening: Arc<AtomicBool>,
+) -> Result<()> {
+    info!("Loading whisper model from {}", model_path.display());
+    let ctx = WhisperContext::new_with_params(
+        model_path.to_str().unwrap(),
+        WhisperContextParameters::default(),
+    )
+    .context("Failed to load whisper model")?;
+
+    info!("Whisper model loaded, starting audio capture");
+    let _ = app.emit("stt-status", "model_loaded");
+
+    let host = cpal::default_host();
+    let device = host
+        .default_input_device()
+        .context("No input audio device found")?;
+
+    if let Ok(desc) = device.description() {
+        info!("Using input device: {}", desc.name());
+    }
+
+    let config = cpal::StreamConfig {
+        channels: 1,
+        sample_rate: SAMPLE_RATE,
+        buffer_size: cpal::BufferSize::Default,
+    };
+
+    let audio_buf: Arc<std::sync::Mutex<Vec<f32>>> = Arc::new(std::sync::Mutex::new(
+        Vec::with_capacity(SAMPLE_RATE as usize * AUDIO_PREALLOC_SECS),
+    ));
+
+    let buf_clone = audio_buf.clone();
+    let stream = device.build_input_stream(
+        &config,
+        move |data: &[f32], _: &cpal::InputCallbackInfo| {
+            if let Ok(mut buf) = buf_clone.lock() {
+                buf.extend_from_slice(data);
+            }
+        },
+        |err| {
+            error!("Audio stream error: {err}");
+        },
+        None,
+    )?;
+    stream.play()?;
+
+    let _ = app.emit("stt-status", "listening");
+
+    let mut last_speech = Instant::now();
+    let mut had_speech = false;
+
+    while listening.load(Ordering::Relaxed) {
+        if stop_rx.try_recv().is_ok() {
+            break;
+        }
+
+        std::thread::sleep(Duration::from_millis(POLL_INTERVAL_MS));
+
+        let audio_len = audio_buf.lock().unwrap().len();
+        let audio_secs = audio_len as f32 / SAMPLE_RATE as f32;
+
+        if audio_len == 0 {
+            continue;
+        }
+
+        // Check RMS of recent audio for silence detection
+        let recent_rms = {
+            let buf = audio_buf.lock().unwrap();
+            let recent_start = buf.len().saturating_sub(SAMPLE_RATE as usize / RMS_WINDOW_DIVISOR);
+            let recent = &buf[recent_start..];
+            if recent.is_empty() {
+                0.0
+            } else {
+                (recent.iter().map(|s| s * s).sum::<f32>() / recent.len() as f32).sqrt()
+            }
+        };
+
+        let is_silent = recent_rms < SILENCE_RMS;
+
+        if !is_silent {
+            last_speech = Instant::now();
+            had_speech = true;
+        }
+
+        let silence_duration = last_speech.elapsed();
+        let should_process = had_speech
+            && is_silent
+            && silence_duration > Duration::from_millis(SILENCE_THRESHOLD_MS)
+            && audio_secs > MIN_AUDIO_SECS;
+
+        if !should_process {
+            // Cap buffer to prevent unbounded growth
+            let max_samples = SAMPLE_RATE as usize * MAX_BUFFER_SECS;
+            let mut buf = audio_buf.lock().unwrap();
+            if buf.len() > max_samples {
+                let drain_to = buf.len() - max_samples;
+                buf.drain(..drain_to);
+            }
+            continue;
+        }
+
+        // Take audio and transcribe
+        let samples: Vec<f32> = {
+            let mut buf = audio_buf.lock().unwrap();
+            let s = buf.clone();
+            buf.clear();
+            s
+        };
+        had_speech = false;
+
+        info!(
+            "Transcribing {:.1}s of audio",
+            samples.len() as f32 / SAMPLE_RATE as f32
+        );
+
+        let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+        params.set_language(Some("en"));
+        params.set_print_special(false);
+        params.set_print_progress(false);
+        params.set_print_realtime(false);
+        params.set_print_timestamps(false);
+        params.set_suppress_blank(true);
+        params.set_suppress_nst(true);
+
+        let mut state = ctx.create_state().context("Failed to create whisper state")?;
+
+        if let Err(e) = state.full(params, &samples) {
+            warn!("Whisper transcription failed: {e}");
+            continue;
+        }
+
+        let num_segments = state.full_n_segments().unwrap_or(0);
+        let mut text = String::new();
+        for i in 0..num_segments {
+            if let Ok(segment) = state.full_get_segment_text(i) {
+                text.push_str(&segment);
+            }
+        }
+
+        let text = text.trim().to_string();
+        if text.is_empty() || text == "[BLANK_AUDIO]" {
+            continue;
+        }
+
+        info!("Transcribed: {text}");
+        let _ = app.emit("stt-transcription", &text);
+    }
+
+    drop(stream);
+    info!("STT stopped");
+    let _ = app.emit("stt-status", "stopped");
+    Ok(())
+}

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -711,7 +711,7 @@
       if (tab === 'feed' && feedItems.length === 0) loadFeed();
       if (tab === 'recent') loadRecent();
       if (tab === 'search') document.getElementById('search-input').focus();
-      if (tab === 'notes') loadSavedNotes();
+      if (tab === 'notes') { loadSavedNotes(); checkSttModel(); }
       if (tab === 'sources') loadSources();
       if (tab === 'stats') loadStats();
     });
@@ -1120,6 +1120,18 @@
         const status = document.getElementById('record-status');
         status.textContent = `${currentTranscript.split(' ').length} words`;
       });
+    }
+
+    function checkSttModel() {
+      if (IS_TAURI && tauriInvoke) {
+        tauriInvoke('get_stt_status').then(status => {
+          if (!status.model_exists) {
+            document.getElementById('record-status').innerHTML =
+              '<span style="color:var(--warn)">Whisper model not found. Download ggml-base.en.bin to ' +
+              escHtml(status.model_path) + '</span>';
+          }
+        }).catch(() => {});
+      }
     }
 
     async function refineWithLLM() {


### PR DESCRIPTION
## Summary

On-device speech-to-text for the Tauri desktop app using whisper-rs, adapted from the Chops project. The frontend already has the wiring from PR #56 — this adds the Rust backend.

Closes #54

## How it works

```
[Mic] → cpal (16kHz mono) → audio buffer → silence detection → whisper-rs → stt-transcription event → frontend
```

- Records continuously until user clicks Stop
- Detects speech/silence via RMS threshold
- Transcribes when 800ms of silence detected after speech
- Emits `stt-transcription` event with text
- Frontend falls back to Web Speech API if model not found or not in Tauri

## New Files

- `app/src-tauri/src/stt.rs` — SttEngine (adapted from Chops, no MQTT)
- `app/src-tauri/src/lib.rs` — Tauri commands: start_recording, stop_recording, get_stt_status

## Dependencies Added

- `whisper-rs = "0.14"` — Rust bindings to whisper.cpp
- `cpal = "0.17"` — cross-platform audio capture
- `tokio`, `tracing`, `anyhow`, `dirs-next`

## CI Changes

- Linux: added `cmake`, `libclang-dev`, `libasound2-dev`
- macOS: `brew install cmake` + whisper.cpp GGML_NATIVE patch (same as Chops)

## Setup

```bash
mkdir -p ~/.local/share/lestash
curl -Lo ~/.local/share/lestash/ggml-base.en.bin \
  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
```

## Test plan

- [x] `cargo check` compiles clean
- [x] 37 server + 41 core Python tests pass
- [x] Lint clean
- [ ] Desktop build CI (macOS + Linux) — will verify after merge