### PR TITLE
feat(app): auto-download Whisper model from within the app

### DIFF
--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -19,6 +19,8 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 anyhow = "1"
 dirs-next = "2"
+reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }
+futures-util = "0.3"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -35,6 +35,11 @@ fn get_stt_status(state: tauri::State<'_, AppState>) -> serde_json::Value {
     })
 }
 
+#[tauri::command]
+async fn download_model(app: tauri::AppHandle) -> Result<String, String> {
+    stt::download_model(app).await.map_err(|e| e.to_string())
+}
+
 pub fn run() {
     tracing_subscriber::fmt::init();
 
@@ -47,6 +52,7 @@ pub fn run() {
             start_recording,
             stop_recording,
             get_stt_status,
+            download_model,
         ])
         .run(tauri::generate_context!())
         .expect("error running lestash");

--- a/app/src-tauri/src/stt.rs
+++ b/app/src-tauri/src/stt.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use futures_util::StreamExt;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -78,6 +79,76 @@ pub fn model_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
         .join("lestash");
     data_dir.join(WHISPER_MODEL)
+}
+
+const MODEL_URL: &str =
+    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin";
+
+pub async fn download_model(app: AppHandle) -> Result<String> {
+    let dest = model_path();
+    if dest.exists() {
+        info!("Model already exists at {}", dest.display());
+        return Ok(dest.display().to_string());
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).context("Failed to create model directory")?;
+    }
+
+    info!("Downloading whisper model to {}", dest.display());
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(MODEL_URL)
+        .send()
+        .await
+        .context("Failed to start model download")?;
+
+    let total = resp.content_length().unwrap_or(0);
+    let mut downloaded: u64 = 0;
+
+    // Download to temp file, then rename
+    let tmp_path = dest.with_extension("bin.tmp");
+    let mut file =
+        tokio::fs::File::create(&tmp_path)
+            .await
+            .context("Failed to create temp file")?;
+
+    let mut stream = resp.bytes_stream();
+    let mut last_emit = Instant::now();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context("Download stream error")?;
+        downloaded += chunk.len() as u64;
+
+        tokio::io::AsyncWriteExt::write_all(&mut file, &chunk)
+            .await
+            .context("Failed to write chunk")?;
+
+        // Emit progress at most every 200ms
+        if last_emit.elapsed() > Duration::from_millis(200) {
+            let _ = app.emit(
+                "model-download-progress",
+                serde_json::json!({ "downloaded": downloaded, "total": total }),
+            );
+            last_emit = Instant::now();
+        }
+    }
+
+    // Final progress emit
+    let _ = app.emit(
+        "model-download-progress",
+        serde_json::json!({ "downloaded": downloaded, "total": total }),
+    );
+
+    // Rename temp to final
+    tokio::fs::rename(&tmp_path, &dest)
+        .await
+        .context("Failed to rename downloaded model")?;
+
+    info!("Model download complete: {}", dest.display());
+    Ok(dest.display().to_string())
 }
 
 fn run_stt_loop(

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -1408,11 +1408,41 @@
       if (IS_TAURI && tauriInvoke) {
         tauriInvoke('get_stt_status').then(status => {
           if (!status.model_exists) {
-            document.getElementById('record-status').innerHTML =
-              '<span style="color:var(--warn)">Whisper model not found. Download ggml-base.en.bin to ' +
-              escHtml(status.model_path) + '</span>';
+            const el = document.getElementById('record-status');
+            el.innerHTML = '<button class="sync-btn" id="download-model-btn" style="font-size:0.75rem">Download Model (~142MB)</button>';
+            document.getElementById('download-model-btn').addEventListener('click', startModelDownload);
           }
         }).catch(() => {});
+      }
+    }
+
+    async function startModelDownload() {
+      const btn = document.getElementById('download-model-btn');
+      const status = document.getElementById('record-status');
+      if (!btn) return;
+      btn.disabled = true;
+      btn.textContent = 'Downloading...';
+
+      // Listen for progress
+      if (tauriListen) {
+        tauriListen('model-download-progress', (event) => {
+          const { downloaded, total } = event.payload;
+          if (total > 0) {
+            const pct = Math.round((downloaded / total) * 100);
+            const mb = (downloaded / 1024 / 1024).toFixed(1);
+            const totalMb = (total / 1024 / 1024).toFixed(0);
+            status.innerHTML = `<span style="font-size:0.75rem">Downloading: ${mb}/${totalMb} MB (${pct}%)</span>`;
+          }
+        });
+      }
+
+      try {
+        await tauriInvoke('download_model');
+        status.innerHTML = '<span style="color:var(--ok);font-size:0.8rem">Model ready — hit Record</span>';
+        showToast('Whisper model downloaded', 'ok');
+      } catch (e) {
+        status.innerHTML = '<span style="color:var(--error);font-size:0.8rem">Download failed: ' + escHtml(e) + '</span>';
+        showToast('Model download failed: ' + e, 'error');
       }
     }
 


### PR DESCRIPTION
## Summary
- When the Whisper model (`ggml-base.en.bin`, ~142MB) is missing, the Notes tab shows a **"Download Model"** button instead of just a path warning
- Downloads from HuggingFace with streaming progress indicator (MB downloaded, percentage)
- Uses `reqwest` with `rustls-tls` (no OpenSSL system dependency)
- Downloads to temp file then renames for atomicity
- No hot-reload needed — model is loaded when the user presses Record

Closes #59

## Test plan
- [ ] Delete model file, open Notes tab → "Download Model" button appears
- [ ] Click Download → progress shows MB/percentage
- [ ] Download completes → "Model ready — hit Record" message
- [ ] Press Record → transcription works
- [ ] Desktop build compiles (`cargo check` passes)
- [ ] Android build unaffected (doesn't use on-device Whisper)