### PR TITLE
feat(google): Drive import UI and server endpoint

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -737,6 +737,22 @@
         </div>
       </div>
 
+      <!-- Google Drive import -->
+      <div id="drive-import-section" style="margin-bottom:1.5rem;display:none">
+        <h3 style="font-size:0.85rem;color:var(--muted);margin-bottom:0.5rem">Google Drive Import</h3>
+        <div class="tag-input-row">
+          <input type="url" id="drive-url-input" placeholder="Paste Drive or Docs URL..." style="flex:1">
+          <button class="sync-btn" id="drive-import-btn" onclick="importDriveUrl()">Import</button>
+        </div>
+        <div style="font-size:0.72rem;margin-top:0.3rem;color:var(--muted)">
+          Google Docs, Drive files, or folder URLs — converts to markdown
+        </div>
+        <div id="drive-import-progress" style="display:none;padding:0.5rem;color:var(--muted);font-size:0.85rem">
+          <span class="spinner"></span> Importing from Drive...
+        </div>
+        <div id="drive-import-result" style="display:none;padding:0.75rem;background:var(--surface);border-radius:6px;margin-top:0.5rem;font-size:0.85rem"></div>
+      </div>
+
       <table class="source-table" id="sources-table">
         <thead>
           <tr><th>Source</th><th>Description</th><th>Last Sync</th><th></th></tr>
@@ -849,6 +865,12 @@
         <label style="display:flex;align-items:center;gap:0.4rem;font-size:0.85rem;cursor:pointer">
           <input type="checkbox" id="capture-fetch-transcript" checked>
           Also fetch video transcript
+        </label>
+      </div>
+      <div id="capture-drive-option" style="display:none;margin-bottom:0.75rem">
+        <label style="display:flex;align-items:center;gap:0.4rem;font-size:0.85rem;cursor:pointer">
+          <input type="checkbox" id="capture-drive-import" checked>
+          Import as document (convert to markdown)
         </label>
       </div>
       <div class="modal-actions">
@@ -1823,6 +1845,7 @@
       const section = document.getElementById('google-auth-section');
       const statusEl = document.getElementById('google-auth-status');
       const flowEl = document.getElementById('google-auth-flow');
+      const driveSection = document.getElementById('drive-import-section');
       try {
         const data = await api('/api/google/auth-status');
         section.style.display = 'block';
@@ -1831,14 +1854,17 @@
         if (data.authenticated && hasYoutube && hasDrive) {
           statusEl.innerHTML = `<span style="color:var(--ok)">Connected</span> <span style="color:var(--muted);font-size:0.75rem">(YouTube + Drive)</span>`;
           flowEl.style.display = 'none';
+          driveSection.style.display = '';
         } else {
           const missing = [!hasYoutube && 'YouTube', !hasDrive && 'Drive'].filter(Boolean);
           const scopeNote = data.authenticated && missing.length ? ` (missing: ${missing.join(', ')})` : '';
           statusEl.innerHTML = `<button class="sync-btn" onclick="startGoogleAuth()">Connect Google</button><span style="color:var(--muted);font-size:0.75rem;margin-left:0.3rem">${scopeNote}</span>`;
           flowEl.style.display = 'none';
+          driveSection.style.display = hasDrive && data.authenticated ? '' : 'none';
         }
       } catch {
         section.style.display = 'none';
+        driveSection.style.display = 'none';
       }
     }
 
