### PR TITLE
feat: Google auth, Takeout import, parent_id, UI redesign

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -105,6 +105,11 @@
       flex: 1; min-width: 200px;
     }
 
+    /* ── Debug mode toggle ── */
+    .debug-only { display: none; }
+    body.debug-mode .debug-only { display: block; }
+    body.debug-mode #debug-toggle { color: var(--accent); }
+
     /* ── Item cards ── */
     .item-list { display: flex; flex-direction: column; gap: 0.5rem; }
     .item-card {
@@ -118,20 +123,23 @@
     .item-card:hover { border-color: var(--accent); }
     .item-card-header {
       display: flex; align-items: center; gap: 0.5rem;
-      margin-bottom: 0.4rem;
+      margin-bottom: 0.3rem;
     }
-    .source-badge {
-      font-size: 0.7rem; padding: 0.15rem 0.4rem;
-      border-radius: 3px; color: #fff; white-space: nowrap;
-      font-weight: bold;
+    .source-dot {
+      width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
     }
-    .source-badge.linkedin { background: var(--src-linkedin); }
-    .source-badge.bluesky { background: var(--src-bluesky); }
-    .source-badge.youtube { background: var(--src-youtube); }
-    .source-badge.arxiv { background: var(--src-arxiv); }
-    .source-badge.microblog { background: var(--src-microblog); }
-    .item-subtype {
-      font-size: 0.75rem; color: var(--muted);
+    .source-dot.linkedin { background: var(--src-linkedin); }
+    .source-dot.bluesky { background: var(--src-bluesky); }
+    .source-dot.youtube { background: var(--src-youtube); }
+    .source-dot.arxiv { background: var(--src-arxiv); }
+    .source-dot.microblog { background: var(--src-microblog); }
+    .source-dot.voice { background: var(--ok); }
+    .source-dot.notebooklm { background: #f9ab00; }
+    .source-dot.gemini { background: #8e44ef; }
+    .source-dot.share { background: var(--muted); }
+    .item-title {
+      font-weight: 600; font-size: 0.9rem; flex: 1;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
     }
     .item-date {
       margin-left: auto; font-size: 0.75rem; color: var(--muted);
@@ -141,6 +149,11 @@
       font-size: 0.85rem; color: var(--text);
       line-height: 1.4;
     }
+    .item-footer {
+      display: flex; gap: 0.75rem; margin-top: 0.3rem;
+      font-size: 0.75rem; color: var(--muted);
+    }
+    .child-count { color: var(--accent); }
     .item-meta {
       display: flex; gap: 1rem; margin-top: 0.3rem;
       font-size: 0.75rem; color: var(--muted);
@@ -164,6 +177,18 @@
       background: var(--bg); color: var(--text);
       border: 1px solid var(--border); border-radius: 4px;
     }
+    /* Legacy source-badge (used in debug mode) */
+    .source-badge {
+      font-size: 0.7rem; padding: 0.15rem 0.4rem;
+      border-radius: 3px; color: #fff; white-space: nowrap;
+      font-weight: bold;
+    }
+    .source-badge.linkedin { background: var(--src-linkedin); }
+    .source-badge.bluesky { background: var(--src-bluesky); }
+    .source-badge.youtube { background: var(--src-youtube); }
+    .source-badge.arxiv { background: var(--src-arxiv); }
+    .source-badge.microblog { background: var(--src-microblog); }
+    .item-subtype { font-size: 0.75rem; color: var(--muted); }
 
     /* ── Item detail (expanded) ── */
     .item-detail {
@@ -173,7 +198,7 @@
       padding: 1rem;
       margin-top: 0.5rem;
       font-size: 0.85rem;
-      line-height: 1.5;
+      line-height: 1.6;
     }
     .item-detail-field {
       margin-bottom: 0.5rem;
@@ -184,7 +209,6 @@
     }
     .item-detail-content {
       white-space: pre-wrap; word-break: break-word;
-      max-height: 400px; overflow-y: auto;
     }
     .item-detail a {
       color: var(--accent); text-decoration: none;
@@ -200,11 +224,30 @@
       overflow-y: auto;
       color: var(--muted);
     }
-
     .item-detail-actions {
       display: flex; gap: 0.5rem; margin-top: 0.75rem;
     }
     .item-detail-actions .sync-btn { font-size: 0.75rem; padding: 0.3rem 0.6rem; }
+
+    /* ── Item detail view (full screen) ── */
+    #item-view { padding: 0.25rem 0; }
+    .item-view-back {
+      display: inline-block; color: var(--accent); background: none; border: none;
+      cursor: pointer; font-size: 0.85rem; padding: 0.4rem 0;
+      font-family: inherit; min-height: 44px;
+    }
+    .item-view-back:hover { text-decoration: underline; }
+    .item-view-title { font-size: 1.1rem; font-weight: bold; margin-bottom: 0.3rem; }
+    .item-view-meta { font-size: 0.8rem; color: var(--muted); margin-bottom: 1rem; }
+    .item-view-content {
+      white-space: pre-wrap; word-break: break-word;
+      line-height: 1.6; font-size: 0.9rem;
+    }
+    .item-view-children { margin-top: 1rem; }
+    .item-view-children-title {
+      font-size: 0.85rem; color: var(--muted);
+      margin-bottom: 0.5rem; font-weight: bold;
+    }
 
     /* ── Single item view ── */
     .single-item-view { padding: 0.5rem 0; }
@@ -528,6 +571,7 @@
     <h1>LeStash</h1>
     <div class="dot" id="dot" title="Server connection"></div>
     <span class="spacer"></span>
+    <button class="gear-btn" id="debug-toggle" title="Toggle debug mode">&#128295;</button>
     <button class="gear-btn" id="settings-btn" title="Settings">&#9881;</button>
   </header>
 
@@ -662,6 +706,11 @@
       </div>
       <h3 style="font-size:0.85rem;color:var(--muted);margin-bottom:0.5rem">API Log</h3>
       <div id="debug-log" style="max-height:60vh;overflow-y:auto;font-size:0.75rem"></div>
+    </div>
+
+    <!-- Item detail view (replaces list when an item is clicked) -->
+    <div id="item-view" style="display:none">
+      <div id="item-view-content"></div>
     </div>
   </main>
 
@@ -945,13 +994,13 @@
     }
 
     /* ── Tabs ── */
-    document.getElementById('tabs').addEventListener('click', e => {
-      if (e.target.tagName !== 'BUTTON') return;
+    function switchTab(tab, skipHistory) {
       document.querySelectorAll('#tabs button').forEach(b => b.classList.remove('active'));
       document.querySelectorAll('.tab-content').forEach(t => t.classList.remove('active'));
-      e.target.classList.add('active');
-      const tab = e.target.dataset.tab;
-      document.getElementById(`tab-${tab}`).classList.add('active');
+      const btn = document.querySelector(`#tabs [data-tab="${tab}"]`);
+      if (btn) btn.classList.add('active');
+      const content = document.getElementById(`tab-${tab}`);
+      if (content) content.classList.add('active');
       if (tab === 'feed' && feedItems.length === 0) loadFeed();
       if (tab === 'recent') loadRecent();
       if (tab === 'search') document.getElementById('search-input').focus();
@@ -959,6 +1008,14 @@
       if (tab === 'sources') loadSources();
       if (tab === 'stats') loadStats();
       if (tab === 'debug') { renderDebugInfo(); renderDebugLog(); }
+      if (!IS_TAURI && !skipHistory) {
+        history.pushState({ tab }, '', '/#' + tab);
+      }
+    }
+
+    document.getElementById('tabs').addEventListener('click', e => {
+      if (e.target.tagName !== 'BUTTON') return;
+      switchTab(e.target.dataset.tab);
     });
 
     /* ── Relative time ── */
@@ -989,54 +1046,111 @@
     function renderCard(item) {
       const card = document.createElement('div');
       card.className = 'item-card';
+      const emoji = item.metadata && item.metadata.emoji ? item.metadata.emoji + ' ' : '';
+      const displayTitle = item.title || item.preview || '(untitled)';
       card.innerHTML = `
         <div class="item-card-header">
-          <span class="source-badge ${sourceClass(item.subtype)}">${sourceName(item.subtype)}</span>
-          <span class="item-subtype">${item.subtype}</span>
+          <span class="source-dot ${sourceClass(item.subtype)}"></span>
+          <span class="item-title">${emoji}${escHtml(displayTitle)}</span>
           <span class="item-date">${relTime(item.created_at)}</span>
         </div>
-        ${item.title ? `<div style="font-size:0.85rem;font-weight:bold;margin:0.25rem 0">${escHtml(item.title)}</div>` : ''}
-        <div class="item-preview">${escHtml(item.preview)}</div>
-        ${item.tags && item.tags.length ? `<div class="item-tags">${item.tags.map(t => `<span class="tag-chip">${escHtml(t)}</span>`).join('')}</div>` : ''}
-        <div class="item-meta">
-          ${item.author_display !== '-' ? `<span>by ${escHtml(item.author_display)}</span>` : ''}
-          ${item.actor_display !== '-' ? `<span>actor: ${escHtml(item.actor_display)}</span>` : ''}
-          ${item.is_own_content ? '<span style="color:var(--ok)">own</span>' : ''}
+        ${item.title && item.preview ? `<div class="item-preview">${escHtml(item.preview)}</div>` : ''}
+        <div class="item-footer">
+          <span>${sourceName(item.subtype)}</span>
+          ${item.child_count ? `<span class="child-count">${item.child_count} children</span>` : ''}
+        </div>
+        <div class="debug-only">
+          <div style="margin-top:0.3rem">
+            <span class="source-badge ${sourceClass(item.subtype)}">${sourceName(item.subtype)}</span>
+            <span class="item-subtype">${item.subtype}</span>
+          </div>
+          <div class="item-meta">
+            ${item.author_display !== '-' ? `<span>by ${escHtml(item.author_display)}</span>` : ''}
+            ${item.actor_display !== '-' ? `<span>actor: ${escHtml(item.actor_display)}</span>` : ''}
+            ${item.is_own_content ? '<span style="color:var(--ok)">own</span>' : ''}
+            <span>id:${item.id}</span>
+          </div>
         </div>
       `;
-      card.addEventListener('click', () => toggleDetail(card, item));
+      card.addEventListener('click', () => openItemView(item));
       return card;
     }
 
-    function toggleDetail(card, item) {
-      const existing = card.querySelector('.item-detail');
-      if (existing) { existing.remove(); return; }
+    /* ── Master-detail navigation ── */
+    const viewStack = [];
 
-      const detail = document.createElement('div');
-      detail.className = 'item-detail';
+    function openItemView(item, skipHistory) {
+      const mainEl = document.querySelector('main');
+      viewStack.push({ scrollY: mainEl.scrollTop, item });
 
-      let html = '';
-      html += `<div class="item-detail-field"><label>ID</label>${item.id}</div>`;
-      html += `<div class="item-detail-field"><label>Type</label>${escHtml(item.subtype)}</div>`;
-      if (item.title) html += `<div class="item-detail-field"><label>Title</label>${escHtml(item.title)}</div>`;
-      if (item.url) html += `<div class="item-detail-field"><label>URL</label><a href="${escHtml(item.url)}" target="_blank" rel="noopener">${escHtml(item.url)}</a></div>`;
-      html += `<div class="item-detail-field"><label>Author</label>${escHtml(item.author_display)}</div>`;
-      if (item.created_at) html += `<div class="item-detail-field"><label>Created</label>${new Date(item.created_at).toLocaleString()}</div>`;
-      html += `<div class="item-detail-field"><label>Content</label><div class="item-detail-content">${escHtml(item.content)}</div></div>`;
+      // Hide tabs and tab content
+      document.querySelector('nav').style.display = 'none';
+      document.querySelectorAll('.tab-content').forEach(t => t.style.display = 'none');
+
+      // Show item view
+      const view = document.getElementById('item-view');
+      view.style.display = 'block';
+      renderItemView(item);
+      mainEl.scrollTop = 0;
+
+      // Push browser history (web only)
+      if (!IS_TAURI && !skipHistory) {
+        history.pushState({ itemId: item.id }, '', '/items/' + item.id);
+      }
+    }
+
+    function closeItemView() {
+      // In browser, let history.back() trigger popstate which handles the DOM update
+      if (!IS_TAURI && viewStack.length > 0) {
+        history.back();
+        return;
+      }
+      _doCloseItemView();
+    }
+
+    function _doCloseItemView() {
+      viewStack.pop();
+      const view = document.getElementById('item-view');
+
+      if (viewStack.length > 0) {
+        // Go back to parent item view
+        renderItemView(viewStack[viewStack.length - 1].item);
+        document.querySelector('main').scrollTop = 0;
+      } else {
+        // Back to list
+        view.style.display = 'none';
+        document.querySelector('nav').style.display = '';
+        document.querySelectorAll('.tab-content').forEach(t => t.style.display = '');
+        const active = document.querySelector('.tab-content.active');
+        if (active) active.style.display = 'block';
+      }
+    }
+
+    function renderItemView(item) {
+      const container = document.getElementById('item-view-content');
+      const emoji = item.metadata && item.metadata.emoji ? item.metadata.emoji + ' ' : '';
+      const dateFmt = item.created_at
+        ? new Date(item.created_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+        : '';
+
+      let html = `<button class="item-view-back" onclick="closeItemView()">&larr; Back</button>`;
+      html += `<div class="item-view-title">${emoji}${escHtml(item.title || item.preview || '(untitled)')}</div>`;
+      html += `<div class="item-view-meta">${sourceName(item.subtype)}${dateFmt ? ' &middot; ' + dateFmt : ''}${item.url ? ' &middot; <a href="' + escHtml(item.url) + '" target="_blank" rel="noopener" style="color:var(--accent)">link</a>' : ''}</div>`;
+      html += `<div class="item-view-content">${escHtml(item.content)}</div>`;
+
       if (item.metadata && item.metadata.processed_text) {
-        html += `<div class="item-detail-field"><label>Processed Note</label><div class="item-detail-content">${escHtml(item.metadata.processed_text)}</div></div>`;
+        html += `<div class="item-detail-field" style="margin-top:0.75rem"><label>Processed Note</label><div class="item-view-content">${escHtml(item.metadata.processed_text)}</div></div>`;
       }
       if (item.source_type === 'voice') {
-        html += `<div style="margin-top:0.5rem"><button class="sync-btn" onclick="event.stopPropagation();openProcessDialog(${item.id})">Process</button></div>`;
+        html += `<div style="margin-top:0.5rem"><button class="sync-btn" onclick="openProcessDialog(${item.id})">Process</button></div>`;
       }
-      if (item.metadata) {
-        html += `<div class="item-detail-field"><label>Metadata</label><div class="item-detail-meta">${escHtml(JSON.stringify(item.metadata, null, 2))}</div></div>`;
-      }
-      // Tags section
+
+      // Tags
+      html += '<hr style="border-color:var(--border);margin:0.75rem 0">';
       const currentTags = (item.tags || []).map(t =>
         `<span class="tag-chip">${escHtml(t)}<span class="tag-remove" data-action="remove-tag" data-tag="${escHtml(t)}" data-id="${item.id}">&times;</span></span>`
       ).join('');
-      html += `<div class="item-detail-field"><label>Tags</label>
+      html += `<div class="item-detail-field">
         <div class="item-tags">${currentTags || '<span style="color:var(--muted);font-size:0.75rem">No tags</span>'}</div>
         <div class="tag-input-row">
           <input type="text" placeholder="Add tag..." data-tag-input="${item.id}">
@@ -1044,27 +1158,49 @@
         </div>
       </div>`;
 
+      // Actions
       html += `<div class="item-detail-actions">
         <button class="sync-btn" data-action="copy" data-id="${item.id}">Copy</button>
         <button class="sync-btn" data-action="copy-link" data-id="${item.id}">Copy Link</button>
       </div>`;
 
-      detail.innerHTML = html;
-      detail.addEventListener('click', async (e) => {
+      // Children placeholder
+      if (item.child_count > 0) {
+        html += `<div class="item-view-children">
+          <div class="item-view-children-title">${item.child_count} items</div>
+          <div class="item-list" id="children-list"><span style="color:var(--muted);font-size:0.8rem">Loading...</span></div>
+        </div>`;
+      }
+
+      // Debug section
+      html += `<div class="debug-only" style="margin-top:0.75rem">
+        <hr style="border-color:var(--border);margin-bottom:0.75rem">
+        <div class="item-detail-field"><label>ID</label>${item.id}</div>
+        <div class="item-detail-field"><label>Source ID</label>${escHtml(item.source_id || '-')}</div>
+        <div class="item-detail-field"><label>Type</label>${escHtml(item.subtype)}</div>
+        <div class="item-detail-field"><label>Author</label>${escHtml(item.author_display)}</div>
+        <div class="item-detail-field"><label>Actor</label>${escHtml(item.actor_display)}</div>
+        <div class="item-detail-field"><label>Fetched</label>${item.fetched_at ? new Date(item.fetched_at).toLocaleString() : '-'}</div>
+        <div class="item-detail-field"><label>Parent ID</label>${item.parent_id || '-'}</div>
+        ${item.metadata ? `<div class="item-detail-field"><label>Metadata</label><div class="item-detail-meta">${escHtml(JSON.stringify(item.metadata, null, 2))}</div></div>` : ''}
+      </div>`;
+
+      container.innerHTML = html;
+
+      // Event delegation for actions
+      container.addEventListener('click', async (e) => {
         const btn = e.target.closest('[data-action]');
         if (!btn) return;
-        e.stopPropagation();
         if (btn.dataset.action === 'copy') copyToClipboard(item.content, 'Copied to clipboard');
         if (btn.dataset.action === 'copy-link') copyToClipboard(`${getApiBase()}/items/${item.id}`, 'Link copied');
         if (btn.dataset.action === 'remove-tag') {
           await api(`/api/items/${btn.dataset.id}/tags/${encodeURIComponent(btn.dataset.tag)}`, { method: 'DELETE' });
           const updated = await api(`/api/items/${btn.dataset.id}`);
           item.tags = updated.tags;
-          card.querySelector('.item-detail').remove();
-          toggleDetail(card, item);
+          renderItemView(item);
         }
         if (btn.dataset.action === 'add-tag') {
-          const input = detail.querySelector(`[data-tag-input="${btn.dataset.id}"]`);
+          const input = container.querySelector(`[data-tag-input="${btn.dataset.id}"]`);
           const name = input.value.trim();
           if (!name) return;
           await api(`/api/items/${btn.dataset.id}/tags`, {
@@ -1072,26 +1208,29 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ name }),
           });
-          input.value = '';
           const updated = await api(`/api/items/${btn.dataset.id}`);
           item.tags = updated.tags;
-          card.querySelector('.item-detail').remove();
-          toggleDetail(card, item);
-          // Also update tag chips in the card
-          const tagsDiv = card.querySelector('.item-tags');
-          if (tagsDiv && !card.querySelector('.item-detail .item-tags') === tagsDiv) {
-            tagsDiv.innerHTML = item.tags.map(t => `<span class="tag-chip">${escHtml(t)}</span>`).join('');
-          }
+          renderItemView(item);
         }
+      }, { once: true });
+
+      // Enter key in tag input
+      container.querySelector(`[data-tag-input="${item.id}"]`)?.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') container.querySelector(`[data-action="add-tag"][data-id="${item.id}"]`).click();
       });
-      // Allow Enter key in tag input
-      detail.querySelector(`[data-tag-input="${item.id}"]`)?.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-          e.stopPropagation();
-          detail.querySelector(`[data-action="add-tag"][data-id="${item.id}"]`).click();
-        }
-      });
-      card.appendChild(detail);
+
+      // Load children
+      if (item.child_count > 0) {
+        api(`/api/items?parent_id=${item.id}&limit=50`).then(data => {
+          const list = document.getElementById('children-list');
+          if (!list) return;
+          list.innerHTML = '';
+          data.items.forEach(child => {
+            const childCard = renderCard(child);
+            list.appendChild(childCard);
+          });
+        }).catch(() => {});
+      }
     }
 
     function escHtml(s) {
@@ -1149,9 +1288,20 @@
 
     function loadMoreFeed() { loadFeed(true); }
 
-    document.getElementById('feed-source').addEventListener('change', () => loadFeed());
+    function pushFilterState() {
+      if (IS_TAURI) return;
+      const source = document.getElementById('feed-source').value;
+      const tag = document.getElementById('feed-tag').value;
+      const params = new URLSearchParams();
+      if (source) params.set('source', source);
+      if (tag) params.set('tag', tag);
+      const qs = params.toString();
+      history.pushState({ filters: true }, '', qs ? '/?' + qs : '/');
+    }
+
+    document.getElementById('feed-source').addEventListener('change', () => { pushFilterState(); loadFeed(); });
     document.getElementById('feed-own').addEventListener('change', () => loadFeed());
-    document.getElementById('feed-tag').addEventListener('change', () => loadFeed());
+    document.getElementById('feed-tag').addEventListener('change', () => { pushFilterState(); loadFeed(); });
 
     /* ── Subtype filters ── */
     const SUBTYPE_STORAGE_KEY = 'lestash-subtype-filters';
@@ -1841,14 +1991,17 @@
     /* ── Populate source filter ── */
     async function populateSourceFilter() {
       try {
-        const sources = await api('/api/sources');
         const sel = document.getElementById('feed-source');
-        sources.forEach(s => {
-          const opt = document.createElement('option');
-          opt.value = s.name;
-          opt.textContent = s.name;
-          sel.appendChild(opt);
-        });
+        // Use stats endpoint to get all source types with counts
+        const stats = await api('/api/stats');
+        if (stats.sources) {
+          Object.entries(stats.sources).sort().forEach(([src, count]) => {
+            const opt = document.createElement('option');
+            opt.value = src;
+            opt.textContent = `${src} (${count})`;
+            sel.appendChild(opt);
+          });
+        }
       } catch {}
     }
 
@@ -1953,42 +2106,66 @@
       const match = window.location.pathname.match(/^\/items\/(\d+)$/);
       if (!match) return false;
       const itemId = match[1];
-      // Hide normal UI, show single item
-      document.querySelector('nav').style.display = 'none';
-      document.querySelectorAll('.tab-content').forEach(t => t.classList.remove('active'));
-      const container = document.createElement('div');
-      container.className = 'single-item-view';
-      container.innerHTML = '<a class="single-item-back" href="/">← Back to LeStash</a><div id="single-item-content">Loading...</div>';
-      document.querySelector('main').appendChild(container);
-      checkHealth().then(() => loadSingleItem(itemId));
+      checkHealth().then(async () => {
+        try {
+          const item = await api(`/api/items/${itemId}?include_children=true`);
+          openItemView(item);
+        } catch (e) {
+          document.querySelector('main').innerHTML = `<div class="empty-state" style="padding:2rem">Item not found: ${escHtml(e.message)}</div>`;
+        }
+      });
       return true;
     }
 
-    async function loadSingleItem(itemId) {
-      const el = document.getElementById('single-item-content');
-      try {
-        const item = await api(`/api/items/${itemId}`);
-        const card = renderCard(item);
-        el.innerHTML = '';
-        el.appendChild(card);
-        // Auto-expand detail
-        toggleDetail(card, item);
-      } catch (e) {
-        el.innerHTML = `<div class="empty-state">Item not found: ${escHtml(e.message)}</div>`;
-      }
-    }
-
     /* ── Init ── */
+    // Debug mode toggle
+    if (localStorage.getItem('lestash-debug-mode') === 'true') document.body.classList.add('debug-mode');
+    document.getElementById('debug-toggle').addEventListener('click', () => {
+      document.body.classList.toggle('debug-mode');
+      localStorage.setItem('lestash-debug-mode', document.body.classList.contains('debug-mode'));
+    });
     document.getElementById('settings-btn').addEventListener('click', openSettings);
     loadAppVersion().then(renderDebugInfo);
     renderDebugInfo();
 
+    // Browser back/forward button support
+    if (!IS_TAURI) {
+      window.addEventListener('popstate', (e) => {
+        if (e.state && e.state.itemId) {
+          api(`/api/items/${e.state.itemId}`).then(item => openItemView(item, true)).catch(() => {});
+        } else if (viewStack.length > 0) {
+          _doCloseItemView();
+        } else if (e.state && e.state.tab) {
+          switchTab(e.state.tab, true);
+        } else {
+          // Restore filter state from URL params
+          applyUrlFilters();
+          loadFeed();
+        }
+      });
+    }
+
+    function applyUrlFilters() {
+      const params = new URLSearchParams(window.location.search);
+      const source = params.get('source') || '';
+      const tag = params.get('tag') || '';
+      document.getElementById('feed-source').value = source;
+      document.getElementById('feed-tag').value = tag;
+    }
+
     if (!checkSingleItemRoute()) {
       // Normal app flow
-      checkHealth().then(() => {
-        populateSourceFilter();
-        populateTagFilter();
-        loadFeed();
+      checkHealth().then(async () => {
+        await populateSourceFilter();
+        await populateTagFilter();
+        if (!IS_TAURI) applyUrlFilters();
+        // Apply tab from URL hash (e.g. /#notes)
+        const hashTab = window.location.hash.replace('#', '');
+        if (hashTab && document.getElementById(`tab-${hashTab}`)) {
+          switchTab(hashTab, true);
+        } else {
+          loadFeed();
+        }
       });
     }
     setInterval(checkHealth, 30000);

--- a/packages/lestash-server/src/lestash_server/models.py
+++ b/packages/lestash-server/src/lestash_server/models.py
@@ -20,12 +20,14 @@ class ItemResponse(BaseModel):
     fetched_at: datetime
     is_own_content: bool = False
     metadata: dict[str, Any] | None = None
+    parent_id: int | None = None
     # Enriched fields
     subtype: str
     author_display: str
     actor_display: str
     preview: str
     tags: list[str] = []
+    child_count: int = 0
 
 
 class ItemListResponse(BaseModel):
@@ -89,6 +91,7 @@ class ItemCreateRequest(BaseModel):
     created_at: datetime | None = None
     is_own_content: bool = True
     metadata: dict[str, Any] | None = None
+    parent_id: int | None = None
 
 
 class ImportResponse(BaseModel):
@@ -99,6 +102,12 @@ class ImportResponse(BaseModel):
     items_added: int
     items_updated: int
     errors: list[str]
+
+
+class DriveImportRequest(BaseModel):
+    """Request to import files from Google Drive."""
+
+    file_ids: list[str]
 
 
 class RefineRequest(BaseModel):

--- a/packages/lestash-server/src/lestash_server/routes/imports.py
+++ b/packages/lestash-server/src/lestash_server/routes/imports.py
@@ -1,5 +1,6 @@
 """File import endpoint."""
 
+import contextlib
 import json
 import logging
 import zipfile
@@ -9,7 +10,7 @@ from io import BytesIO
 from fastapi import APIRouter, HTTPException, UploadFile
 
 from lestash_server.deps import get_db
-from lestash_server.models import ImportResponse
+from lestash_server.models import DriveImportRequest, ImportResponse
 from lestash_server.parsers.json_items import parse_json_items
 
 logger = logging.getLogger(__name__)
@@ -55,53 +56,169 @@ async def import_file(file: UploadFile):
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from None
 
-    # Insert items
-    items_added = 0
-    items_updated = 0
-
     with get_db() as conn:
-        for item in items:
-            try:
-                metadata_json = json.dumps(item.metadata) if item.metadata else None
-                source_id = item.source_id or item.url
-                cursor = conn.execute(
-                    """
-                    INSERT INTO items (
-                        source_type, source_id, url, title, content,
-                        author, created_at, is_own_content, metadata
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(source_type, source_id) DO UPDATE SET
-                        content = excluded.content,
-                        title = excluded.title,
-                        author = excluded.author,
-                        metadata = excluded.metadata
-                    """,
-                    (
-                        item.source_type,
-                        source_id,
-                        item.url,
-                        item.title,
-                        item.content,
-                        item.author,
-                        item.created_at,
-                        item.is_own_content,
-                        metadata_json,
-                    ),
-                )
-                if cursor.rowcount > 0:
-                    items_added += 1
-            except Exception as e:
-                errors.append(f"Failed to import item: {e}")
-
-        conn.commit()
+        items_added, import_errors = _insert_items_with_parents(conn, items)
+        errors.extend(import_errors)
 
     return ImportResponse(
         status="completed",
         source_type=source_type,
         items_added=items_added,
-        items_updated=items_updated,
+        items_updated=0,
         errors=errors,
     )
+
+
+def _upsert_item(conn, item, parent_id=None):
+    """Insert or update a single item. Returns the row ID."""
+    metadata = dict(item.metadata) if item.metadata else {}
+    # Strip internal parent marker before storing
+    metadata.pop("_parent_source_id", None)
+    metadata_json = json.dumps(metadata) if metadata else None
+    source_id = item.source_id or item.url
+    cursor = conn.execute(
+        """
+        INSERT INTO items (
+            source_type, source_id, url, title, content,
+            author, created_at, is_own_content, metadata, parent_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(source_type, source_id) DO UPDATE SET
+            content = excluded.content,
+            title = excluded.title,
+            author = excluded.author,
+            metadata = excluded.metadata,
+            parent_id = excluded.parent_id
+        """,
+        (
+            item.source_type,
+            source_id,
+            item.url,
+            item.title,
+            item.content,
+            item.author,
+            item.created_at,
+            item.is_own_content,
+            metadata_json,
+            parent_id or item.parent_id,
+        ),
+    )
+    # Get the ID (works for both insert and upsert)
+    if cursor.lastrowid:
+        return cursor.lastrowid
+    row = conn.execute(
+        "SELECT id FROM items WHERE source_type = ? AND source_id = ?",
+        (item.source_type, source_id),
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _insert_items_with_parents(conn, items):
+    """Two-pass insert: parents first, then children with resolved parent_id."""
+    parents = []
+    children = []
+    for item in items:
+        if item.metadata and item.metadata.get("_parent_source_id"):
+            children.append(item)
+        else:
+            parents.append(item)
+
+    items_added = 0
+    errors: list[str] = []
+    # Map source_id → DB id for parent resolution
+    parent_id_map: dict[str, int] = {}
+
+    # Pass 1: insert parents
+    for item in parents:
+        try:
+            row_id = _upsert_item(conn, item)
+            if row_id:
+                parent_id_map[item.source_id or ""] = row_id
+                items_added += 1
+        except Exception as e:
+            errors.append(f"Failed to import parent: {e}")
+
+    # Pass 2: insert children with resolved parent_id
+    for item in children:
+        try:
+            parent_source_id = item.metadata["_parent_source_id"]
+            resolved_parent_id = parent_id_map.get(parent_source_id)
+            row_id = _upsert_item(conn, item, parent_id=resolved_parent_id)
+            if row_id:
+                items_added += 1
+        except Exception as e:
+            errors.append(f"Failed to import child: {e}")
+
+    # Also handle items without parent markers (flat items)
+    conn.commit()
+    return items_added, errors
+
+
+@router.post("/api/import/drive", response_model=list[ImportResponse])
+async def import_from_drive(body: DriveImportRequest):
+    """Download files from Google Drive and import them.
+
+    Requires Google auth to be configured via 'lestash google auth'.
+    """
+    from lestash.core.google_auth import download_drive_file, extract_drive_file_id
+
+    results = []
+    for file_id_or_url in body.file_ids:
+        file_id = extract_drive_file_id(file_id_or_url)
+        try:
+            path = download_drive_file(file_id)
+            data = path.read_bytes()
+
+            if path.name.endswith(".zip"):
+                items, source_type = _parse_zip(data)
+            elif path.name.endswith(".json"):
+                items = parse_json_items(data)
+                source_type = "json"
+            else:
+                results.append(
+                    ImportResponse(
+                        status="error",
+                        source_type="unknown",
+                        items_added=0,
+                        items_updated=0,
+                        errors=[f"Unsupported file: {path.name}"],
+                    )
+                )
+                continue
+
+            with get_db() as conn:
+                items_added, import_errors = _insert_items_with_parents(conn, items)
+
+            results.append(
+                ImportResponse(
+                    status="completed",
+                    source_type=source_type,
+                    items_added=items_added,
+                    items_updated=0,
+                    errors=import_errors,
+                )
+            )
+        except ValueError as e:
+            results.append(
+                ImportResponse(
+                    status="error",
+                    source_type="unknown",
+                    items_added=0,
+                    items_updated=0,
+                    errors=[str(e)],
+                )
+            )
+        except Exception as e:
+            results.append(
+                ImportResponse(
+                    status="error",
+                    source_type="unknown",
+                    items_added=0,
+                    items_updated=0,
+                    errors=[f"Drive download failed for {file_id}: {e}"],
+                )
+            )
+
+    return results
 
 
 def _parse_zip(data: bytes):
@@ -117,10 +234,29 @@ def _parse_zip(data: bytes):
             if keep_files:
                 return _parse_google_keep_zip(zf, keep_files), "google-keep"
 
-            # Detect Gemini Takeout
-            gemini_files = [n for n in names if "Gemini" in n and n.endswith(".json")]
-            if gemini_files:
-                return _parse_gemini_zip(zf, gemini_files), "gemini"
+            # Detect Google Takeout with Gemini and/or NotebookLM
+            gemini_convos = [
+                n
+                for n in names
+                if ("Gemini" in n)
+                and (n.endswith(".txt") or n.endswith(".json"))
+                and "Conversation" in n
+                and not n.endswith("/")
+            ]
+            nlm_files = [n for n in names if "NotebookLM" in n and not n.endswith("/")]
+
+            if gemini_convos or nlm_files:
+                all_items = []
+                if gemini_convos:
+                    all_items.extend(_parse_gemini_zip(zf, gemini_convos))
+                if nlm_files:
+                    all_items.extend(_parse_notebooklm_zip(zf, nlm_files, names))
+                source_type = "takeout"
+                if gemini_convos and not nlm_files:
+                    source_type = "gemini"
+                elif nlm_files and not gemini_convos:
+                    source_type = "notebooklm"
+                return all_items, source_type
 
             # Try generic JSON files in zip
             json_files = [n for n in names if n.endswith(".json")]
@@ -200,8 +336,232 @@ def _parse_google_keep_zip(zf, keep_files):
 
 
 def _parse_gemini_zip(zf, gemini_files):
-    """Parse Gemini conversations from a Google Takeout ZIP (stub)."""
-    raise ValueError(
-        "Gemini Takeout import is not yet implemented. "
-        "Please export as JSON manually or check issue #33."
-    )
+    """Parse Gemini conversations from a Google Takeout ZIP.
+
+    Gemini Takeout exports conversations as .txt files containing JSON with
+    'conversation_turns' array of user_turn/system_turn pairs.
+    """
+    from datetime import datetime
+
+    from lestash.models.item import ItemCreate
+
+    items = []
+    for name in gemini_files:
+        try:
+            raw = zf.read(name).decode("utf-8")
+            data = json.loads(raw)
+            turns = data.get("conversation_turns", [])
+            if not turns:
+                continue
+
+            parts = []
+            first_prompt = ""
+            earliest_ts = None
+
+            for turn in turns:
+                if "user_turn" in turn:
+                    ut = turn["user_turn"]
+                    prompt = ut.get("prompt", "")
+                    if prompt:
+                        parts.append(f"**User:** {prompt}")
+                        if not first_prompt:
+                            first_prompt = prompt
+                    ts = ut.get("turn_last_modified")
+                    if ts and not earliest_ts:
+                        earliest_ts = ts
+
+                if "system_turn" in turn:
+                    st = turn["system_turn"]
+                    text_parts = st.get("text", [])
+                    text = "\n".join(t.get("data", "") for t in text_parts if isinstance(t, dict))
+                    if text:
+                        parts.append(f"**Gemini:** {text}")
+
+            if not parts:
+                continue
+
+            created_at = None
+            if earliest_ts:
+                with contextlib.suppress(ValueError, OSError):
+                    created_at = datetime.fromisoformat(str(earliest_ts).replace("Z", "+00:00"))
+
+            title = first_prompt[:80] + ("..." if len(first_prompt) > 80 else "")
+
+            items.append(
+                ItemCreate(
+                    source_type="gemini",
+                    source_id=name,
+                    title=title or None,
+                    content="\n\n".join(parts),
+                    created_at=created_at,
+                    is_own_content=True,
+                    metadata={"source": "takeout", "turn_count": len(turns)},
+                )
+            )
+        except Exception:
+            logger.warning(f"Failed to parse Gemini file: {name}", exc_info=True)
+            continue
+
+    return items
+
+
+def _parse_notebooklm_zip(zf, nlm_files, all_names):
+    """Parse NotebookLM notebooks from a Google Takeout ZIP.
+
+    Structure: NotebookLM/<notebook-title>/
+      - <notebook-title>.json (title, emoji, metadata)
+      - Notes/*.html (generated notes)
+      - Chat History/*.html (chat sessions)
+      - Sources/*.html (source content)
+      - Sources/*metadata.json (source metadata)
+    """
+    import re
+    from datetime import datetime
+
+    from lestash.models.item import ItemCreate
+
+    # Discover notebook directories
+    nb_dirs: set[str] = set()
+    for name in nlm_files:
+        match = re.match(r"(Takeout/NotebookLM/[^/]+)/", name)
+        if match:
+            nb_dirs.add(match.group(1))
+
+    items = []
+    for nb_dir in sorted(nb_dirs):
+        try:
+            nb_name = nb_dir.rsplit("/", 1)[-1]
+
+            # Find metadata JSON (not from Sources/Notes/Chat/Artifacts)
+            meta_data: dict = {}
+            meta_candidates = [
+                n
+                for n in all_names
+                if n.startswith(f"{nb_dir}/")
+                and n.endswith(".json")
+                and "/Sources/" not in n
+                and "/Notes/" not in n
+                and "/Chat History/" not in n
+                and "/Artifacts/" not in n
+            ]
+            for m in meta_candidates:
+                try:
+                    meta_data = json.loads(zf.read(m))
+                    break
+                except (json.JSONDecodeError, KeyError):
+                    continue
+
+            title = meta_data.get("title", nb_name)
+            metadata_inner = meta_data.get("metadata", {})
+
+            # Collect content HTML files
+            note_htmls = sorted(
+                n for n in all_names if n.startswith(f"{nb_dir}/Notes/") and n.endswith(".html")
+            )
+            chat_htmls = sorted(
+                n
+                for n in all_names
+                if n.startswith(f"{nb_dir}/Chat History/") and n.endswith(".html")
+            )
+            source_metas = [
+                n for n in all_names if n.startswith(f"{nb_dir}/Sources/") and n.endswith(".json")
+            ]
+
+            if not note_htmls and not chat_htmls:
+                continue
+
+            created_at = None
+            create_time = metadata_inner.get("createTime", "")
+            if create_time:
+                with contextlib.suppress(ValueError, OSError):
+                    created_at = datetime.fromisoformat(str(create_time).replace("Z", "+00:00"))
+
+            source_titles = []
+            for sm in source_metas:
+                try:
+                    sd = json.loads(zf.read(sm))
+                    if sd.get("title"):
+                        source_titles.append(sd["title"])
+                except Exception:
+                    continue
+
+            # Parent item: notebook overview
+            parent_metadata: dict[str, object] = {
+                "source": "takeout",
+                "note_count": len(note_htmls),
+                "chat_count": len(chat_htmls),
+            }
+            if meta_data.get("emoji"):
+                parent_metadata["emoji"] = meta_data["emoji"]
+            if source_titles:
+                parent_metadata["sources"] = source_titles
+                parent_metadata["source_count"] = len(source_titles)
+
+            summary_parts = [f"# {title}"]
+            if source_titles:
+                summary_parts.append(
+                    f"**Sources ({len(source_titles)}):** " + ", ".join(source_titles)
+                )
+            summary_parts.append(f"**Notes:** {len(note_htmls)} | **Chats:** {len(chat_htmls)}")
+
+            items.append(
+                ItemCreate(
+                    source_type="notebooklm",
+                    source_id=nb_dir,
+                    title=title,
+                    content="\n\n".join(summary_parts),
+                    created_at=created_at,
+                    is_own_content=True,
+                    metadata=parent_metadata,
+                )
+            )
+
+            # Child items: individual notes
+            for nh in note_htmls:
+                note_name = nh.rsplit("/", 1)[-1].replace(".html", "")
+                html = zf.read(nh).decode("utf-8", errors="replace")
+                text = re.sub(r"<[^>]+>", "", html).strip()
+                if text:
+                    items.append(
+                        ItemCreate(
+                            source_type="notebooklm",
+                            source_id=nh,
+                            title=f"{title} — {note_name}",
+                            content=text,
+                            created_at=created_at,
+                            is_own_content=True,
+                            metadata={
+                                "source": "takeout",
+                                "type": "note",
+                                "_parent_source_id": nb_dir,
+                            },
+                        )
+                    )
+
+            # Child items: individual chat sessions
+            for ch in chat_htmls:
+                chat_name = ch.rsplit("/", 1)[-1].replace(".html", "")
+                html = zf.read(ch).decode("utf-8", errors="replace")
+                text = re.sub(r"<[^>]+>", "", html).strip()
+                if text:
+                    text = text.replace("MODEL:", "**Gemini:**")
+                    items.append(
+                        ItemCreate(
+                            source_type="notebooklm",
+                            source_id=ch,
+                            title=f"{title} — {chat_name}",
+                            content=text,
+                            created_at=created_at,
+                            is_own_content=True,
+                            metadata={
+                                "source": "takeout",
+                                "type": "chat",
+                                "_parent_source_id": nb_dir,
+                            },
+                        )
+                    )
+        except Exception:
+            logger.warning(f"Failed to parse NotebookLM notebook: {nb_dir}", exc_info=True)
+            continue
+
+    return items

--- a/packages/lestash-server/src/lestash_server/routes/items.py
+++ b/packages/lestash-server/src/lestash_server/routes/items.py
@@ -22,6 +22,9 @@ router = APIRouter(prefix="/api/items", tags=["items"])
 def _enrich_item(conn, item: Item) -> ItemResponse:
     """Convert an Item to an enriched API response."""
     author_display, actor_display = get_author_actor(conn, item)
+    child_count = conn.execute(
+        "SELECT COUNT(*) FROM items WHERE parent_id = ?", (item.id,)
+    ).fetchone()[0]
     return ItemResponse(
         id=item.id,
         source_type=item.source_type,
@@ -34,11 +37,13 @@ def _enrich_item(conn, item: Item) -> ItemResponse:
         fetched_at=item.fetched_at,
         is_own_content=item.is_own_content,
         metadata=item.metadata,
+        parent_id=item.parent_id,
         subtype=get_item_subtype(item),
         author_display=author_display,
         actor_display=actor_display,
         preview=get_preview(conn, item, max_length=120),
         tags=get_tags(conn, item.id),
+        child_count=child_count,
     )
 
 
@@ -56,6 +61,8 @@ def list_items(
     ),
     since: str | None = Query(None, description="Only items fetched since this ISO datetime"),
     tag: str | None = Query(None, description="Filter by tag name"),
+    parent_id: int | None = Query(None, description="Filter to children of this parent item"),
+    include_children: bool = Query(False, description="Include items that have a parent"),
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ):
@@ -64,6 +71,14 @@ def list_items(
         count_query = "SELECT COUNT(*) FROM items WHERE 1=1"
         query = "SELECT * FROM items WHERE 1=1"
         params: list = []
+
+        if parent_id is not None:
+            query += " AND parent_id = ?"
+            count_query += " AND parent_id = ?"
+            params.append(parent_id)
+        elif not include_children:
+            query += " AND parent_id IS NULL"
+            count_query += " AND parent_id IS NULL"
 
         if tag:
             query = (
@@ -164,13 +179,14 @@ def create_item(body: ItemCreateRequest):
             """
             INSERT INTO items (
                 source_type, source_id, url, title, content,
-                author, created_at, is_own_content, metadata
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                author, created_at, is_own_content, metadata, parent_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(source_type, source_id) DO UPDATE SET
                 content = excluded.content,
                 title = excluded.title,
                 author = excluded.author,
-                metadata = excluded.metadata
+                metadata = excluded.metadata,
+                parent_id = excluded.parent_id
             """,
             (
                 body.source_type,
@@ -182,6 +198,7 @@ def create_item(body: ItemCreateRequest):
                 body.created_at,
                 body.is_own_content,
                 metadata_json,
+                body.parent_id,
             ),
         )
         conn.commit()

--- a/packages/lestash/pyproject.toml
+++ b/packages/lestash/pyproject.toml
@@ -10,6 +10,9 @@ dependencies = [
     "pydantic-settings>=2.1.0",
     "rich>=13.7.0",
     "toml>=0.10.2",
+    "google-api-python-client>=2.0.0",
+    "google-auth-oauthlib>=1.0.0",
+    "google-auth-httplib2>=0.2.0",
 ]
 
 [project.scripts]

--- a/packages/lestash/src/lestash/cli/google.py
+++ b/packages/lestash/src/lestash/cli/google.py
@@ -1,0 +1,97 @@
+"""Google integration CLI commands — auth, doctor, and Drive download."""
+
+import typer
+from rich.console import Console
+
+app = typer.Typer(help="Google account integration (Drive, Docs).", no_args_is_help=True)
+console = Console()
+
+
+@app.command()
+def auth(
+    headless: bool = typer.Option(False, "--headless", help="Force console-based auth (for SSH)"),
+) -> None:
+    """Authenticate with Google (opens browser or prints URL for SSH)."""
+    from lestash.core.google_auth import is_headless, run_auth_flow
+
+    use_headless = headless or is_headless()
+    if use_headless:
+        console.print("[dim]SSH detected — using console auth flow.[/dim]")
+        console.print("[dim]A URL will be printed. Open it in your local browser,[/dim]")
+        console.print("[dim]authorize, then paste the code back here.[/dim]\n")
+
+    try:
+        credentials = run_auth_flow(headless=use_headless)
+        console.print("\n[green]✓[/green] Authenticated successfully.")
+        if credentials.scopes:
+            console.print(f"  Scopes: {', '.join(credentials.scopes)}")
+    except FileNotFoundError as e:
+        console.print(f"[red]✗[/red] {e}")
+        raise typer.Exit(1) from None
+    except Exception as e:
+        console.print(f"[red]✗[/red] Auth failed: {e}")
+        raise typer.Exit(1) from None
+
+
+@app.command()
+def doctor() -> None:
+    """Check Google auth status."""
+    from lestash.core.google_auth import (
+        check_auth_status,
+        get_client_secrets_path,
+        get_credentials_path,
+    )
+
+    status = check_auth_status()
+
+    console.print("[bold]Google Auth Status[/bold]\n")
+
+    if status["client_secrets_exists"]:
+        console.print(f"  [green]✓[/green] Client secrets: {get_client_secrets_path()}")
+    else:
+        console.print(f"  [red]✗[/red] Client secrets missing: {get_client_secrets_path()}")
+        console.print("    Download from https://console.cloud.google.com/apis/credentials")
+        return
+
+    if status["credentials_exists"]:
+        console.print(f"  [green]✓[/green] Credentials: {get_credentials_path()}")
+    else:
+        console.print("  [yellow]○[/yellow] No credentials — run 'lestash google auth'")
+        return
+
+    if status["authenticated"]:
+        console.print("  [green]✓[/green] Authenticated")
+        scopes = status.get("scopes", [])
+        if scopes:
+            for scope in scopes:
+                console.print(f"    • {scope}")
+    else:
+        console.print("  [red]✗[/red] Not authenticated — run 'lestash google auth'")
+        if status.get("refresh_error"):
+            console.print(f"    Refresh error: {status['refresh_error']}")
+
+
+@app.command()
+def download(
+    url: str = typer.Argument(help="Google Drive URL or file ID"),
+    output: str = typer.Option(None, "--output", "-o", help="Output directory"),
+) -> None:
+    """Download a file from Google Drive."""
+    from pathlib import Path
+
+    from lestash.core.google_auth import download_drive_file, extract_drive_file_id
+
+    file_id = extract_drive_file_id(url)
+    console.print(f"Downloading file [dim]{file_id}[/dim]...")
+
+    try:
+        output_dir = Path(output) if output else None
+        path = download_drive_file(file_id, output_dir)
+        console.print(f"[green]✓[/green] Saved to {path}")
+        console.print(f"  Size: {path.stat().st_size / 1024 / 1024:.1f} MB")
+    except ValueError as e:
+        console.print(f"[red]✗[/red] {e}")
+        raise typer.Exit(1) from None
+    except Exception as e:
+        console.print(f"[red]✗[/red] Download failed: {e}")
+        raise typer.Exit(1) from None

--- a/packages/lestash/src/lestash/cli/main.py
+++ b/packages/lestash/src/lestash/cli/main.py
@@ -3,7 +3,7 @@
 import typer
 
 from lestash import __version__
-from lestash.cli import config, items, profiles, sources
+from lestash.cli import config, google, items, profiles, sources
 from lestash.core.database import init_database
 from lestash.core.logging import get_console, get_logger, setup_logging
 from lestash.plugins.loader import load_plugins
@@ -21,6 +21,7 @@ app.add_typer(items.app, name="items")
 app.add_typer(sources.app, name="sources")
 app.add_typer(config.app, name="config")
 app.add_typer(profiles.app, name="profiles")
+app.add_typer(google.app, name="google")
 
 
 def register_plugin_commands() -> None:

--- a/packages/lestash/src/lestash/core/database.py
+++ b/packages/lestash/src/lestash/core/database.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Current schema version - increment when adding migrations
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 # Base schema (version 0) - applied to new databases
 SCHEMA = """
@@ -209,6 +209,17 @@ MIGRATIONS = [
         ALTER TABLE post_cache ADD COLUMN reactor_name TEXT;
         """,
     ),
+    (
+        5,
+        "Add parent_id column to items for parent-child relationships",
+        # Note: no IF NOT EXISTS for ALTER TABLE ADD COLUMN in SQLite,
+        # so we check via PRAGMA before altering. Using executescript
+        # doesn't support conditionals, so this is handled specially
+        # in apply_migrations().
+        """
+        CREATE INDEX IF NOT EXISTS idx_items_parent ON items(parent_id);
+        """,
+    ),
 ]
 
 
@@ -230,6 +241,12 @@ def set_schema_version(conn: sqlite3.Connection, version: int) -> None:
     conn.execute(f"PRAGMA user_version = {version}")
 
 
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    """Check if a column exists in a table."""
+    cursor = conn.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cursor.fetchall())
+
+
 def apply_migrations(conn: sqlite3.Connection) -> int:
     """Apply any pending migrations.
 
@@ -242,6 +259,10 @@ def apply_migrations(conn: sqlite3.Connection) -> int:
     for version, description, sql in MIGRATIONS:
         if version > current_version:
             logger.info(f"Applying migration {version}: {description}")
+            # Migration 5: add parent_id column (needs special handling
+            # because ALTER TABLE ADD COLUMN has no IF NOT EXISTS in SQLite)
+            if version == 5 and not _column_exists(conn, "items", "parent_id"):
+                conn.execute("ALTER TABLE items ADD COLUMN parent_id INTEGER")
             conn.executescript(sql)
             set_schema_version(conn, version)
             conn.commit()

--- a/packages/lestash/src/lestash/core/google_auth.py
+++ b/packages/lestash/src/lestash/core/google_auth.py
@@ -1,0 +1,228 @@
+"""Shared Google OAuth 2.0 module for Drive, Docs, and other Google APIs.
+
+Supports headless (SSH) environments via console-based auth flow.
+Credentials are shared across all Google integrations.
+"""
+
+import json
+import os
+import re
+from pathlib import Path
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+# Default scopes — callers can request additional scopes
+DEFAULT_SCOPES = [
+    "https://www.googleapis.com/auth/drive.readonly",
+]
+
+CREDENTIALS_FILE = "google_credentials.json"
+CLIENT_SECRETS_FILE = "google_client_secrets.json"
+
+
+def get_config_dir() -> Path:
+    """Get lestash config directory."""
+    config_dir = Path.home() / ".config" / "lestash"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir
+
+
+def get_client_secrets_path() -> Path:
+    return get_config_dir() / CLIENT_SECRETS_FILE
+
+
+def get_credentials_path() -> Path:
+    return get_config_dir() / CREDENTIALS_FILE
+
+
+def is_headless() -> bool:
+    """Detect if running in a headless/SSH environment."""
+    return bool(os.environ.get("SSH_TTY") or os.environ.get("SSH_CLIENT"))
+
+
+def save_credentials(credentials: Credentials, scopes: list[str] | None = None) -> None:
+    """Save OAuth credentials to config file."""
+    creds_data = {
+        "token": credentials.token,
+        "refresh_token": credentials.refresh_token,
+        "token_uri": credentials.token_uri,
+        "client_id": credentials.client_id,
+        "client_secret": credentials.client_secret,
+        "scopes": list(credentials.scopes) if credentials.scopes else (scopes or DEFAULT_SCOPES),
+    }
+    path = get_credentials_path()
+    path.write_text(json.dumps(creds_data, indent=2))
+    path.chmod(0o600)
+
+
+def load_credentials() -> Credentials | None:
+    """Load OAuth credentials from config file."""
+    path = get_credentials_path()
+    if not path.exists():
+        return None
+
+    try:
+        creds_data = json.loads(path.read_text())
+        return Credentials(
+            token=creds_data.get("token"),
+            refresh_token=creds_data.get("refresh_token"),
+            token_uri=creds_data.get("token_uri"),
+            client_id=creds_data.get("client_id"),
+            client_secret=creds_data.get("client_secret"),
+            scopes=creds_data.get("scopes", DEFAULT_SCOPES),
+        )
+    except (json.JSONDecodeError, OSError, KeyError):
+        return None
+
+
+def run_auth_flow(
+    scopes: list[str] | None = None,
+    headless: bool | None = None,
+) -> Credentials:
+    """Run OAuth 2.0 flow to get user credentials.
+
+    Args:
+        scopes: OAuth scopes to request. Defaults to DEFAULT_SCOPES.
+        headless: Force headless (console) mode. Auto-detected if None.
+
+    Returns:
+        Authenticated credentials.
+    """
+    secrets_path = get_client_secrets_path()
+    if not secrets_path.exists():
+        msg = (
+            f"Client secrets file not found at {secrets_path}.\n"
+            "Download it from Google Cloud Console:\n"
+            "1. Go to https://console.cloud.google.com/apis/credentials\n"
+            "2. Create OAuth 2.0 Client ID (Desktop application)\n"
+            "3. Download the JSON and save it as:\n"
+            f"   {secrets_path}"
+        )
+        raise FileNotFoundError(msg)
+
+    effective_scopes = scopes or DEFAULT_SCOPES
+    flow = InstalledAppFlow.from_client_secrets_file(str(secrets_path), effective_scopes)
+
+    use_headless = headless if headless is not None else is_headless()
+    credentials = _run_manual_flow(flow) if use_headless else flow.run_local_server(port=0)
+
+    save_credentials(credentials, effective_scopes)
+    return credentials
+
+
+def _run_manual_flow(flow: InstalledAppFlow) -> Credentials:
+    """Manual OAuth flow for headless/SSH environments.
+
+    Prints a URL for the user to visit, then accepts the authorization code.
+    """
+    flow.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
+    auth_url, _ = flow.authorization_url(prompt="consent")
+
+    print(f"Visit this URL to authorize:\n\n  {auth_url}\n")
+    code = input("Enter the authorization code: ").strip()
+
+    flow.fetch_token(code=code)
+    return flow.credentials
+
+
+def get_credentials(scopes: list[str] | None = None) -> Credentials:
+    """Get valid OAuth credentials, refreshing if necessary.
+
+    Returns:
+        Valid credentials.
+
+    Raises:
+        ValueError: If no credentials available.
+    """
+    credentials = load_credentials()
+
+    if credentials and credentials.valid:
+        return credentials
+
+    if credentials and credentials.expired and credentials.refresh_token:
+        try:
+            credentials.refresh(Request())
+            save_credentials(credentials, scopes)
+            return credentials
+        except Exception:
+            pass
+
+    raise ValueError("No valid Google credentials. Run 'lestash google auth' to authenticate.")
+
+
+def check_auth_status() -> dict:
+    """Check Google auth status. Returns a status dict."""
+    result: dict[str, object] = {
+        "client_secrets_exists": get_client_secrets_path().exists(),
+        "credentials_exists": get_credentials_path().exists(),
+        "authenticated": False,
+        "scopes": [],
+    }
+
+    credentials = load_credentials()
+    if credentials:
+        result["scopes"] = list(credentials.scopes) if credentials.scopes else []
+        if credentials.valid:
+            result["authenticated"] = True
+        elif credentials.expired and credentials.refresh_token:
+            try:
+                credentials.refresh(Request())
+                save_credentials(credentials)
+                result["authenticated"] = True
+            except Exception as e:
+                result["refresh_error"] = str(e)
+
+    return result
+
+
+def extract_drive_file_id(url_or_id: str) -> str:
+    """Extract Google Drive file ID from a URL or return as-is if already an ID."""
+    # Match /d/<id>/ or /file/d/<id>/
+    match = re.search(r"/d/([a-zA-Z0-9_-]+)", url_or_id)
+    if match:
+        return match.group(1)
+    # Match id= parameter
+    match = re.search(r"[?&]id=([a-zA-Z0-9_-]+)", url_or_id)
+    if match:
+        return match.group(1)
+    # Assume it's already a file ID
+    return url_or_id
+
+
+def download_drive_file(file_id: str, output_dir: Path | None = None) -> Path:
+    """Download a file from Google Drive.
+
+    Args:
+        file_id: Google Drive file ID.
+        output_dir: Directory to save the file. Defaults to cache dir.
+
+    Returns:
+        Path to the downloaded file.
+    """
+    from googleapiclient.discovery import build
+    from googleapiclient.http import MediaIoBaseDownload
+
+    credentials = get_credentials()
+    service = build("drive", "v3", credentials=credentials)
+
+    # Get file metadata
+    file_meta = service.files().get(fileId=file_id, fields="name,size,mimeType").execute()
+    file_name = file_meta["name"]
+
+    # Prepare output path
+    if output_dir is None:
+        output_dir = get_config_dir() / "cache"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / file_name
+
+    # Download
+    request = service.files().get_media(fileId=file_id)
+    with open(output_path, "wb") as f:
+        downloader = MediaIoBaseDownload(f, request)
+        done = False
+        while not done:
+            _, done = downloader.next_chunk()
+
+    return output_path

--- a/packages/lestash/src/lestash/models/item.py
+++ b/packages/lestash/src/lestash/models/item.py
@@ -18,6 +18,7 @@ class ItemCreate(BaseModel):
     created_at: datetime | None = None
     is_own_content: bool = False
     metadata: dict[str, Any] | None = None
+    parent_id: int | None = None
 
 
 class Item(BaseModel):
@@ -34,6 +35,7 @@ class Item(BaseModel):
     fetched_at: datetime
     is_own_content: bool = False
     metadata: dict[str, Any] | None = None
+    parent_id: int | None = None
 
     @classmethod
     def from_row(cls, row: Any) -> "Item":

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ members = [
     "lestash-linkedin",
     "lestash-microblog",
     "lestash-server",
+    "lestash-voice",
     "lestash-youtube",
 ]
 
@@ -91,6 +92,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bb/9b/b1661026ff24bc641b76b78c5222d614776b0c085bcfdac9bd15a1cb4b35/authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e", size = 164894, upload-time = "2025-12-12T08:01:41.464Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/51/321e821856452f7386c4e9df866f196720b1ad0c5ea1623ea7399969ae3b/authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd", size = 244005, upload-time = "2025-12-12T08:01:40.209Z" },
+]
+
+[[package]]
+name = "av"
+version = "17.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/eb/abca886df3a091bc406feb5ff71b4c4f426beaae6b71b9697264ce8c7211/av-17.0.0.tar.gz", hash = "sha256:c53685df73775a8763c375c7b2d62a6cb149d992a26a4b098204da42ade8c3df", size = 4410769, upload-time = "2026-03-14T14:38:45.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/fb/55e3b5b5d1fc61466292f26fbcbabafa2642f378dc48875f8f554591e1a4/av-17.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ed4013fac77c309a4a68141dcf6148f1821bb1073a36d4289379762a6372f711", size = 23238424, upload-time = "2026-03-14T14:38:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/52/03/9ace1acc08bc9ae38c14bf3a4b1360e995e4d999d1d33c2cbd7c9e77582a/av-17.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:e44b6c83e9f3be9f79ee87d0b77a27cea9a9cd67bd630362c86b7e56a748dfbb", size = 18709043, upload-time = "2026-03-14T14:38:08.288Z" },
+    { url = "https://files.pythonhosted.org/packages/00/c0/637721f3cd5bb8bd16105a1a08efd781fc12f449931bdb3a4d0cfd63fa55/av-17.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b440da6ac47da0629d509316f24bcd858f33158dbdd0f1b7293d71e99beb26de", size = 34018780, upload-time = "2026-03-14T14:38:10.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/d19bc3257dd985d55337d7f0414c019414b97e16cd3690ebf9941a847543/av-17.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1060cba85f97f4a337311169d92c0b5e143452cfa5ca0e65fa499d7955e8592e", size = 36358757, upload-time = "2026-03-14T14:38:13.092Z" },
+    { url = "https://files.pythonhosted.org/packages/52/6c/a1f4f2677bae6f2ade7a8a18e90ebdcf70690c9b1c4e40e118aa30fa313f/av-17.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:deda202e6021cfc7ba3e816897760ec5431309d59a4da1f75df3c0e9413d71e7", size = 35195281, upload-time = "2026-03-14T14:38:15.789Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ea/52b0fc6f69432c7bf3f5fbe6f707113650aa40a1a05b9096ffc2bba4f77d/av-17.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ffaf266a1a9c2148072de0a4b5ae98061465178d2cfaa69ee089761149342974", size = 37444817, upload-time = "2026-03-14T14:38:18.563Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ad/d2172966282cb8f146c13b6be7416efefde74186460c5e1708ddfc13dba6/av-17.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:45a35a40b2875bf2f98de7c952d74d960f92f319734e6d28e03b4c62a49e6f49", size = 28888553, upload-time = "2026-03-14T14:38:21.223Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/bb/c5a4c4172c514d631fb506e6366b503576b8c7f29809cf42aca73e28ff01/av-17.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:3d32e9b5c5bbcb872a0b6917b352a1db8a42142237826c9b49a36d5dbd9e9c26", size = 21916910, upload-time = "2026-03-14T14:38:23.706Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8e/c40ac08e63f79387c59f6ecc38f47d4c942b549130eee579ec1a91f6a291/av-17.0.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:d13250fb4b4522e9a6bec32da082556d5f257110ea223758151375748d9bbe25", size = 23483029, upload-time = "2026-03-14T14:38:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/fb/b4419494bfc249163ec393c613966d66db7e95c76da3345711cd115a79df/av-17.0.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:dbb56aa3b7ae72451d1bf6e9d37c7d83d39b97af712f73583ff419fbf08fc237", size = 18920446, upload-time = "2026-03-14T14:38:27.905Z" },
+    { url = "https://files.pythonhosted.org/packages/30/62/c2306d91602ddad2c56106f21dcb334fd51d5ea2e952f7fa025bb8aa39fc/av-17.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a213ac9e83b7ab12c2e9f277a09cac8e9d85cf0883efdab7a87a60e2e4e48879", size = 37477266, upload-time = "2026-03-14T14:38:30.404Z" },
+    { url = "https://files.pythonhosted.org/packages/28/cd/c8510a9607886785c0b3ca019d503e888c3757529be42a7287fe2bfa92d5/av-17.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:e15c88bb0921f9435bcc5a27a0863dba571a80ad5e1389c4fcf2073833bb4a74", size = 39572988, upload-time = "2026-03-14T14:38:32.984Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/2d/207d9361e25b5abec9be335bbab4df6b6b838e2214be4b374f4cfb285427/av-17.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:096cfd1e9fc896506726c7c42aaf9b370e78c2f257cde4d6ddb6c889bfcc49ec", size = 38399591, upload-time = "2026-03-14T14:38:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ca/307740c6aa2980966bf11383ffcb04bacc5b13f3d268ab4cfb274ad6f793/av-17.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3649ab3d2c7f58049ded1a36e100c0d8fd529cf258f41dd88678ba824034d8c9", size = 40590681, upload-time = "2026-03-14T14:38:38.269Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f2/6fdb26d0651adf409864cb2a0d60da107e467d3d1aabc94b234ead54324a/av-17.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e5002271ab2135b551d980c2db8f3299d452e3b9d3633f24f6bb57fffe91cd10", size = 29216337, upload-time = "2026-03-14T14:38:40.83Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0a/0896b829a39b5669a2d811e1a79598de661693685cd62b31f11d0c18e65b/av-17.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dba98603fc4665b4f750de86fbaf6c0cfaece970671a9b529e0e3d1711e8367e", size = 22071058, upload-time = "2026-03-14T14:38:43.663Z" },
 ]
 
 [[package]]
@@ -303,6 +328,38 @@ wheels = [
 ]
 
 [[package]]
+name = "ctranslate2"
+version = "4.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/0f/581de94b64c5f2327a736270bc7e7a5f8fe5cf1ed56a2203b52de4d8986a/ctranslate2-4.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4c0cbd46a23b8dc37ccdbd9b447cb5f7fadc361c90e9df17d82ca84b1f019986", size = 1257089, upload-time = "2026-02-04T06:11:32.442Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e9/d55b0e436362f9fe26bd98fefd2dd5d81926121f1d7f799c805e6035bb26/ctranslate2-4.7.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:5b141ddad1da5f84cf3c2a569a56227a37de649a555d376cbd9b80e8f0373dd8", size = 11918502, upload-time = "2026-02-04T06:11:33.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ce/9f29f0b0bb4280c2ebafb3ddb6cdff8ef1c2e185ee020c0ec0ecba7dc934/ctranslate2-4.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d00a62544db4a3caaa58a3c50d39b25613c042b430053ae32384d94eb1d40990", size = 16859601, upload-time = "2026-02-04T06:11:36.227Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/86/428d270fd72117d19fb48ed3211aa8a3c8bd7577373252962cb634e0fd01/ctranslate2-4.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:722b93a89647974cbd182b4c7f87fefc7794fff7fc9cbd0303b6447905cc157e", size = 38995338, upload-time = "2026-02-04T06:11:42.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f4/d23dbfb9c62cb642c114a30f05d753ba61d6ffbfd8a3a4012fe85a073bcb/ctranslate2-4.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:d0f734dc3757118094663bdaaf713f5090c55c1927fb330a76bb8b84173940e8", size = 18844949, upload-time = "2026-02-04T06:11:45.436Z" },
+    { url = "https://files.pythonhosted.org/packages/34/6d/eb49ba05db286b4ea9d5d3fcf5f5cd0a9a5e218d46349618d5041001e303/ctranslate2-4.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6b2abf2929756e3ec6246057b56df379995661560a2d776af05f9d97f63afcf5", size = 1256960, upload-time = "2026-02-04T06:11:47.487Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5a/b9cce7b00d89fc6fdeaf27587aa52d0597b465058563e93ff50910553bdd/ctranslate2-4.7.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:857ef3959d6b1c40dc227c715a36db33db2d097164996d6c75b6db8e30828f52", size = 11918645, upload-time = "2026-02-04T06:11:49.599Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/03/c0db0a5276599fb44ceafa2f2cb1afd5628808ec406fe036060a39693680/ctranslate2-4.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:393a9e7e989034660526a2c0e8bb65d1924f43d9a5c77d336494a353d16ba2a4", size = 16860452, upload-time = "2026-02-04T06:11:52.276Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/03/4e3728ce29d192ee75ed9a2d8589bf4f19edafe5bed3845187de51b179a3/ctranslate2-4.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a3d0682f2b9082e31c73d75b45f16cde77355ab76d7e8356a24c3cb2480a6d3", size = 38995174, upload-time = "2026-02-04T06:11:55.477Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/15/6e8e87c6a201d69803a79ac2e29623ce7c2cc9cd1df9db99810cca714373/ctranslate2-4.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:baa6d2b10f57933d8c11791e8522659217918722d07bbef2389a443801125fe7", size = 18844953, upload-time = "2026-02-04T06:11:58.519Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/8a6b7ba18cad0c8667ee221ddab8c361cb70926440e5b8dd0e81924c28ac/ctranslate2-4.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d5dfb076566551f4959dfd0706f94c923c1931def9b7bb249a2caa6ab23353a0", size = 1257560, upload-time = "2026-02-04T06:12:00.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c2/8817ca5d6c1b175b23a12f7c8b91484652f8718a76353317e5919b038733/ctranslate2-4.7.1-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:eecdb4ed934b384f16e8c01b185b082d6b5ffc7dcbb0b6a6eb48cd465282d957", size = 11918995, upload-time = "2026-02-04T06:12:02.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/33/b8eb3acc67bbca4d9872fc9ff94db78e6167a7ba5cd932f585d1560effc7/ctranslate2-4.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1aa6796edcc3c8d163c9e39c429d50076d266d68980fed9d1b2443f617c67e9e", size = 16844162, upload-time = "2026-02-04T06:12:05.099Z" },
+    { url = "https://files.pythonhosted.org/packages/80/11/6474893b07121057035069a0a483fe1cd8c47878213f282afb4c0c6fc275/ctranslate2-4.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24c0482c51726430fb83724451921c0e539d769c8618dcfd46b1645e7f75960d", size = 38966728, upload-time = "2026-02-04T06:12:07.923Z" },
+    { url = "https://files.pythonhosted.org/packages/94/88/8fc7ff435c5e783e5fad9586d839d463e023988dbbbad949d442092d01f1/ctranslate2-4.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:76db234c0446a23d20dd8eeaa7a789cc87d1d05283f48bf3152bae9fa0a69844", size = 19100788, upload-time = "2026-02-04T06:12:10.592Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b3/f100013a76a98d64e67c721bd4559ea4eeb54be3e4ac45f4d801769899af/ctranslate2-4.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:058c9db2277dc8b19ecc86c7937628f69022f341844b9081d2ab642965d88fc6", size = 1280179, upload-time = "2026-02-04T06:12:12.596Z" },
+    { url = "https://files.pythonhosted.org/packages/39/22/b77f748015667a5e2ca54a5ee080d7016fce34314f0e8cf904784549305a/ctranslate2-4.7.1-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:5abcf885062c7f28a3f9a46be8d185795e8706ac6230ad086cae0bc82917df31", size = 11940166, upload-time = "2026-02-04T06:12:14.054Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/78/6d7fd52f646c6ba3343f71277a9bbef33734632949d1651231948b0f0359/ctranslate2-4.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9950acb04a002d5c60ae90a1ddceead1a803af1f00cadd9b1a1dc76e1f017481", size = 16849483, upload-time = "2026-02-04T06:12:17.082Z" },
+    { url = "https://files.pythonhosted.org/packages/40/27/58769ff15ac31b44205bd7a8aeca80cf7357c657ea5df1b94ce0f5c83771/ctranslate2-4.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1dcc734e92e3f1ceeaa0c42bbfd009352857be179ecd4a7ed6cccc086a202f58", size = 38949393, upload-time = "2026-02-04T06:12:21.302Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5c/9fa0ad6462b62efd0fb5ac1100eee47bc96ecc198ff4e237c731e5473616/ctranslate2-4.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:dfb7657bdb7b8211c8f9ecb6f3b70bc0db0e0384d01a8b1808cb66fe7199df59", size = 19123451, upload-time = "2026-02-04T06:12:24.115Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -337,6 +394,22 @@ wheels = [
 ]
 
 [[package]]
+name = "faster-whisper"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av" },
+    { name = "ctranslate2" },
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
+]
+
+[[package]]
 name = "feedparser"
 version = "6.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -355,6 +428,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
 ]
 
 [[package]]
@@ -450,6 +540,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/08/23c84a26716382c89151b5b447b4beb19e3345f3a93d3b73009a71a57ad3/hf_xet-1.4.2.tar.gz", hash = "sha256:b7457b6b482d9e0743bd116363239b1fa904a5e65deede350fbc0c4ea67c71ea", size = 672357, upload-time = "2026-03-13T06:58:51.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/06/e8cf74c3c48e5485c7acc5a990d0d8516cdfb5fdf80f799174f1287cc1b5/hf_xet-1.4.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ac8202ae1e664b2c15cdfc7298cbb25e80301ae596d602ef7870099a126fcad4", size = 3796125, upload-time = "2026-03-13T06:58:33.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d4/b73ebab01cbf60777323b7de9ef05550790451eb5172a220d6b9845385ec/hf_xet-1.4.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6d2f8ee39fa9fba9af929f8c0d0482f8ee6e209179ad14a909b6ad78ffcb7c81", size = 3555985, upload-time = "2026-03-13T06:58:31.797Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e7/ded6d1bd041c3f2bca9e913a0091adfe32371988e047dd3a68a2463c15a2/hf_xet-1.4.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4642a6cf249c09da8c1f87fe50b24b2a3450b235bf8adb55700b52f0ea6e2eb6", size = 4212085, upload-time = "2026-03-13T06:58:24.323Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c1/a0a44d1f98934f7bdf17f7a915b934f9fca44bb826628c553589900f6df8/hf_xet-1.4.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:769431385e746c92dc05492dde6f687d304584b89c33d79def8367ace06cb555", size = 3988266, upload-time = "2026-03-13T06:58:22.887Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/82/be713b439060e7d1f1d93543c8053d4ef2fe7e6922c5b31642eaa26f3c4b/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c9dd1c1bc4cc56168f81939b0e05b4c36dd2d28c13dc1364b17af89aa0082496", size = 4188513, upload-time = "2026-03-13T06:58:40.858Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/cbd4188b22abd80ebd0edbb2b3e87f2633e958983519980815fb8314eae5/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:fca58a2ae4e6f6755cc971ac6fcdf777ea9284d7e540e350bb000813b9a3008d", size = 4428287, upload-time = "2026-03-13T06:58:42.601Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/4e/84e45b25e2e3e903ed3db68d7eafa96dae9a1d1f6d0e7fc85120347a852f/hf_xet-1.4.2-cp313-cp313t-win_amd64.whl", hash = "sha256:163aab46854ccae0ab6a786f8edecbbfbaa38fcaa0184db6feceebf7000c93c0", size = 3665574, upload-time = "2026-03-13T06:58:53.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/71/c5ac2b9a7ae39c14e91973035286e73911c31980fe44e7b1d03730c00adc/hf_xet-1.4.2-cp313-cp313t-win_arm64.whl", hash = "sha256:09b138422ecbe50fd0c84d4da5ff537d27d487d3607183cd10e3e53f05188e82", size = 3528760, upload-time = "2026-03-13T06:58:52.187Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0f/fcd2504015eab26358d8f0f232a1aed6b8d363a011adef83fe130bff88f7/hf_xet-1.4.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:949dcf88b484bb9d9276ca83f6599e4aa03d493c08fc168c124ad10b2e6f75d7", size = 3796493, upload-time = "2026-03-13T06:58:39.267Z" },
+    { url = "https://files.pythonhosted.org/packages/82/56/19c25105ff81731ca6d55a188b5de2aa99d7a2644c7aa9de1810d5d3b726/hf_xet-1.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:41659966020d59eb9559c57de2cde8128b706a26a64c60f0531fa2318f409418", size = 3555797, upload-time = "2026-03-13T06:58:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/8933c073186849b5e06762aa89847991d913d10a95d1603eb7f2c3834086/hf_xet-1.4.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c588e21d80010119458dd5d02a69093f0d115d84e3467efe71ffb2c67c19146", size = 4212127, upload-time = "2026-03-13T06:58:30.539Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/01/f89ebba4e369b4ed699dcb60d3152753870996f41c6d22d3d7cac01310e1/hf_xet-1.4.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a296744d771a8621ad1d50c098d7ab975d599800dae6d48528ba3944e5001ba0", size = 3987788, upload-time = "2026-03-13T06:58:29.139Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4d/8a53e5ffbc2cc33bbf755382ac1552c6d9af13f623ed125fe67cc3e6772f/hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f563f7efe49588b7d0629d18d36f46d1658fe7e08dce3fa3d6526e1c98315e2d", size = 4188315, upload-time = "2026-03-13T06:58:48.017Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b8/b7a1c1b5592254bd67050632ebbc1b42cc48588bf4757cb03c2ef87e704a/hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5b2e0132c56d7ee1bf55bdb638c4b62e7106f6ac74f0b786fed499d5548c5570", size = 4428306, upload-time = "2026-03-13T06:58:49.502Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/40779e45b20e11c7c5821a94135e0207080d6b3d76e7b78ccb413c6f839b/hf_xet-1.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:2f45c712c2fa1215713db10df6ac84b49d0e1c393465440e9cb1de73ecf7bbf6", size = 3665826, upload-time = "2026-03-13T06:58:59.88Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4c/e2688c8ad1760d7c30f7c429c79f35f825932581bc7c9ec811436d2f21a0/hf_xet-1.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6d53df40616f7168abfccff100d232e9d460583b9d86fa4912c24845f192f2b8", size = 3529113, upload-time = "2026-03-13T06:58:58.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/86/b40b83a2ff03ef05c4478d2672b1fc2b9683ff870e2b25f4f3af240f2e7b/hf_xet-1.4.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:71f02d6e4cdd07f344f6844845d78518cc7186bd2bc52d37c3b73dc26a3b0bc5", size = 3800339, upload-time = "2026-03-13T06:58:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/2e/af4475c32b4378b0e92a587adb1aa3ec53e3450fd3e5fe0372a874531c00/hf_xet-1.4.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9b38d876e94d4bdcf650778d6ebbaa791dd28de08db9736c43faff06ede1b5a", size = 3559664, upload-time = "2026-03-13T06:58:34.787Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4c/781267da3188db679e601de18112021a5cb16506fe86b246e22c5401a9c4/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:77e8c180b7ef12d8a96739a4e1e558847002afe9ea63b6f6358b2271a8bdda1c", size = 4217422, upload-time = "2026-03-13T06:58:27.472Z" },
+    { url = "https://files.pythonhosted.org/packages/68/47/d6cf4a39ecf6c7705f887a46f6ef5c8455b44ad9eb0d391aa7e8a2ff7fea/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c3b3c6a882016b94b6c210957502ff7877802d0dbda8ad142c8595db8b944271", size = 3992847, upload-time = "2026-03-13T06:58:25.989Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ef/e80815061abff54697239803948abc665c6b1d237102c174f4f7a9a5ffc5/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d9a634cc929cfbaf2e1a50c0e532ae8c78fa98618426769480c58501e8c8ac2", size = 4193843, upload-time = "2026-03-13T06:58:44.59Z" },
+    { url = "https://files.pythonhosted.org/packages/54/75/07f6aa680575d9646c4167db6407c41340cbe2357f5654c4e72a1b01ca14/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04", size = 4432751, upload-time = "2026-03-13T06:58:46.533Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/71/193eabd7e7d4b903c4aa983a215509c6114915a5a237525ec562baddb868/hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f", size = 3671149, upload-time = "2026-03-13T06:58:57.07Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/7e/ccf239da366b37ba7f0b36095450efae4a64980bdc7ec2f51354205fdf39/hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87", size = 3533426, upload-time = "2026-03-13T06:58:55.46Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -519,6 +641,26 @@ wheels = [
 ]
 
 [[package]]
+name = "huggingface-hub"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/2a/a847fd02261cd051da218baf99f90ee7c7040c109a01833db4f838f25256/huggingface_hub-1.8.0.tar.gz", hash = "sha256:c5627b2fd521e00caf8eff4ac965ba988ea75167fad7ee72e17f9b7183ec63f3", size = 735839, upload-time = "2026-03-25T16:01:28.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ae/8a3a16ea4d202cb641b51d2681bdd3d482c1c592d7570b3fa264730829ce/huggingface_hub-1.8.0-py3-none-any.whl", hash = "sha256:d3eb5047bd4e33c987429de6020d4810d38a5bef95b3b40df9b17346b7f353f2", size = 625208, upload-time = "2026-03-25T16:01:26.603Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.16"
 source = { registry = "https://pypi.org/simple" }
@@ -547,7 +689,7 @@ wheels = [
 
 [[package]]
 name = "le-stash-workspace"
-version = "1.19.1"
+version = "1.27.2"
 source = { virtual = "." }
 dependencies = [
     { name = "lestash" },
@@ -556,6 +698,7 @@ dependencies = [
     { name = "lestash-linkedin" },
     { name = "lestash-microblog" },
     { name = "lestash-server" },
+    { name = "lestash-voice" },
     { name = "lestash-youtube" },
 ]
 
@@ -578,6 +721,7 @@ requires-dist = [
     { name = "lestash-linkedin", editable = "packages/lestash-linkedin" },
     { name = "lestash-microblog", editable = "packages/lestash-microblog" },
     { name = "lestash-server", editable = "packages/lestash-server" },
+    { name = "lestash-voice", editable = "packages/lestash-voice" },
     { name = "lestash-youtube", editable = "packages/lestash-youtube" },
 ]
 
@@ -594,9 +738,12 @@ dev = [
 
 [[package]]
 name = "lestash"
-version = "1.19.1"
+version = "1.27.2"
 source = { editable = "packages/lestash" }
 dependencies = [
+    { name = "google-api-python-client" },
+    { name = "google-auth-httplib2" },
+    { name = "google-auth-oauthlib" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rich" },
@@ -606,6 +753,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "google-api-python-client", specifier = ">=2.0.0" },
+    { name = "google-auth-httplib2", specifier = ">=0.2.0" },
+    { name = "google-auth-oauthlib", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "rich", specifier = ">=13.7.0" },
@@ -615,7 +765,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-arxiv"
-version = "1.19.1"
+version = "1.27.2"
 source = { editable = "packages/lestash-arxiv" }
 dependencies = [
     { name = "arxiv" },
@@ -630,7 +780,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-bluesky"
-version = "1.19.1"
+version = "1.27.2"
 source = { editable = "packages/lestash-bluesky" }
 dependencies = [
     { name = "atproto" },
@@ -645,7 +795,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-linkedin"
-version = "1.19.1"
+version = "1.27.2"
 source = { editable = "packages/lestash-linkedin" }
 dependencies = [
     { name = "authlib" },
@@ -662,7 +812,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-microblog"
-version = "1.19.1"
+version = "1.27.2"
 source = { editable = "packages/lestash-microblog" }
 dependencies = [
     { name = "httpx" },
@@ -677,11 +827,12 @@ requires-dist = [
 
 [[package]]
 name = "lestash-server"
-version = "1.19.1"
+version = "1.27.2"
 source = { editable = "packages/lestash-server" }
 dependencies = [
     { name = "fastapi" },
     { name = "lestash" },
+    { name = "lestash-voice" },
     { name = "python-multipart" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -690,13 +841,29 @@ dependencies = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "lestash", editable = "packages/lestash" },
+    { name = "lestash-voice", editable = "packages/lestash-voice" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
 
 [[package]]
+name = "lestash-voice"
+version = "1.27.2"
+source = { editable = "packages/lestash-voice" }
+dependencies = [
+    { name = "faster-whisper" },
+    { name = "lestash" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "faster-whisper", specifier = ">=1.0.0" },
+    { name = "lestash", editable = "packages/lestash" },
+]
+
+[[package]]
 name = "lestash-youtube"
-version = "1.19.1"
+version = "1.27.2"
 source = { editable = "packages/lestash-youtube" }
 dependencies = [
     { name = "google-api-python-client" },
@@ -834,6 +1001,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -885,12 +1061,106 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/8b/c265f4823726ab832de836cdd184d0986dcf94480f81e8739692a7ac7af2/numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd", size = 20727743, upload-time = "2026-03-09T07:58:53.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ed/6388632536f9788cea23a3a1b629f25b43eaacd7d7377e5d6bc7b9deb69b/numpy-2.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:61b0cbabbb6126c8df63b9a3a0c4b1f44ebca5e12ff6997b80fcf267fb3150ef", size = 16669628, upload-time = "2026-03-09T07:56:24.252Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1b/ee2abfc68e1ce728b2958b6ba831d65c62e1b13ce3017c13943f8f9b5b2e/numpy-2.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7395e69ff32526710748f92cd8c9849b361830968ea3e24a676f272653e8983e", size = 14696872, upload-time = "2026-03-09T07:56:26.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d1/780400e915ff5638166f11ca9dc2c5815189f3d7cf6f8759a1685e586413/numpy-2.4.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:abdce0f71dcb4a00e4e77f3faf05e4616ceccfe72ccaa07f47ee79cda3b7b0f4", size = 5203489, upload-time = "2026-03-09T07:56:29.414Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/bb/baffa907e9da4cc34a6e556d6d90e032f6d7a75ea47968ea92b4858826c4/numpy-2.4.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:48da3a4ee1336454b07497ff7ec83903efa5505792c4e6d9bf83d99dc07a1e18", size = 6550814, upload-time = "2026-03-09T07:56:32.225Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/12/8c9f0c6c95f76aeb20fc4a699c33e9f827fa0d0f857747c73bb7b17af945/numpy-2.4.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32e3bef222ad6b052280311d1d60db8e259e4947052c3ae7dd6817451fc8a4c5", size = 15666601, upload-time = "2026-03-09T07:56:34.461Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/cc665495e4d57d0aa6fbcc0aa57aa82671dfc78fbf95fe733ed86d98f52a/numpy-2.4.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7dd01a46700b1967487141a66ac1a3cf0dd8ebf1f08db37d46389401512ca97", size = 16621358, upload-time = "2026-03-09T07:56:36.852Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/b4ecb7224af1065c3539f5ecfff879d090de09608ad1008f02c05c770cb3/numpy-2.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:76f0f283506c28b12bba319c0fab98217e9f9b54e6160e9c79e9f7348ba32e9c", size = 17016135, upload-time = "2026-03-09T07:56:39.337Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b1/6a88e888052eed951afed7a142dcdf3b149a030ca59b4c71eef085858e43/numpy-2.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:737f630a337364665aba3b5a77e56a68cc42d350edd010c345d65a3efa3addcc", size = 18345816, upload-time = "2026-03-09T07:56:42.31Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8f/103a60c5f8c3d7fc678c19cd7b2476110da689ccb80bc18050efbaeae183/numpy-2.4.3-cp312-cp312-win32.whl", hash = "sha256:26952e18d82a1dbbc2f008d402021baa8d6fc8e84347a2072a25e08b46d698b9", size = 5960132, upload-time = "2026-03-09T07:56:44.851Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/7c/f5ee1bf6ed888494978046a809df2882aad35d414b622893322df7286879/numpy-2.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:65f3c2455188f09678355f5cae1f959a06b778bc66d535da07bf2ef20cd319d5", size = 12316144, upload-time = "2026-03-09T07:56:47.057Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/8d1cb3f7a00f2fb6394140e7e6623696e54c6318a9d9691bb4904672cf42/numpy-2.4.3-cp312-cp312-win_arm64.whl", hash = "sha256:2abad5c7fef172b3377502bde47892439bae394a71bc329f31df0fd829b41a9e", size = 10220364, upload-time = "2026-03-09T07:56:49.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d0/1fe47a98ce0df229238b77611340aff92d52691bcbc10583303181abf7fc/numpy-2.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b346845443716c8e542d54112966383b448f4a3ba5c66409771b8c0889485dd3", size = 16665297, upload-time = "2026-03-09T07:56:52.296Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d9/4e7c3f0e68dfa91f21c6fb6cf839bc829ec920688b1ce7ec722b1a6202fb/numpy-2.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2629289168f4897a3c4e23dc98d6f1731f0fc0fe52fb9db19f974041e4cc12b9", size = 14691853, upload-time = "2026-03-09T07:56:54.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/bd096b13a87549683812b53ab211e6d413497f84e794fb3c39191948da97/numpy-2.4.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:bb2e3cf95854233799013779216c57e153c1ee67a0bf92138acca0e429aefaee", size = 5198435, upload-time = "2026-03-09T07:56:57.184Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/687722910b5a5601de2135c891108f51dfc873d8e43c8ed9f4ebb440b4a2/numpy-2.4.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:7f3408ff897f8ab07a07fbe2823d7aee6ff644c097cc1f90382511fe982f647f", size = 6546347, upload-time = "2026-03-09T07:56:59.531Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/7971c4e98d86c564750393fab8d7d83d0a9432a9d78bb8a163a6dc59967a/numpy-2.4.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:decb0eb8a53c3b009b0962378065589685d66b23467ef5dac16cbe818afde27f", size = 15664626, upload-time = "2026-03-09T07:57:01.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/eb/7daecbea84ec935b7fc732e18f532073064a3816f0932a40a17f3349185f/numpy-2.4.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5f51900414fc9204a0e0da158ba2ac52b75656e7dce7e77fb9f84bfa343b4cc", size = 16608916, upload-time = "2026-03-09T07:57:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/df/58/2a2b4a817ffd7472dca4421d9f0776898b364154e30c95f42195041dc03b/numpy-2.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6bd06731541f89cdc01b261ba2c9e037f1543df7472517836b78dfb15bd6e476", size = 17015824, upload-time = "2026-03-09T07:57:06.347Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ca/627a828d44e78a418c55f82dd4caea8ea4a8ef24e5144d9e71016e52fb40/numpy-2.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22654fe6be0e5206f553a9250762c653d3698e46686eee53b399ab90da59bd92", size = 18334581, upload-time = "2026-03-09T07:57:09.114Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c0/76f93962fc79955fcba30a429b62304332345f22d4daec1cb33653425643/numpy-2.4.3-cp313-cp313-win32.whl", hash = "sha256:d71e379452a2f670ccb689ec801b1218cd3983e253105d6e83780967e899d687", size = 5958618, upload-time = "2026-03-09T07:57:11.432Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3c/88af0040119209b9b5cb59485fa48b76f372c73068dbf9254784b975ac53/numpy-2.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:0a60e17a14d640f49146cb38e3f105f571318db7826d9b6fef7e4dce758faecd", size = 12312824, upload-time = "2026-03-09T07:57:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ce/3d07743aced3d173f877c3ef6a454c2174ba42b584ab0b7e6d99374f51ed/numpy-2.4.3-cp313-cp313-win_arm64.whl", hash = "sha256:c9619741e9da2059cd9c3f206110b97583c7152c1dc9f8aafd4beb450ac1c89d", size = 10221218, upload-time = "2026-03-09T07:57:16.183Z" },
+    { url = "https://files.pythonhosted.org/packages/62/09/d96b02a91d09e9d97862f4fc8bfebf5400f567d8eb1fe4b0cc4795679c15/numpy-2.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7aa4e54f6469300ebca1d9eb80acd5253cdfa36f2c03d79a35883687da430875", size = 14819570, upload-time = "2026-03-09T07:57:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/ca/0b1aba3905fdfa3373d523b2b15b19029f4f3031c87f4066bd9d20ef6c6b/numpy-2.4.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d1b90d840b25874cf5cd20c219af10bac3667db3876d9a495609273ebe679070", size = 5326113, upload-time = "2026-03-09T07:57:21.052Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/63/406e0fd32fcaeb94180fd6a4c41e55736d676c54346b7efbce548b94a914/numpy-2.4.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:a749547700de0a20a6718293396ec237bb38218049cfce788e08fcb716e8cf73", size = 6646370, upload-time = "2026-03-09T07:57:22.804Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d0/10f7dc157d4b37af92720a196be6f54f889e90dcd30dce9dc657ed92c257/numpy-2.4.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f3c4a151a2e529adf49c1d54f0f57ff8f9b233ee4d44af623a81553ab86368", size = 15723499, upload-time = "2026-03-09T07:57:24.693Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f1/d1c2bf1161396629701bc284d958dc1efa3a5a542aab83cf11ee6eb4cba5/numpy-2.4.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22c31dc07025123aedf7f2db9e91783df13f1776dc52c6b22c620870dc0fab22", size = 16657164, upload-time = "2026-03-09T07:57:27.676Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/cca19230b740af199ac47331a21c71e7a3d0ba59661350483c1600d28c37/numpy-2.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:148d59127ac95979d6f07e4d460f934ebdd6eed641db9c0db6c73026f2b2101a", size = 17081544, upload-time = "2026-03-09T07:57:30.664Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/9602b0cbb703a0936fb40f8a95407e8171935b15846de2f0776e08af04c7/numpy-2.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a97cbf7e905c435865c2d939af3d93f99d18eaaa3cabe4256f4304fb51604349", size = 18380290, upload-time = "2026-03-09T07:57:33.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/81/9f24708953cd30be9ee36ec4778f4b112b45165812f2ada4cc5ea1c1f254/numpy-2.4.3-cp313-cp313t-win32.whl", hash = "sha256:be3b8487d725a77acccc9924f65fd8bce9af7fac8c9820df1049424a2115af6c", size = 6082814, upload-time = "2026-03-09T07:57:36.491Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9e/52f6eaa13e1a799f0ab79066c17f7016a4a8ae0c1aefa58c82b4dab690b4/numpy-2.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1ec84fd7c8e652b0f4aaaf2e6e9cc8eaa9b1b80a537e06b2e3a2fb176eedcb26", size = 12452673, upload-time = "2026-03-09T07:57:38.281Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/04/b8cece6ead0b30c9fbd99bb835ad7ea0112ac5f39f069788c5558e3b1ab2/numpy-2.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:120df8c0a81ebbf5b9020c91439fccd85f5e018a927a39f624845be194a2be02", size = 10290907, upload-time = "2026-03-09T07:57:40.747Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ae/3936f79adebf8caf81bd7a599b90a561334a658be4dcc7b6329ebf4ee8de/numpy-2.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5884ce5c7acfae1e4e1b6fde43797d10aa506074d25b531b4f54bde33c0c31d4", size = 16664563, upload-time = "2026-03-09T07:57:43.817Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/62/760f2b55866b496bb1fa7da2a6db076bef908110e568b02fcfc1422e2a3a/numpy-2.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:297837823f5bc572c5f9379b0c9f3a3365f08492cbdc33bcc3af174372ebb168", size = 14702161, upload-time = "2026-03-09T07:57:46.169Z" },
+    { url = "https://files.pythonhosted.org/packages/32/af/a7a39464e2c0a21526fb4fb76e346fb172ebc92f6d1c7a07c2c139cc17b1/numpy-2.4.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a111698b4a3f8dcbe54c64a7708f049355abd603e619013c346553c1fd4ca90b", size = 5208738, upload-time = "2026-03-09T07:57:48.506Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8c/2a0cf86a59558fa078d83805589c2de490f29ed4fb336c14313a161d358a/numpy-2.4.3-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:4bd4741a6a676770e0e97fe9ab2e51de01183df3dcbcec591d26d331a40de950", size = 6543618, upload-time = "2026-03-09T07:57:50.591Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b8/612ce010c0728b1c363fa4ea3aa4c22fe1c5da1de008486f8c2f5cb92fae/numpy-2.4.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54f29b877279d51e210e0c80709ee14ccbbad647810e8f3d375561c45ef613dd", size = 15680676, upload-time = "2026-03-09T07:57:52.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7e/4f120ecc54ba26ddf3dc348eeb9eb063f421de65c05fc961941798feea18/numpy-2.4.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:679f2a834bae9020f81534671c56fd0cc76dd7e5182f57131478e23d0dc59e24", size = 16613492, upload-time = "2026-03-09T07:57:54.91Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/86/1b6020db73be330c4b45d5c6ee4295d59cfeef0e3ea323959d053e5a6909/numpy-2.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d84f0f881cb2225c2dfd7f78a10a5645d487a496c6668d6cc39f0f114164f3d0", size = 17031789, upload-time = "2026-03-09T07:57:57.641Z" },
+    { url = "https://files.pythonhosted.org/packages/07/3a/3b90463bf41ebc21d1b7e06079f03070334374208c0f9a1f05e4ae8455e7/numpy-2.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d213c7e6e8d211888cc359bab7199670a00f5b82c0978b9d1c75baf1eddbeac0", size = 18339941, upload-time = "2026-03-09T07:58:00.577Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/74/6d736c4cd962259fd8bae9be27363eb4883a2f9069763747347544c2a487/numpy-2.4.3-cp314-cp314-win32.whl", hash = "sha256:52077feedeff7c76ed7c9f1a0428558e50825347b7545bbb8523da2cd55c547a", size = 6007503, upload-time = "2026-03-09T07:58:03.331Z" },
+    { url = "https://files.pythonhosted.org/packages/48/39/c56ef87af669364356bb011922ef0734fc49dad51964568634c72a009488/numpy-2.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:0448e7f9caefb34b4b7dd2b77f21e8906e5d6f0365ad525f9f4f530b13df2afc", size = 12444915, upload-time = "2026-03-09T07:58:06.353Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1f/ab8528e38d295fd349310807496fabb7cf9fe2e1f70b97bc20a483ea9d4a/numpy-2.4.3-cp314-cp314-win_arm64.whl", hash = "sha256:b44fd60341c4d9783039598efadd03617fa28d041fc37d22b62d08f2027fa0e7", size = 10494875, upload-time = "2026-03-09T07:58:08.734Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ef/b7c35e4d5ef141b836658ab21a66d1a573e15b335b1d111d31f26c8ef80f/numpy-2.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0a195f4216be9305a73c0e91c9b026a35f2161237cf1c6de9b681637772ea657", size = 14822225, upload-time = "2026-03-09T07:58:11.034Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8d/7730fa9278cf6648639946cc816e7cc89f0d891602584697923375f801ed/numpy-2.4.3-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:cd32fbacb9fd1bf041bf8e89e4576b6f00b895f06d00914820ae06a616bdfef7", size = 5328769, upload-time = "2026-03-09T07:58:13.67Z" },
+    { url = "https://files.pythonhosted.org/packages/47/01/d2a137317c958b074d338807c1b6a383406cdf8b8e53b075d804cc3d211d/numpy-2.4.3-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:2e03c05abaee1f672e9d67bc858f300b5ccba1c21397211e8d77d98350972093", size = 6649461, upload-time = "2026-03-09T07:58:15.912Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/34/812ce12bc0f00272a4b0ec0d713cd237cb390666eb6206323d1cc9cedbb2/numpy-2.4.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d1ce23cce91fcea443320a9d0ece9b9305d4368875bab09538f7a5b4131938a", size = 15725809, upload-time = "2026-03-09T07:58:17.787Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c0/2aed473a4823e905e765fee3dc2cbf504bd3e68ccb1150fbdabd5c39f527/numpy-2.4.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c59020932feb24ed49ffd03704fbab89f22aa9c0d4b180ff45542fe8918f5611", size = 16655242, upload-time = "2026-03-09T07:58:20.476Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c8/7e052b2fc87aa0e86de23f20e2c42bd261c624748aa8efd2c78f7bb8d8c6/numpy-2.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9684823a78a6cd6ad7511fc5e25b07947d1d5b5e2812c93fe99d7d4195130720", size = 17080660, upload-time = "2026-03-09T07:58:23.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/3d/0876746044db2adcb11549f214d104f2e1be00f07a67edbb4e2812094847/numpy-2.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0200b25c687033316fb39f0ff4e3e690e8957a2c3c8d22499891ec58c37a3eb5", size = 18380384, upload-time = "2026-03-09T07:58:25.839Z" },
+    { url = "https://files.pythonhosted.org/packages/07/12/8160bea39da3335737b10308df4f484235fd297f556745f13092aa039d3b/numpy-2.4.3-cp314-cp314t-win32.whl", hash = "sha256:5e10da9e93247e554bb1d22f8edc51847ddd7dde52d85ce31024c1b4312bfba0", size = 6154547, upload-time = "2026-03-09T07:58:28.289Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f3/76534f61f80d74cc9cdf2e570d3d4eeb92c2280a27c39b0aaf471eda7b48/numpy-2.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:45f003dbdffb997a03da2d1d0cb41fbd24a87507fb41605c0420a3db5bd4667b", size = 12633645, upload-time = "2026-03-09T07:58:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b6/7c0d4334c15983cec7f92a69e8ce9b1e6f31857e5ee3a413ac424e6bd63d/numpy-2.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:4d382735cecd7bcf090172489a525cd7d4087bc331f7df9f60ddc9a296cf208e", size = 10565454, upload-time = "2026-03-09T07:58:33.031Z" },
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.24.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/38/31db1b232b4ba960065a90c1506ad7a56995cd8482033184e97fadca17cc/onnxruntime-1.24.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cad1c2b3f455c55678ab2a8caa51fb420c25e6e3cf10f4c23653cdabedc8de78", size = 17341875, upload-time = "2026-03-17T22:05:51.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/60/c4d1c8043eb42f8a9aa9e931c8c293d289c48ff463267130eca97d13357f/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a5c5a544b22f90859c88617ecb30e161ee3349fcc73878854f43d77f00558b5", size = 15172485, upload-time = "2026-03-17T22:03:32.182Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ab/5b68110e0460d73fad814d5bd11c7b1ddcce5c37b10177eb264d6a36e331/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d640eb9f3782689b55cfa715094474cd5662f2f137be6a6f847a594b6e9705c", size = 17244912, upload-time = "2026-03-17T22:04:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f4/6b89e297b93704345f0f3f8c62229bee323ef25682a3f9b4f89a39324950/onnxruntime-1.24.4-cp312-cp312-win_amd64.whl", hash = "sha256:535b29475ca42b593c45fbb2152fbf1cdf3f287315bf650e6a724a0a1d065cdb", size = 12596856, upload-time = "2026-03-17T22:05:41.224Z" },
+    { url = "https://files.pythonhosted.org/packages/43/06/8b8ec6e9e6a474fcd5d772453f627ad4549dfe3ab8c0bf70af5afcde551b/onnxruntime-1.24.4-cp312-cp312-win_arm64.whl", hash = "sha256:e6214096e14b7b52e3bee1903dc12dc7ca09cb65e26664668a4620cc5e6f9a90", size = 12270275, upload-time = "2026-03-17T22:05:31.132Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f0/8a21ec0a97e40abb7d8da1e8b20fb9e1af509cc6d191f6faa75f73622fb2/onnxruntime-1.24.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e99a48078baaefa2b50fe5836c319499f71f13f76ed32d0211f39109147a49e0", size = 17341922, upload-time = "2026-03-17T22:03:56.364Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/25/d7908de8e08cee9abfa15b8aa82349b79733ae5865162a3609c11598805d/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4aaed1e5e1aaacf2343c838a30a7c3ade78f13eeb16817411f929d04040a13", size = 15172290, upload-time = "2026-03-17T22:03:37.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/72/105ec27a78c5aa0154a7c0cd8c41c19a97799c3b12fc30392928997e3be3/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e30c972bc02e072911aabb6891453ec73795386c0af2b761b65444b8a4c4745f", size = 17244738, upload-time = "2026-03-17T22:04:40.625Z" },
+    { url = "https://files.pythonhosted.org/packages/05/fb/a592736d968c2f58e12de4d52088dda8e0e724b26ad5c0487263adb45875/onnxruntime-1.24.4-cp313-cp313-win_amd64.whl", hash = "sha256:3b6ba8b0181a3aa88edab00eb01424ffc06f42e71095a91186c2249415fcff93", size = 12597435, upload-time = "2026-03-17T22:05:43.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/04/ae2479e9841b64bd2eb44f8a64756c62593f896514369a11243b1b86ca5c/onnxruntime-1.24.4-cp313-cp313-win_arm64.whl", hash = "sha256:71d6a5c1821d6e8586a024000ece458db8f2fc0ecd050435d45794827ce81e19", size = 12269852, upload-time = "2026-03-17T22:05:33.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/af/a479a536c4398ffaf49fbbe755f45d5b8726bdb4335ab31b537f3d7149b8/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1700f559c8086d06b2a4d5de51e62cb4ff5e2631822f71a36db8c72383db71ee", size = 15176861, upload-time = "2026-03-17T22:03:40.143Z" },
+    { url = "https://files.pythonhosted.org/packages/be/13/19f5da70c346a76037da2c2851ecbf1266e61d7f0dcdb887c667210d4608/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c74e268dc808e61e63784d43f9ddcdaf50a776c2819e8bd1d1b11ef64bf7e36", size = 17247454, upload-time = "2026-03-17T22:04:46.643Z" },
+    { url = "https://files.pythonhosted.org/packages/89/db/b30dbbd6037847b205ab75d962bc349bf1e46d02a65b30d7047a6893ffd6/onnxruntime-1.24.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:fbff2a248940e3398ae78374c5a839e49a2f39079b488bc64439fa0ec327a3e4", size = 17343300, upload-time = "2026-03-17T22:03:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/61/88/1746c0e7959961475b84c776d35601a21d445f463c93b1433a409ec3e188/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2b7969e72d8cb53ffc88ab6d49dd5e75c1c663bda7be7eb0ece192f127343d1", size = 15175936, upload-time = "2026-03-17T22:03:43.671Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ba/4699cde04a52cece66cbebc85bd8335a0d3b9ad485abc9a2e15946a1349d/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14ed1f197fab812b695a5eaddb536c635e58a2fbbe50a517c78f082cc6ce9177", size = 17246432, upload-time = "2026-03-17T22:04:49.58Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/4590910841bb28bd3b4b388a9efbedf4e2d2cca99ddf0c863642b4e87814/onnxruntime-1.24.4-cp314-cp314-win_amd64.whl", hash = "sha256:311e309f573bf3c12aa5723e23823077f83d5e412a18499d4485c7eb41040858", size = 12903276, upload-time = "2026-03-17T22:05:46.349Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/6f/60e2c0acea1e1ac09b3e794b5a19c166eebf91c0b860b3e6db8e74983fda/onnxruntime-1.24.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f0b910e86b759a4732663ec61fd57ac42ee1b0066f68299de164220b660546d", size = 12594365, upload-time = "2026-03-17T22:05:35.795Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/0c05d10f8f6c40fe0912ebec0d5a33884aaa2af2053507e864dab0883208/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa12ddc54c9c4594073abcaa265cd9681e95fb89dae982a6f508a794ca42e661", size = 15176889, upload-time = "2026-03-17T22:03:48.021Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/1d/1666dc64e78d8587d168fec4e3b7922b92eb286a2ddeebcf6acb55c7dc82/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1cc6a518255f012134bc791975a6294806be9a3b20c4a54cca25194c90cf731", size = 17247021, upload-time = "2026-03-17T22:04:52.377Z" },
 ]
 
 [[package]]
@@ -1315,6 +1585,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
 name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1343,12 +1622,62 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Google OAuth** — shared auth module with headless/SSH support, CLI commands (`lestash google auth/doctor/download`), Drive import endpoint
- **Takeout parsers** — Gemini conversations + NotebookLM notebooks (with parent-child items) auto-detected from ZIP uploads
- **`parent_id` column** (migration v5) — formal parent-child relationships for items, API filters, child_count enrichment, two-pass import
- **UI redesign** — two-mode view (content default + debug toggle), master-detail navigation with drill-down, browser history/URL support for items, tabs, and filters

Refs #33

## Test plan
- [x] `lestash google auth` — authenticates via console flow on SSH
- [x] `lestash google download <drive-url>` — downloads file from Google Drive
- [x] Upload Gemini/NotebookLM Takeout ZIP via `/api/import` — creates parent + child items
- [x] `GET /api/items` — hides children by default, `?parent_id=X` returns children
- [x] UI: click item → detail view with back button, drill into children
- [x] UI: wrench toggle shows/hides debug metadata
- [x] UI: browser back/forward works for items, tabs, and filters
- [x] `uv run just check` — all tests pass