### PR TITLE
feat(arxiv): persistent paper tracking and update detection

### DIFF
--- a/packages/lestash-arxiv/src/lestash_arxiv/client.py
+++ b/packages/lestash-arxiv/src/lestash_arxiv/client.py
@@ -21,6 +21,7 @@ class Paper:
     primary_category: str
     url: str
     pdf_url: str
+    version: int | None = None
 
     @property
     def author_display(self) -> str:
@@ -52,6 +53,23 @@ def extract_arxiv_id(entry_id: str) -> str:
     return entry_id
 
 
+def extract_version(entry_id: str) -> int | None:
+    """Extract version number from arXiv entry ID.
+
+    Examples:
+        http://arxiv.org/abs/1706.03762v7 -> 7
+        2301.00001v1 -> 1
+        2301.00001 -> None
+    """
+    if "/" in entry_id:
+        entry_id = entry_id.split("/")[-1]
+
+    match = re.search(r"v(\d+)$", entry_id)
+    if match:
+        return int(match.group(1))
+    return None
+
+
 def paper_from_result(result: arxiv.Result) -> Paper:
     """Convert arxiv.Result to Paper dataclass."""
     return Paper(
@@ -65,6 +83,7 @@ def paper_from_result(result: arxiv.Result) -> Paper:
         primary_category=result.primary_category,
         url=result.entry_id,
         pdf_url=result.pdf_url,
+        version=extract_version(result.entry_id),
     )
 
 
@@ -105,3 +124,21 @@ def get_paper(arxiv_id: str) -> Paper | None:
     if results:
         return paper_from_result(results[0])
     return None
+
+
+def get_papers(arxiv_ids: list[str]) -> list[Paper]:
+    """Batch-fetch multiple papers by arXiv ID.
+
+    Args:
+        arxiv_ids: List of arXiv paper IDs.
+
+    Returns:
+        List of Paper objects (missing IDs are silently skipped).
+    """
+    if not arxiv_ids:
+        return []
+
+    client = arxiv.Client()
+    search = arxiv.Search(id_list=arxiv_ids)
+
+    return [paper_from_result(r) for r in client.results(search)]

--- a/packages/lestash-arxiv/src/lestash_arxiv/source.py
+++ b/packages/lestash-arxiv/src/lestash_arxiv/source.py
@@ -1,6 +1,8 @@
 """arXiv source plugin implementation."""
 
 import json
+import re
+import sqlite3
 from collections.abc import Iterator
 from typing import Annotated
 
@@ -10,7 +12,7 @@ from lestash.plugins.base import SourcePlugin
 from rich.console import Console
 from rich.table import Table
 
-from lestash_arxiv.client import Paper, get_paper, search_papers
+from lestash_arxiv.client import Paper, get_paper, get_papers, search_papers
 
 console = Console()
 
@@ -32,6 +34,7 @@ def paper_to_item(paper: Paper) -> ItemCreate:
             "primary_category": paper.primary_category,
             "pdf_url": paper.pdf_url,
             "updated": paper.updated.isoformat() if paper.updated else None,
+            "version": paper.version,
         },
     )
 
@@ -49,6 +52,31 @@ def display_paper(paper: Paper, verbose: bool = False) -> None:
         console.print()
         console.print("[bold]Abstract:[/bold]")
         console.print(paper.abstract)
+
+
+_PAPER_ID_RE = re.compile(r"^\d{4}\.\d{4,5}$")
+
+
+def _get_tracking_config(conn: sqlite3.Connection) -> dict:
+    """Read tracking config from sources table."""
+    cursor = conn.execute("SELECT config FROM sources WHERE source_type = 'arxiv'")
+    row = cursor.fetchone()
+    if row and row[0]:
+        return json.loads(row[0])
+    return {"queries": [], "untracked_papers": []}
+
+
+def _save_tracking_config(conn: sqlite3.Connection, config: dict) -> None:
+    """Write tracking config to sources table."""
+    conn.execute(
+        """
+        INSERT INTO sources (source_type, config)
+        VALUES ('arxiv', ?)
+        ON CONFLICT(source_type) DO UPDATE SET config = excluded.config
+        """,
+        (json.dumps(config),),
+    )
+    conn.commit()
 
 
 class ArxivSource(SourcePlugin):
