### PR TITLE
fix(server): harden import parsers for idempotent re-imports

### DIFF
--- a/packages/lestash-server/src/lestash_server/parsers/json_items.py
+++ b/packages/lestash-server/src/lestash_server/parsers/json_items.py
@@ -1,5 +1,6 @@
 """Parse a JSON array of items for import."""
 
+import hashlib
 import json
 
 from lestash.models.item import ItemCreate
@@ -37,10 +38,16 @@ def parse_json_items(data: bytes) -> list[ItemCreate]:
         if "source_type" not in item:
             item["source_type"] = "import"
 
+        # Generate deterministic source_id from content if missing
+        source_id = item.get("source_id")
+        if not source_id and not item.get("url"):
+            content_hash = hashlib.sha256(item["content"][:500].encode()).hexdigest()[:12]
+            source_id = f"{item['source_type']}-{content_hash}"
+
         results.append(
             ItemCreate(
                 source_type=item["source_type"],
-                source_id=item.get("source_id"),
+                source_id=source_id,
                 url=item.get("url"),
                 title=item.get("title"),
                 content=item["content"],

--- a/packages/lestash-server/src/lestash_server/parsers/mistral.py
+++ b/packages/lestash-server/src/lestash_server/parsers/mistral.py
@@ -38,7 +38,10 @@ def parse_mistral_zip(zf: zipfile.ZipFile) -> list[ItemCreate]:
             if not isinstance(messages, list) or not messages:
                 continue
 
-            chat_id = messages[0].get("chatId", name)
+            chat_id = messages[0].get("chatId")
+            if not chat_id:
+                logger.warning("Skipping chat without chatId: %s", name)
+                continue
             parent_source_id = f"mistral-{chat_id}"
 
             first_user_msg = ""
@@ -52,8 +55,12 @@ def parse_mistral_zip(zf: zipfile.ZipFile) -> list[ItemCreate]:
                 if not content:
                     continue
 
+                msg_id = msg.get("id")
+                if not msg_id:
+                    logger.warning("Skipping message without id in chat %s", chat_id)
+                    continue
+
                 msg_count += 1
-                msg_id = msg.get("id", f"{chat_id}-{msg_count}")
 
                 if role == "user" and not first_user_msg:
                     first_user_msg = content

--- a/packages/lestash-server/src/lestash_server/routes/imports.py
+++ b/packages/lestash-server/src/lestash_server/routes/imports.py
@@ -70,12 +70,20 @@ async def import_file(file: UploadFile):
 
 
 def _upsert_item(conn, item, parent_id=None):
-    """Insert or update a single item. Returns the row ID."""
+    """Insert or update a single item. Returns the row ID, or None if skipped."""
     metadata = dict(item.metadata) if item.metadata else {}
     # Strip internal parent marker before storing
     metadata.pop("_parent_source_id", None)
     metadata_json = json.dumps(metadata) if metadata else None
     source_id = item.source_id or item.url
+
+    if not source_id:
+        logger.warning(
+            "Skipping item with no source_id or url: %s",
+            (item.title or item.content[:50]) if item.content else "empty",
+        )
+        return None
+
     cursor = conn.execute(
         """
         INSERT INTO items (
@@ -83,9 +91,11 @@ def _upsert_item(conn, item, parent_id=None):
             author, created_at, is_own_content, metadata, parent_id
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(source_type, source_id) DO UPDATE SET
+            url = excluded.url,
             content = excluded.content,
             title = excluded.title,
             author = excluded.author,
+            is_own_content = excluded.is_own_content,
             metadata = excluded.metadata,
             parent_id = excluded.parent_id
         """,
@@ -132,7 +142,9 @@ def _insert_items_with_parents(conn, items):
         try:
             row_id = _upsert_item(conn, item)
             if row_id:
-                parent_id_map[item.source_id or ""] = row_id
+                # Use the effective source_id (same logic as _upsert_item)
+                effective_id = item.source_id or item.url or ""
+                parent_id_map[effective_id] = row_id
                 items_added += 1
         except Exception as e:
             errors.append(f"Failed to import parent: {e}")


### PR DESCRIPTION
## Summary

Follow-up to #87 — the idempotency hardening commit was lost during the squash merge.

- `_upsert_item`: skip items with no source_id or url; add `url` and `is_own_content` to ON CONFLICT UPDATE clause
- JSON parser: generate deterministic content-hash source_id when both source_id and url are missing
- Mistral parser: require message `id` field (no synthetic index-based fallback); validate `chatId` presence
- Parent map: use effective source_id matching `_upsert_item` logic

## Test plan

- [x] Re-import Mistral ZIP produces 0 new items (all upserted)
- [x] JSON import with missing source_id gets a content-hash ID
- [x] `uv run just check` passes