### PR TITLE
feat: add tagging support to items (UI + API)

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -145,6 +145,25 @@
       display: flex; gap: 1rem; margin-top: 0.3rem;
       font-size: 0.75rem; color: var(--muted);
     }
+    .item-tags { display: flex; flex-wrap: wrap; gap: 0.25rem; margin-top: 0.25rem; }
+    .tag-chip {
+      display: inline-block; font-size: 0.7rem;
+      background: var(--surface); color: var(--accent);
+      border: 1px solid var(--accent); border-radius: 10px;
+      padding: 0.1rem 0.5rem; cursor: default;
+    }
+    .tag-chip .tag-remove {
+      cursor: pointer; margin-left: 0.25rem; opacity: 0.6;
+    }
+    .tag-chip .tag-remove:hover { opacity: 1; }
+    .tag-input-row {
+      display: flex; gap: 0.3rem; margin-top: 0.4rem; align-items: center;
+    }
+    .tag-input-row input {
+      flex: 1; font-size: 0.8rem; padding: 0.25rem 0.5rem;
+      background: var(--bg); color: var(--text);
+      border: 1px solid var(--border); border-radius: 4px;
+    }
 
     /* ── Item detail (expanded) ── */
     .item-detail {
@@ -530,6 +549,9 @@
       <div class="filters">
         <select id="feed-source">
           <option value="">All sources</option>
+        </select>
+        <select id="feed-tag">
+          <option value="">All tags</option>
         </select>
         <label style="font-size:0.8rem;display:flex;align-items:center;gap:0.3rem;color:var(--muted)">
           <input type="checkbox" id="feed-own"> Own
@@ -943,6 +965,7 @@
         </div>
         ${item.title ? `<div style="font-size:0.85rem;font-weight:bold;margin:0.25rem 0">${escHtml(item.title)}</div>` : ''}
         <div class="item-preview">${escHtml(item.preview)}</div>
+        ${item.tags && item.tags.length ? `<div class="item-tags">${item.tags.map(t => `<span class="tag-chip">${escHtml(t)}</span>`).join('')}</div>` : ''}
         <div class="item-meta">
           ${item.author_display !== '-' ? `<span>by ${escHtml(item.author_display)}</span>` : ''}
           ${item.actor_display !== '-' ? `<span>actor: ${escHtml(item.actor_display)}</span>` : ''}
@@ -977,18 +1000,64 @@
       if (item.metadata) {
         html += `<div class="item-detail-field"><label>Metadata</label><div class="item-detail-meta">${escHtml(JSON.stringify(item.metadata, null, 2))}</div></div>`;
       }
+      // Tags section
+      const currentTags = (item.tags || []).map(t =>
+        `<span class="tag-chip">${escHtml(t)}<span class="tag-remove" data-action="remove-tag" data-tag="${escHtml(t)}" data-id="${item.id}">&times;</span></span>`
+      ).join('');
+      html += `<div class="item-detail-field"><label>Tags</label>
+        <div class="item-tags">${currentTags || '<span style="color:var(--muted);font-size:0.75rem">No tags</span>'}</div>
+        <div class="tag-input-row">
+          <input type="text" placeholder="Add tag..." data-tag-input="${item.id}">
+          <button class="sync-btn" data-action="add-tag" data-id="${item.id}" style="font-size:0.75rem;padding:0.25rem 0.5rem">Add</button>
+        </div>
+      </div>`;
+
       html += `<div class="item-detail-actions">
         <button class="sync-btn" data-action="copy" data-id="${item.id}">Copy</button>
         <button class="sync-btn" data-action="copy-link" data-id="${item.id}">Copy Link</button>
       </div>`;
 
       detail.innerHTML = html;
-      detail.addEventListener('click', (e) => {
+      detail.addEventListener('click', async (e) => {
         const btn = e.target.closest('[data-action]');
         if (!btn) return;
         e.stopPropagation();
         if (btn.dataset.action === 'copy') copyToClipboard(item.content, 'Copied to clipboard');
         if (btn.dataset.action === 'copy-link') copyToClipboard(`${getApiBase()}/items/${item.id}`, 'Link copied');
+        if (btn.dataset.action === 'remove-tag') {
+          await api(`/api/items/${btn.dataset.id}/tags/${encodeURIComponent(btn.dataset.tag)}`, { method: 'DELETE' });
+          const updated = await api(`/api/items/${btn.dataset.id}`);
+          item.tags = updated.tags;
+          card.querySelector('.item-detail').remove();
+          toggleDetail(card, item);
+        }
+        if (btn.dataset.action === 'add-tag') {
+          const input = detail.querySelector(`[data-tag-input="${btn.dataset.id}"]`);
+          const name = input.value.trim();
+          if (!name) return;
+          await api(`/api/items/${btn.dataset.id}/tags`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name }),
+          });
+          input.value = '';
+          const updated = await api(`/api/items/${btn.dataset.id}`);
+          item.tags = updated.tags;
+          card.querySelector('.item-detail').remove();
+          toggleDetail(card, item);
+          // Also update tag chips in the card
+          const tagsDiv = card.querySelector('.item-tags');
+          if (tagsDiv && !card.querySelector('.item-detail .item-tags') === tagsDiv) {
+            tagsDiv.innerHTML = item.tags.map(t => `<span class="tag-chip">${escHtml(t)}</span>`).join('');
+          }
+        }
+      });
+      // Allow Enter key in tag input
+      detail.querySelector(`[data-tag-input="${item.id}"]`)?.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.stopPropagation();
+          detail.querySelector(`[data-action="add-tag"][data-id="${item.id}"]`).click();
+        }
       });
       card.appendChild(detail);
     }