@@ -153,22 +181,279 @@ class ArxivSource(SourcePlugin):
             console.print(f"[green]Saved: {paper.title}[/green]")
             console.print(f"[dim]arXiv:{paper.arxiv_id}[/dim]")
 
+        @app.command("track")
+        def track_cmd(
+            value: Annotated[str, typer.Argument(help="Search query or arXiv paper ID")],
+            category: Annotated[
+                str | None,
+                typer.Option("--category", "-c", help="arXiv category filter"),
+            ] = None,
+            max_results: Annotated[
+                int,
+                typer.Option("--max-results", "-n", help="Max results per query"),
+            ] = 10,
+        ) -> None:
+            """Track a search query or re-enable tracking for an untracked paper."""
+            from lestash.core.config import Config
+            from lestash.core.database import get_connection
+
+            config = Config.load()
+            is_paper_id = bool(_PAPER_ID_RE.match(value))
+
+            with get_connection(config) as conn:
+                tracking = _get_tracking_config(conn)
+
+                if is_paper_id:
+                    untracked = tracking.get("untracked_papers", [])
+                    if value in untracked:
+                        untracked.remove(value)
+                        _save_tracking_config(conn, tracking)
+                        console.print(f"[green]Re-enabled tracking for paper: {value}[/green]")
+                    else:
+                        # Check if paper is already in DB
+                        cursor = conn.execute(
+                            "SELECT title FROM items WHERE source_type = 'arxiv' AND source_id = ?",
+                            (value,),
+                        )
+                        row = cursor.fetchone()
+                        if row:
+                            console.print(
+                                f"[yellow]Paper {value} is already tracked"
+                                " (all saved papers are tracked by default).[/yellow]"
+                            )
+                            return
+
+                    # Fetch and save the paper if not already in DB
+                    paper = get_paper(value)
+                    if paper:
+                        item = paper_to_item(paper)
+                        metadata_json = json.dumps(item.metadata) if item.metadata else None
+                        conn.execute(
+                            """
+                            INSERT INTO items (
+                                source_type, source_id, url, title, content,
+                                author, created_at, is_own_content, metadata
+                            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                            ON CONFLICT(source_type, source_id) DO UPDATE SET
+                                title = excluded.title,
+                                content = excluded.content,
+                                metadata = excluded.metadata
+                            """,
+                            (
+                                item.source_type,
+                                item.source_id,
+                                item.url,
+                                item.title,
+                                item.content,
+                                item.author,
+                                item.created_at,
+                                item.is_own_content,
+                                metadata_json,
+                            ),
+                        )
+                        conn.commit()
+                        console.print(f"[green]Saved: {paper.title}[/green]")
+                        console.print(f"[dim]arXiv:{value} (v{paper.version or '?'})[/dim]")
+                    elif not conn.execute(
+                        "SELECT 1 FROM items WHERE source_type = 'arxiv' AND source_id = ?",
+                        (value,),
+                    ).fetchone():
+                        console.print(f"[red]Paper {value} not found on arXiv.[/red]")
+                else:
+                    query_entry: dict = {"query": value, "max_results": max_results}
+                    if category:
+                        query_entry["category"] = category
+
+                    existing = tracking.get("queries", [])
+                    if any(q["query"] == value for q in existing):
+                        console.print(f"[yellow]Query '{value}' is already tracked.[/yellow]")
+                        return
+                    tracking.setdefault("queries", []).append(query_entry)
+                    _save_tracking_config(conn, tracking)
+                    cat_str = f" (category: {category})" if category else ""
+                    console.print(f"[green]Tracking query: '{value}'{cat_str}[/green]")
+
+        @app.command("tracked")
+        def tracked_cmd() -> None:
+            """List tracked queries and papers."""
+            from lestash.core.config import Config
+            from lestash.core.database import get_connection
+
+            config = Config.load()
+
+            with get_connection(config) as conn:
+                tracking = _get_tracking_config(conn)
+                untracked = set(tracking.get("untracked_papers", []))
+
+                # All saved arxiv papers minus untracked ones
+                cursor = conn.execute(
+                    "SELECT source_id, title, "
+                    "json_extract(metadata, '$.version') as version "
+                    "FROM items WHERE source_type = 'arxiv' "
+                    "ORDER BY datetime(created_at) DESC"
+                )
+                all_papers = cursor.fetchall()
+
+            queries = tracking.get("queries", [])
+            tracked_papers = [p for p in all_papers if p["source_id"] not in untracked]
+            untracked_papers = [p for p in all_papers if p["source_id"] in untracked]
+
+            if not queries and not tracked_papers:
+                console.print(
+                    "[dim]Nothing tracked. Use 'lestash arxiv track'"
+                    " to add queries, or save papers with"
+                    " 'lestash arxiv save'.[/dim]"
+                )
+                return
+
+            if queries:
+                table = Table(
+                    title="Tracked Queries",
+                    show_header=True,
+                    header_style="bold",
+                )
+                table.add_column("Query")
+                table.add_column("Category")
+                table.add_column("Max Results")
+                for q in queries:
+                    table.add_row(
+                        q["query"],
+                        q.get("category", "-"),
+                        str(q.get("max_results", 10)),
+                    )
+                console.print(table)
+
+            if tracked_papers:
+                table = Table(
+                    title="Tracked Papers (updates checked on sync)",
+                    show_header=True,
+                    header_style="bold",
+                )
+                table.add_column("arXiv ID", style="dim")
+                table.add_column("Title", max_width=50)
+                table.add_column("Version")
+                for p in tracked_papers:
+                    table.add_row(
+                        p["source_id"],
+                        p["title"] or "-",
+                        f"v{p['version']}" if p["version"] else "-",
+                    )
+                console.print(table)
+
+            if untracked_papers:
+                table = Table(
+                    title="Untracked Papers (updates skipped)",
+                    show_header=True,
+                    header_style="bold dim",
+                )
+                table.add_column("arXiv ID", style="dim")
+                table.add_column("Title", max_width=50)
+                for p in untracked_papers:
+                    table.add_row(p["source_id"], p["title"] or "-")
+                console.print(table)
+
+        @app.command("untrack")
+        def untrack_cmd(
+            value: Annotated[
+                str,
+                typer.Argument(help="Search query or arXiv paper ID to remove"),
+            ],
+        ) -> None:
+            """Stop tracking a query or paper for updates."""
+            from lestash.core.config import Config
+            from lestash.core.database import get_connection
+
+            config = Config.load()
+
+            with get_connection(config) as conn:
+                tracking = _get_tracking_config(conn)
+                is_paper_id = bool(_PAPER_ID_RE.match(value))
+
+                if is_paper_id:
+                    untracked = tracking.get("untracked_papers", [])
+                    if value in untracked:
+                        console.print(f"[yellow]Paper {value} is already untracked.[/yellow]")
+                        return
+                    tracking.setdefault("untracked_papers", []).append(value)
+                    _save_tracking_config(conn, tracking)
+                    console.print(
+                        f"[green]Untracked paper: {value} "
+                        "(will no longer check for updates)[/green]"
+                    )
+                else:
+                    queries = tracking.get("queries", [])
+                    original_len = len(queries)
+                    tracking["queries"] = [q for q in queries if q["query"] != value]
+                    if len(tracking["queries"]) == original_len:
+                        console.print(f"[yellow]Query '{value}' is not tracked.[/yellow]")
+                        return
+                    _save_tracking_config(conn, tracking)
+                    console.print(f"[green]Untracked query: '{value}'[/green]")
+
         return app
 
     def sync(self, config: dict) -> Iterator[ItemCreate]:
