### PR TITLE
fix(chrome): support Gemini shared URLs

### DIFF
--- a/extensions/chrome/content-scripts/gemini.js
+++ b/extensions/chrome/content-scripts/gemini.js
@@ -28,23 +28,26 @@ const SELECTORS = {
  */
 function extractGeminiConversation() {
   const url = window.location.href;
-  const match = url.match(/\/app\/([a-f0-9]+)/);
+  const appMatch = url.match(/\/app\/([a-f0-9]+)/);
+  const shareMatch = url.match(/\/share\/([a-f0-9]+)/);
+  const match = appMatch || shareMatch;
   if (!match) return null;
 
   const conversationId = match[1];
+  const isShared = !!shareMatch;
 
-  // Title: try active sidebar entry first, fall back to page title / first prompt
+  // Title: try active sidebar entry (not available on shared pages)
   let title = 'Untitled';
-  const activeLink = document.querySelector(SELECTORS.activeConversation);
-  if (activeLink) {
-    const titleEl = activeLink.querySelector(SELECTORS.conversationTitle);
-    if (titleEl) title = titleEl.textContent.trim();
-  }
+  let isPinned = false;
 
-  // Pinned state
-  const isPinned = activeLink
-    ? !!activeLink.querySelector(SELECTORS.pinnedIcon)
-    : false;
+  if (!isShared) {
+    const activeLink = document.querySelector(SELECTORS.activeConversation);
+    if (activeLink) {
+      const titleEl = activeLink.querySelector(SELECTORS.conversationTitle);
+      if (titleEl) title = titleEl.textContent.trim();
+      isPinned = !!activeLink.querySelector(SELECTORS.pinnedIcon);
+    }
+  }
 
   // Extract turns
   const turnEls = document.querySelectorAll(SELECTORS.turnContainer);
@@ -92,9 +95,10 @@ function extractGeminiConversation() {
   }
 
   return {
-    conversation_id: `c_${conversationId}`,
+    conversation_id: isShared ? `share_${conversationId}` : `c_${conversationId}`,
     title,
     is_pinned: isPinned,
+    is_shared: isShared,
     url,
     turns,
   };

--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -20,7 +20,10 @@
   "options_page": "options/options.html",
   "content_scripts": [
     {
-      "matches": ["https://gemini.google.com/app/*"],
+      "matches": [
+        "https://gemini.google.com/app/*",
+        "https://gemini.google.com/share/*"
+      ],
       "js": ["content-scripts/gemini.js"],
       "run_at": "document_idle"
     }

--- a/extensions/chrome/popup/popup.js
+++ b/extensions/chrome/popup/popup.js
@@ -18,7 +18,11 @@ let isGeminiPage = false;
   // Get active tab
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   activeTab = tab;
-  isGeminiPage = tab.url && tab.url.startsWith('https://gemini.google.com/app/');
+  isGeminiPage = tab.url && (
+    tab.url.startsWith('https://gemini.google.com/app/') ||
+    tab.url.startsWith('https://gemini.google.com/share/')
+  );
+  const isGeminiShared = tab.url && tab.url.startsWith('https://gemini.google.com/share/');
 
   // Check config
   const config = await LeStashAPI.getConfig();
@@ -62,6 +66,9 @@ let isGeminiPage = false;
   // Show Gemini section if on gemini.google.com
   if (isGeminiPage) {
     geminiSection.style.display = '';
+    if (isGeminiShared) {
+      $('#save-all-gemini').style.display = 'none';
+    }
     loadGeminiInfo();
   }
 })();


### PR DESCRIPTION
## Summary

- Extend Chrome extension to import Gemini conversations from shared links (`g.co/gemini/share/xxx` -> `gemini.google.com/share/xxx`)
- Content script now matches both `/app/*` and `/share/*` paths
- Shared pages skip sidebar lookups (read-only view, no sidebar)
- Source ID uses `share_` prefix to distinguish from owned conversations (`c_`)
- "Save All" button hidden on shared pages (no sidebar to enumerate)

## Files changed

- `extensions/chrome/manifest.json` — add `/share/*` match pattern
- `extensions/chrome/content-scripts/gemini.js` — dual URL matching, shared-aware extraction
- `extensions/chrome/popup/popup.js` — detect share URLs, hide bulk button

## Test plan

- [ ] Open a regular conversation (`/app/{id}`) — both buttons work as before
- [ ] Open a shared link (`/share/{id}`) — "Save This Conversation" works, "Save All" hidden
- [ ] Verify saved item has `source_id: share_xxx` and `metadata.is_shared: true`
- [ ] Title falls back to first prompt on shared pages