@@ -1013,9 +1082,11 @@
       try {
         const source = document.getElementById('feed-source').value;
         const own = document.getElementById('feed-own').checked;
+        const tag = document.getElementById('feed-tag').value;
         let url = `/api/items?limit=${FEED_LIMIT}&offset=${feedOffset}`;
         if (source) url += `&source=${encodeURIComponent(source)}`;
         if (own) url += `&own=true`;
+        if (tag) url += `&tag=${encodeURIComponent(tag)}`;
 
         // Subtype exclusions
         const excluded = getExcludedSubtypes();
@@ -1048,6 +1119,7 @@
 
     document.getElementById('feed-source').addEventListener('change', () => loadFeed());
     document.getElementById('feed-own').addEventListener('change', () => loadFeed());
+    document.getElementById('feed-tag').addEventListener('change', () => loadFeed());
 
     /* ── Subtype filters ── */
     const SUBTYPE_STORAGE_KEY = 'lestash-subtype-filters';
@@ -1617,6 +1689,22 @@
       } catch {}
     }
 
+    async function populateTagFilter() {
+      try {
+        const data = await api('/api/items/tags');
+        const sel = document.getElementById('feed-tag');
+        const current = sel.value;
+        sel.innerHTML = '<option value="">All tags</option>';
+        data.tags.forEach(t => {
+          const opt = document.createElement('option');
+          opt.value = t.name;
+          opt.textContent = `${t.name} (${t.count})`;
+          sel.appendChild(opt);
+        });
+        sel.value = current;
+      } catch {}
+    }
+
     /* ── Skeleton loading ── */
     function renderSkeletons(count) {
       let html = '';
@@ -1669,6 +1757,7 @@
       showToast('Reconnecting...', '');
       await checkHealth();
       populateSourceFilter();
+      populateTagFilter();
       loadFeed();
     }
 
@@ -1734,6 +1823,7 @@
       // Normal app flow
       checkHealth().then(() => {
         populateSourceFilter();
+        populateTagFilter();
         loadFeed();
       });
     }

--- a/packages/lestash-server/src/lestash_server/models.py
+++ b/packages/lestash-server/src/lestash_server/models.py
@@ -25,6 +25,7 @@ class ItemResponse(BaseModel):
     author_display: str
     actor_display: str
     preview: str
+    tags: list[str] = []
 
 
 class ItemListResponse(BaseModel):
@@ -132,6 +133,25 @@ class TranscribeResponse(BaseModel):
     model: str
     item_id: int
     title: str
+
+
+class TagInfo(BaseModel):
+    """A tag with its usage count."""
+
+    name: str
+    count: int
+
+
+class TagListResponse(BaseModel):
+    """List of all tags."""
+
+    tags: list[TagInfo]
+
+
+class TagAddRequest(BaseModel):
+    """Request to add a tag to an item."""
+
+    name: str
 
 
 class HealthResponse(BaseModel):

--- a/packages/lestash-server/src/lestash_server/routes/items.py
+++ b/packages/lestash-server/src/lestash_server/routes/items.py
@@ -3,11 +3,18 @@
 import json
 
 from fastapi import APIRouter, HTTPException, Query
+from lestash.core.database import add_tag, get_tags, list_tags, remove_tag
 from lestash.core.enrichment import get_author_actor, get_item_subtype, get_preview
 from lestash.models.item import Item
 
 from lestash_server.deps import get_db
-from lestash_server.models import ItemCreateRequest, ItemListResponse, ItemResponse
+from lestash_server.models import (
+    ItemCreateRequest,
+    ItemListResponse,
+    ItemResponse,
+    TagAddRequest,
+    TagListResponse,
+)
 
 router = APIRouter(prefix="/api/items", tags=["items"])
 