@@ -1872,6 +1898,45 @@
         loadGoogleAuth();
       } catch (e) {
         showToast(`Auth failed: ${e.message}`, 'error');
+      }
+    }
+
+    function _isDriveOrDocsUrl(url) {
+      return /^https?:\/\/(drive\.google\.com|docs\.google\.com)\//i.test(url);
+    }
+
+    async function importDriveUrl() {
+      const input = document.getElementById('drive-url-input');
+      const url = input.value.trim();
+      if (!url) return;
+      const btn = document.getElementById('drive-import-btn');
+      const progress = document.getElementById('drive-import-progress');
+      const result = document.getElementById('drive-import-result');
+      btn.disabled = true;
+      progress.style.display = '';
+      result.style.display = 'none';
+      try {
+        const data = await api('/api/import/drive/sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ urls: [url] }),
+        });
+        result.style.display = '';
+        let html = `Imported <strong>${data.items_added}</strong> items`;
+        if (data.items_skipped) html += `, ${data.items_skipped} skipped`;
+        if (data.errors.length) {
+          html += `<br><span style="color:var(--error)">${data.errors.length} errors</span>`;
+        }
+        result.innerHTML = html;
+        showToast(`Imported ${data.items_added} items from Drive`, 'ok');
+        input.value = '';
+      } catch (e) {
+        result.style.display = '';
+        result.innerHTML = `<span style="color:var(--error)">Import failed: ${escHtml(e.message)}</span>`;
+        showToast(`Drive import failed: ${e.message}`, 'error');
+      } finally {
+        btn.disabled = false;
+        progress.style.display = 'none';
       }
     }
 
@@ -2167,6 +2232,10 @@
       const transcriptOpt = document.getElementById('capture-transcript-option');
       transcriptOpt.style.display = _isYouTubeUrl(url) ? 'block' : 'none';
       document.getElementById('capture-fetch-transcript').checked = true;
+      // Show Drive import option for Drive/Docs URLs
+      const driveOpt = document.getElementById('capture-drive-option');
+      driveOpt.style.display = _isDriveOrDocsUrl(url) ? 'block' : 'none';
+      document.getElementById('capture-drive-import').checked = true;
       document.getElementById('capture-modal').classList.add('open');
     }
 
@@ -2197,10 +2266,25 @@
             metadata: notes ? { notes, shared_text: content } : { shared_text: content },
           }),
         });
+        // Import from Drive if Drive URL and checkbox checked
+        const importDrive = _isDriveOrDocsUrl(url)
+          && document.getElementById('capture-drive-import').checked;
         // Fetch transcript if YouTube and checkbox checked
         const fetchTranscript = _isYouTubeUrl(url)
           && document.getElementById('capture-fetch-transcript').checked;
