### PR TITLE
fix(app): SPA fallback for binary assets and prevent double-save

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -1474,14 +1474,9 @@
           body: formData,
         });
 
-        currentTranscript = data.text;
-        document.getElementById('note-title').value = data.title;
-        document.getElementById('original-transcript').textContent = data.text;
-        document.getElementById('edited-note').value = data.text;
-        editor.style.display = '';
+        // Item already saved by the server — just refresh the list
         status.textContent = `${data.text.split(' ').length} words transcribed from ${file.name}`;
-        refineResult = null;
-        showToast('Transcription complete', 'ok');
+        showToast(`Saved: ${data.title}`, 'ok');
         loadSavedNotes();
       } catch (e) {
         showToast('Transcription failed: ' + e.message, 'error');

--- a/packages/lestash-server/src/lestash_server/app.py
+++ b/packages/lestash-server/src/lestash_server/app.py
@@ -63,20 +63,18 @@ def create_app(static_dir: str | None = None) -> FastAPI:
     if static_dir:
         from pathlib import Path
 
-        from fastapi.responses import HTMLResponse
+        from fastapi.responses import FileResponse, HTMLResponse
 
         index_path = Path(static_dir) / "index.html"
 
         app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
-        @app.get("/{path:path}", response_class=HTMLResponse, include_in_schema=False)
+        @app.get("/{path:path}", include_in_schema=False)
         def spa_fallback(path: str):
-            """Serve index.html for all non-API paths (SPA routing)."""
-            # Try to serve the exact file first
+            """Serve static files or index.html for SPA routing."""
             file_path = Path(static_dir) / path
             if file_path.is_file():
-                return HTMLResponse(file_path.read_text())
-            # Fall back to index.html for client-side routing
+                return FileResponse(file_path)
             return HTMLResponse(index_path.read_text())
 
     return app


### PR DESCRIPTION
## Summary
- **SPA fallback**: Use `FileResponse` for existing static files instead of `HTMLResponse(read_text())`. The old approach would break binary assets (images, fonts) and served everything as `text/html`.
- **Double-save**: File transcription no longer shows the note editor after upload. The server already saves the item during transcription, so showing the editor led to duplicate entries if the user hit Save.

## Test plan
- [x] `/items/42` still serves index.html (SPA routing works)
- [ ] Upload audio file → toast shows "Saved: {title}", note appears in list, no editor shown
- [ ] Live recording still shows editor with Save button (unchanged)
- [ ] `uv run just check` passes