@@ -31,6 +38,7 @@ def _enrich_item(conn, item: Item) -> ItemResponse:
         author_display=author_display,
         actor_display=actor_display,
         preview=get_preview(conn, item, max_length=120),
+        tags=get_tags(conn, item.id),
     )
 
 
@@ -47,6 +55,7 @@ def list_items(
         None, description="Comma-separated subtypes to exclude (e.g., reaction,invitation,message)"
     ),
     since: str | None = Query(None, description="Only items fetched since this ISO datetime"),
+    tag: str | None = Query(None, description="Filter by tag name"),
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ):
@@ -55,6 +64,21 @@ def list_items(
         count_query = "SELECT COUNT(*) FROM items WHERE 1=1"
         query = "SELECT * FROM items WHERE 1=1"
         params: list = []
+
+        if tag:
+            query = (
+                "SELECT items.* FROM items "
+                "JOIN item_tags ON items.id = item_tags.item_id "
+                "JOIN tags ON item_tags.tag_id = tags.id "
+                "WHERE tags.name = ?"
+            )
+            count_query = (
+                "SELECT COUNT(*) FROM items "
+                "JOIN item_tags ON items.id = item_tags.item_id "
+                "JOIN tags ON item_tags.tag_id = tags.id "
+                "WHERE tags.name = ?"
+            )
+            params.append(tag.strip().lower())
 
         if source:
             query += " AND source_type = ?"
@@ -173,6 +197,17 @@ def create_item(body: ItemCreateRequest):
         return _enrich_item(conn, Item.from_row(row))
 
 
+@router.get("/tags", response_model=TagListResponse)
+def get_all_tags():
+    """List all tags with item counts."""
+    from lestash_server.models import TagInfo
+
+    with get_db() as conn:
+        return TagListResponse(
+            tags=[TagInfo(**t) for t in list_tags(conn)],
+        )
+
+
 @router.get("/{item_id}", response_model=ItemResponse)
 def get_item(item_id: int):
     """Get a single item by ID."""
@@ -180,4 +215,26 @@ def get_item(item_id: int):
         row = conn.execute("SELECT * FROM items WHERE id = ?", (item_id,)).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail=f"Item {item_id} not found")
+        return _enrich_item(conn, Item.from_row(row))
+
+
+@router.post("/{item_id}/tags", response_model=ItemResponse, status_code=201)
+def add_item_tag(item_id: int, body: TagAddRequest):
+    """Add a tag to an item."""
+    with get_db() as conn:
+        row = conn.execute("SELECT * FROM items WHERE id = ?", (item_id,)).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail=f"Item {item_id} not found")
+        add_tag(conn, item_id, body.name)
+        return _enrich_item(conn, Item.from_row(row))
+
+
+@router.delete("/{item_id}/tags/{tag_name}", response_model=ItemResponse)
+def remove_item_tag(item_id: int, tag_name: str):
+    """Remove a tag from an item."""
+    with get_db() as conn:
+        row = conn.execute("SELECT * FROM items WHERE id = ?", (item_id,)).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail=f"Item {item_id} not found")
+        remove_tag(conn, item_id, tag_name)
         return _enrich_item(conn, Item.from_row(row))

--- a/packages/lestash-server/tests/test_api.py
+++ b/packages/lestash-server/tests/test_api.py
@@ -426,6 +426,71 @@ class TestVoiceTranscribe:
         assert resp.status_code == 413
 
 
+class TestTags:
+    """Test tag endpoints."""
+
+    def _create_item(self, client):
+        resp = client.post(
+            "/api/items",
+            json={
+                "source_type": "test",
+                "source_id": "tag-test-1",
+                "content": "Tag test item",
+            },
+        )
+        return resp.json()["id"]
+
+    def test_add_tag(self, client):
+        """Should add a tag to an item."""
+        item_id = self._create_item(client)
+        resp = client.post(f"/api/items/{item_id}/tags", json={"name": "important"})
+        assert resp.status_code == 201
+        assert "important" in resp.json()["tags"]
+
+    def test_add_duplicate_tag(self, client):
+        """Adding the same tag twice should be idempotent."""
+        item_id = self._create_item(client)
+        client.post(f"/api/items/{item_id}/tags", json={"name": "dup"})
+        resp = client.post(f"/api/items/{item_id}/tags", json={"name": "dup"})
+        assert resp.status_code == 201
+        assert resp.json()["tags"].count("dup") == 1
+
+    def test_remove_tag(self, client):
+        """Should remove a tag from an item."""
+        item_id = self._create_item(client)
+        client.post(f"/api/items/{item_id}/tags", json={"name": "remove-me"})
+        resp = client.delete(f"/api/items/{item_id}/tags/remove-me")
+        assert resp.status_code == 200
+        assert "remove-me" not in resp.json()["tags"]
+
+    def test_list_tags(self, client):
+        """Should list all tags with counts."""
+        item_id = self._create_item(client)
+        client.post(f"/api/items/{item_id}/tags", json={"name": "alpha"})
+        client.post(f"/api/items/{item_id}/tags", json={"name": "beta"})
+        resp = client.get("/api/items/tags")
+        assert resp.status_code == 200
+        tags = {t["name"]: t["count"] for t in resp.json()["tags"]}
+        assert "alpha" in tags
+        assert "beta" in tags
+
+    def test_filter_by_tag(self, client):
+        """Should filter items by tag."""
+        id1 = self._create_item(client)
+        self._create_item(client)  # untagged
+        client.post(f"/api/items/{id1}/tags", json={"name": "filtered"})
+        resp = client.get("/api/items?tag=filtered")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) >= 1
+        assert all("filtered" in i["tags"] for i in items)
+
+    def test_tag_on_nonexistent_item(self, client):
+        """Should return 404 for missing item."""
+        resp = client.post("/api/items/99999/tags", json={"name": "nope"})
+        assert resp.status_code == 404
+
+
 class TestCORS:
     """Test CORS headers."""
 