-        if (fetchTranscript) {
+        if (importDrive) {
+          btn.textContent = 'Importing from Drive...';
+          try {
+            const result = await api('/api/import/drive/sync', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ urls: [url] }),
+            });
+            showToast(`Saved + imported ${result.items_added} items`, 'ok');
+          } catch (e) {
+            showToast('Saved (Drive import failed)', 'ok');
+          }
+        } else if (fetchTranscript) {
           btn.textContent = 'Fetching transcript...';
           try {
             const result = await api('/api/youtube/fetch-transcript', {

--- a/packages/lestash-server/src/lestash_server/models.py
+++ b/packages/lestash-server/src/lestash_server/models.py
@@ -157,6 +157,21 @@ class DriveImportRequest(BaseModel):
     file_ids: list[str]
 
 
+class DriveSyncRequest(BaseModel):
+    """Request to sync Google Drive files/folders with Docling conversion."""
+
+    urls: list[str]
+
+
+class DriveSyncResponse(BaseModel):
+    """Response from Drive sync import."""
+
+    status: str
+    items_added: int
+    items_skipped: int
+    errors: list[str]
+
+
 class RefineRequest(BaseModel):
     """Request to refine a transcript via LLM."""
 

--- a/packages/lestash-server/src/lestash_server/routes/imports.py
+++ b/packages/lestash-server/src/lestash_server/routes/imports.py
@@ -10,7 +10,12 @@ from io import BytesIO
 from fastapi import APIRouter, HTTPException, UploadFile
 
 from lestash_server.deps import get_db
-from lestash_server.models import DriveImportRequest, ImportResponse
+from lestash_server.models import (
+    DriveImportRequest,
+    DriveSyncRequest,
+    DriveSyncResponse,
+    ImportResponse,
+)
 from lestash_server.parsers.json_items import parse_json_items
 
 logger = logging.getLogger(__name__)
@@ -231,6 +236,58 @@ async def import_from_drive(body: DriveImportRequest):
             )
 
     return results
+
+
+@router.post("/api/import/drive/sync", response_model=DriveSyncResponse)
+async def sync_from_drive(body: DriveSyncRequest):
+    """Import Google Drive files/folders with Docling markdown conversion.
+
+    Accepts Drive URLs, Google Docs URLs, folder URLs, or bare file IDs.
+    Files are downloaded, converted to markdown, and stored as items.
+    """
+    from lestash.core.database import upsert_item
+    from lestash.core.google_drive import (
+        classify_drive_url,
+        sync_drive_folder,
+        sync_single_file,
+    )
+
+    items_added = 0
+    items_skipped = 0
+    errors: list[str] = []
+
+    for url in body.urls:
+        try:
+            url_type, file_id = classify_drive_url(url)
+
+            if url_type == "folder":
+                with get_db() as conn:
+                    for item in sync_drive_folder(file_id, recursive=True):
+                        try:
+                            upsert_item(conn, item)
+                            items_added += 1
+                        except Exception as e:
+                            errors.append(f"{item.title}: {e}")
+                    conn.commit()
+            elif url_type == "file":
+                item = sync_single_file(file_id)
+                with get_db() as conn:
+                    upsert_item(conn, item)
+                    conn.commit()
+                items_added += 1
+            else:
+                errors.append(f"Could not parse URL: {url}")
+                items_skipped += 1
+        except Exception as e:
+            logger.exception("Failed to sync %s", url)
+            errors.append(f"{url}: {e}")
+
+    return DriveSyncResponse(
+        status="completed" if not errors else "completed_with_errors",
+        items_added=items_added,
+        items_skipped=items_skipped,
+        errors=errors,
+    )
 
 
 def _parse_zip(data: bytes):

--- a/packages/lestash/src/lestash/core/google_drive.py
+++ b/packages/lestash/src/lestash/core/google_drive.py
@@ -46,6 +46,37 @@ def extract_folder_id(url_or_id: str) -> str:
     return url_or_id
 
 
+def extract_file_id(url_or_id: str) -> str:
+    """Extract a Google Drive/Docs file ID from a URL or return as-is."""
+    # Match /d/<id> in Drive and Docs URLs
+    match = re.search(r"/d/([a-zA-Z0-9_-]+)", url_or_id)
+    if match:
+        return match.group(1)
+    # Match id= parameter
+    match = re.search(r"[?&]id=([a-zA-Z0-9_-]+)", url_or_id)
+    if match:
+        return match.group(1)
+    return url_or_id
+
+
+def classify_drive_url(url: str) -> tuple[str, str]:
+    """Classify a Google Drive/Docs URL and extract its ID.
+
+    Returns:
+        Tuple of (type, id) where type is 'folder', 'file', or 'unknown'.
+    """
+    if re.search(r"drive\.google\.com/drive/folders/", url):
+        return "folder", extract_folder_id(url)
+    if re.search(r"(drive\.google\.com/file/d/|docs\.google\.com/\w+/d/)", url):
+        return "file", extract_file_id(url)
+    if re.search(r"/d/[a-zA-Z0-9_-]+", url):
+        return "file", extract_file_id(url)
+    # Bare ID — assume file
+    if re.match(r"^[a-zA-Z0-9_-]{10,}$", url):
+        return "file", url
+    return "unknown", url
+
+
 def list_drive_folder(
     service,
     folder_id: str,
@@ -182,15 +213,52 @@ def file_to_item(file_meta: dict, content: str) -> ItemCreate:
     )
 
 
+def _process_file(service, file_meta: dict) -> ItemCreate:
+    """Download/export a single file, convert to markdown, return ItemCreate."""
+    from lestash.core.text_extract import extract_content
+
+    file_id = file_meta["id"]
+    name = file_meta["name"]
+    mime_type = file_meta.get("mimeType", "")
+
+    logger.info("Processing %s (%s)", name, mime_type)
+
+    content = ""
+    try:
+        # Google Workspace files need export, not download
+        if mime_type in EXPORTABLE_MIMES:
+            path = _export_google_file(service, file_id, name, mime_type)
+            export_mime, _ = EXPORTABLE_MIMES[mime_type]
+        else:
+            path = _download_file(service, file_id, name)
+            export_mime = mime_type
+
+        try:
+            content = extract_content(path, export_mime)
+        finally:
+            path.unlink(missing_ok=True)
+    except Exception:
+        logger.exception("Failed to download/extract %s", name)
+
+    return file_to_item(file_meta, content)
+
+
+def _filter_syncable(files: list[dict]) -> list[dict]:
+    """Filter out folders and non-document files."""
+    return [
+        f
+        for f in files
+        if f.get("mimeType") != FOLDER_MIME
+        and not any(f.get("mimeType", "").startswith(p) for p in SKIP_MIME_PREFIXES)
+    ]
+
+
 def sync_drive_folder(
     folder_id: str,
     since: str | None = None,
     recursive: bool = False,
 ) -> Iterator[ItemCreate]:
     """Sync files from a Google Drive folder, yielding ItemCreate objects.
-
-    Downloads each file to a local cache, converts to markdown via Docling,
-    and yields an ItemCreate with the full markdown content.
 
     Args:
         folder_id: Google Drive folder ID or URL.
@@ -201,42 +269,31 @@ def sync_drive_folder(
         ItemCreate objects ready for database upsert.
     """
     from lestash.core.google_auth import get_drive_service
-    from lestash.core.text_extract import extract_content
 
     folder_id = extract_folder_id(folder_id)
     service = get_drive_service()
     files = list_drive_folder(service, folder_id, since=since, recursive=recursive)
-
-    # Skip folders and non-document files (images, audio, video, binary)
-    files = [
-        f
-        for f in files
-        if f.get("mimeType") != FOLDER_MIME
-        and not any(f.get("mimeType", "").startswith(p) for p in SKIP_MIME_PREFIXES)
-    ]
+    files = _filter_syncable(files)
 
     for file_meta in files:
-        file_id = file_meta["id"]
-        name = file_meta["name"]
-        mime_type = file_meta.get("mimeType", "")
+        yield _process_file(service, file_meta)
 
-        logger.info("Processing %s (%s)", name, mime_type)
 
-        content = ""
-        try:
-            # Google Workspace files need export, not download
-            if mime_type in EXPORTABLE_MIMES:
-                path = _export_google_file(service, file_id, name, mime_type)
-                export_mime, _ = EXPORTABLE_MIMES[mime_type]
-            else:
-                path = _download_file(service, file_id, name)
-                export_mime = mime_type
+def sync_single_file(file_id: str) -> ItemCreate:
+    """Download/export a single Drive file and return an ItemCreate.
 
-            try:
-                content = extract_content(path, export_mime)
-            finally:
-                path.unlink(missing_ok=True)
-        except Exception:
-            logger.exception("Failed to download/extract %s", name)
+    Args:
+        file_id: Google Drive file ID.
 
-        yield file_to_item(file_meta, content)
+    Returns:
+        ItemCreate with markdown content.
+    """
+    from lestash.core.google_auth import get_drive_service
+
+    service = get_drive_service()
+    file_meta = (
+        service.files()
+        .get(fileId=file_id, fields="id,name,mimeType,size,modifiedTime,webViewLink")
+        .execute()
+    )
+    return _process_file(service, file_meta)


### PR DESCRIPTION
## Summary

- New `POST /api/import/drive/sync` server endpoint — accepts Drive URLs, Google Docs URLs, folder URLs, or file IDs. Downloads, exports Google Workspace files, converts via Docling, and upserts as `google-drive` items.
- **Sources tab**: "Google Drive Import" section with URL input (visible when Google auth connected)
- **Capture dialog**: Detects Drive/Docs URLs and shows "Import as document" checkbox — works automatically when sharing from Google Drive on Android
- Refactored `google_drive.py`: extracted `sync_single_file()`, `classify_drive_url()`, `_process_file()`, `_filter_syncable()` for reuse

Partially closes #51

## How it works

1. **Web UI (Sources tab)**: Paste a Drive URL → click Import → server downloads + Docling converts → item created
2. **Android share**: Share Drive link from Google Drive app → capture dialog opens → "Import as document" checkbox auto-checked → Save triggers server-side conversion
3. **Folder support**: Paste a folder URL → recursively imports all documents (skips images/audio/binary)

## Test plan

- [x] CI passes
- [x] Paste a Google Doc URL in Sources tab → imports with markdown content
- [x] Paste a Drive folder URL → imports multiple items
- [ ] Share a Drive URL via capture dialog → "Import as document" option works
- [ ] Drive import section hidden when Google auth not connected