### PR TITLE
feat(app): add copy button, copy link, and shareable item URLs

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -182,6 +182,19 @@
       color: var(--muted);
     }
 
+    .item-detail-actions {
+      display: flex; gap: 0.5rem; margin-top: 0.75rem;
+    }
+    .item-detail-actions .sync-btn { font-size: 0.75rem; padding: 0.3rem 0.6rem; }
+
+    /* ── Single item view ── */
+    .single-item-view { padding: 0.5rem 0; }
+    .single-item-back {
+      display: inline-block; margin-bottom: 1rem;
+      color: var(--accent); text-decoration: none; font-size: 0.85rem;
+    }
+    .single-item-back:hover { text-decoration: underline; }
+
     /* ── Load more ── */
     .load-more {
       display: block; margin: 1rem auto 0;
@@ -964,8 +977,19 @@
       if (item.metadata) {
         html += `<div class="item-detail-field"><label>Metadata</label><div class="item-detail-meta">${escHtml(JSON.stringify(item.metadata, null, 2))}</div></div>`;
       }
+      html += `<div class="item-detail-actions">
+        <button class="sync-btn" data-action="copy" data-id="${item.id}">Copy</button>
+        <button class="sync-btn" data-action="copy-link" data-id="${item.id}">Copy Link</button>
+      </div>`;
 
       detail.innerHTML = html;
+      detail.addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-action]');
+        if (!btn) return;
+        e.stopPropagation();
+        if (btn.dataset.action === 'copy') copyToClipboard(item.content, 'Copied to clipboard');
+        if (btn.dataset.action === 'copy-link') copyToClipboard(`${getApiBase()}/items/${item.id}`, 'Link copied');
+      });
       card.appendChild(detail);
     }
 
@@ -1648,14 +1672,71 @@
       loadFeed();
     }
 
+    /* ── Clipboard ── */
+    function copyToClipboard(text, message) {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(
+          () => showToast(message || 'Copied', 'ok'),
+          () => copyFallback(text, message)
+        );
+      } else {
+        copyFallback(text, message);
+      }
+    }
+
+    function copyFallback(text, message) {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.cssText = 'position:fixed;left:-9999px';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      showToast(message || 'Copied', 'ok');
+    }
+
+    /* ── Single Item View (URL routing) ── */
+    function checkSingleItemRoute() {
+      if (IS_TAURI) return false;
+      const match = window.location.pathname.match(/^\/items\/(\d+)$/);
+      if (!match) return false;
+      const itemId = match[1];
+      // Hide normal UI, show single item
+      document.querySelector('nav').style.display = 'none';
+      document.querySelectorAll('.tab-content').forEach(t => t.classList.remove('active'));
+      const container = document.createElement('div');
+      container.className = 'single-item-view';
+      container.innerHTML = '<a class="single-item-back" href="/">← Back to LeStash</a><div id="single-item-content">Loading...</div>';
+      document.querySelector('main').appendChild(container);
+      checkHealth().then(() => loadSingleItem(itemId));
+      return true;
+    }
+
+    async function loadSingleItem(itemId) {
+      const el = document.getElementById('single-item-content');
+      try {
+        const item = await api(`/api/items/${itemId}`);
+        const card = renderCard(item);
+        el.innerHTML = '';
+        el.appendChild(card);
+        // Auto-expand detail
+        toggleDetail(card, item);
+      } catch (e) {
+        el.innerHTML = `<div class="empty-state">Item not found: ${escHtml(e.message)}</div>`;
+      }
+    }
+
     /* ── Init ── */
     document.getElementById('settings-btn').addEventListener('click', openSettings);
     renderDebugInfo();
-    // Wait for health check before loading data (Android WebView may not be ready immediately)
-    checkHealth().then(() => {
-      populateSourceFilter();
-      loadFeed();
-    });
+
+    if (!checkSingleItemRoute()) {
+      // Normal app flow
+      checkHealth().then(() => {
+        populateSourceFilter();
+        loadFeed();
+      });
+    }
     setInterval(checkHealth, 30000);
   </script>
 </body>

--- a/packages/lestash-server/src/lestash_server/app.py
+++ b/packages/lestash-server/src/lestash_server/app.py
@@ -59,8 +59,24 @@ def create_app(static_dir: str | None = None) -> FastAPI:
             count = conn.execute("SELECT COUNT(*) FROM items").fetchone()[0]
         return HealthResponse(version=__version__, items=count)
 
-    # Serve static frontend files as fallback
+    # Serve static frontend files with SPA fallback
     if static_dir:
-        app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
+        from pathlib import Path
+
+        from fastapi.responses import HTMLResponse
+
+        index_path = Path(static_dir) / "index.html"
+
+        app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+        @app.get("/{path:path}", response_class=HTMLResponse, include_in_schema=False)
+        def spa_fallback(path: str):
+            """Serve index.html for all non-API paths (SPA routing)."""
+            # Try to serve the exact file first
+            file_path = Path(static_dir) / path
+            if file_path.is_file():
+                return HTMLResponse(file_path.read_text())
+            # Fall back to index.html for client-side routing
+            return HTMLResponse(index_path.read_text())
 
     return app


### PR DESCRIPTION
## Summary
- Add **Copy** and **Copy Link** buttons to item detail views
- Copy Link generates a shareable web URL (e.g. `https://host:8444/items/42`) that works on any device on the tailnet
- Client-side URL routing: opening `/items/{id}` in a browser loads and displays that single item
- SPA catch-all route in server to serve `index.html` for non-API paths
- Clipboard fallback (`document.execCommand`) for Android WebView compatibility

## Test plan
- [ ] Expand any item card → Copy and Copy Link buttons visible
- [ ] Copy → content in clipboard, toast shown
- [ ] Copy Link → URL copied, paste shows `https://host:8444/items/{id}`
- [ ] Open that URL in a browser → single item view with detail expanded
- [ ] "← Back to LeStash" link returns to main app
- [ ] `uv run just check` passes