-        """Sync arXiv papers based on configured keywords.
+        """Sync arXiv papers from keywords, tracked queries, and tracked papers.
 
-        If keywords are configured, fetches recent papers matching them.
+        Three phases:
+        1. Legacy keywords from TOML config (backwards compatible)
+        2. Tracked queries from sources.config DB column
+        3. Update detection for tracked paper IDs
         """
+        seen: set[str] = set()
+
+        # Phase 1: Legacy keywords from TOML config
         keywords = config.get("keywords", [])
-
-        if not keywords:
-            return
-
         for keyword in keywords:
+            self.logger.info("Searching keyword: %s", keyword)
             papers = search_papers(keyword, max_results=config.get("max_per_keyword", 5))
             for paper in papers:
-                yield paper_to_item(paper)
+                if paper.arxiv_id not in seen:
+                    seen.add(paper.arxiv_id)
+                    yield paper_to_item(paper)
+
+        # Phase 2+3: Tracked queries and papers from DB config
+        try:
+            from lestash.core.config import Config
+            from lestash.core.database import get_connection
+
+            app_config = Config.load()
+            with get_connection(app_config) as conn:
+                tracking = _get_tracking_config(conn)
+
+                # Get all saved arxiv paper IDs for update detection
+                cursor = conn.execute("SELECT source_id FROM items WHERE source_type = 'arxiv'")
+                all_saved_ids = [row[0] for row in cursor.fetchall()]
+        except Exception:
+            self.logger.warning("Could not read tracking config from DB, skipping")
+            return
+
+        # Phase 2: Tracked queries
+        for query_conf in tracking.get("queries", []):
+            query = query_conf["query"]
+            max_results = query_conf.get("max_results", 10)
+            category = query_conf.get("category")
+
+            search_query = f"cat:{category} AND {query}" if category else query
+            self.logger.info("Searching tracked query: %s", search_query)
+
+            papers = search_papers(search_query, max_results=max_results)
+            for paper in papers:
+                if paper.arxiv_id not in seen:
+                    seen.add(paper.arxiv_id)
+                    yield paper_to_item(paper)
+
+        # Phase 3: Update detection for all saved papers (minus untracked)
+        untracked = set(tracking.get("untracked_papers", []))
+        papers_to_check = [pid for pid in all_saved_ids if pid not in seen and pid not in untracked]
+
+        if papers_to_check:
+            self.logger.info("Checking %d saved papers for updates", len(papers_to_check))
+            papers = get_papers(papers_to_check)
+            for paper in papers:
+                if paper.arxiv_id not in seen:
+                    seen.add(paper.arxiv_id)
+                    yield paper_to_item(paper)
 
     def configure(self) -> dict:
         """Interactive configuration."""


### PR DESCRIPTION
## Summary

Closes #41

- All saved arXiv papers are tracked for updates by default during sync — no opt-in needed
- New CLI commands: `track` (add search queries or re-enable paper tracking), `tracked` (list everything), `untrack` (exclude papers from update checks or remove queries)
- Version detection: extracts and stores paper version number from arXiv entry IDs (e.g., v1 → v2)
- Batch paper fetching via `get_papers()` for efficient update checks during sync
- Three-phase sync: legacy TOML keywords → tracked DB queries (with category filter) → update detection for all saved papers minus exclusions
- Tracking config stored in `sources.config` JSON column (no schema changes needed)

## Test plan

- [x] `lestash arxiv track "neuro-symbolic" -c cs.AI` — adds tracked query
- [x] `lestash arxiv tracked` — shows queries and all saved papers with version info
- [x] `lestash sources sync arxiv` — runs tracked queries + checks all saved papers for updates
- [x] Verify paper 2512.20660 gets updated to v2 metadata after sync
- [x] `lestash arxiv untrack 2512.20660` — excludes from future update checks
- [x] `lestash arxiv track 2512.20660` — re-enables tracking
- [x] `uv run just check` passes (lint, format, types, tests)