--- a/packages/lestash/src/lestash/core/database.py
+++ b/packages/lestash/src/lestash/core/database.py
@@ -415,6 +415,70 @@ def upsert_item(conn: sqlite3.Connection, item: ItemCreate) -> int:
     return item_id
 
 
+def add_tag(conn: sqlite3.Connection, item_id: int, tag_name: str) -> int:
+    """Add a tag to an item. Creates the tag if it doesn't exist.
+
+    Returns:
+        The tag ID.
+    """
+    tag_name = tag_name.strip().lower()
+    conn.execute("INSERT OR IGNORE INTO tags (name) VALUES (?)", (tag_name,))
+    row = conn.execute("SELECT id FROM tags WHERE name = ?", (tag_name,)).fetchone()
+    tag_id = row[0]
+    conn.execute(
+        "INSERT OR IGNORE INTO item_tags (item_id, tag_id) VALUES (?, ?)",
+        (item_id, tag_id),
+    )
+    conn.commit()
+    return tag_id
+
+
+def remove_tag(conn: sqlite3.Connection, item_id: int, tag_name: str) -> bool:
+    """Remove a tag from an item.
+
+    Returns:
+        True if the tag was removed, False if it wasn't present.
+    """
+    tag_name = tag_name.strip().lower()
+    row = conn.execute("SELECT id FROM tags WHERE name = ?", (tag_name,)).fetchone()
+    if not row:
+        return False
+    cursor = conn.execute(
+        "DELETE FROM item_tags WHERE item_id = ? AND tag_id = ?",
+        (item_id, row[0]),
+    )
+    conn.commit()
+    return cursor.rowcount > 0
+
+
+def get_tags(conn: sqlite3.Connection, item_id: int) -> list[str]:
+    """Get all tag names for an item."""
+    rows = conn.execute(
+        """
+        SELECT t.name FROM tags t
+        JOIN item_tags it ON t.id = it.tag_id
+        WHERE it.item_id = ?
+        ORDER BY t.name
+        """,
+        (item_id,),
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def list_tags(conn: sqlite3.Connection) -> list[dict]:
+    """List all tags with their item counts."""
+    rows = conn.execute(
+        """
+        SELECT t.name, COUNT(it.item_id) as count
+        FROM tags t
+        LEFT JOIN item_tags it ON t.id = it.tag_id
+        GROUP BY t.id, t.name
+        ORDER BY count DESC, t.name
+        """,
+    ).fetchall()
+    return [{"name": row[0], "count": row[1]} for row in rows]
+
+
 def get_cache_dir(config: Config | None = None) -> Path:
     """Get the cache directory for storing files like screenshots.
 


### PR DESCRIPTION
## Summary
- **Database**: `add_tag`, `remove_tag`, `get_tags`, `list_tags` helper functions using existing `tags`/`item_tags` tables
- **API**: `POST /api/items/{id}/tags`, `DELETE /api/items/{id}/tags/{name}`, `GET /api/items/tags` (list all with counts), `?tag=X` filter on item list
- **UI**: Tag chips on item cards, inline add/remove in detail view, tag filter dropdown in feed tab
- **Tests**: 6 new tests covering add, remove, list, filter, duplicates, and 404

Closes #61

## Test plan
- [ ] Add a tag to an item via detail view → tag chip appears
- [ ] Remove a tag via × button → chip disappears
- [ ] Tag filter dropdown in feed → shows only tagged items
- [ ] `GET /api/items/tags` returns all tags with counts
- [ ] Duplicate tag add is idempotent
- [ ] `uv run just check` passes (48 tests)