### PR TITLE
feat(import): HTML page import with auto-detection and type picker

### DIFF
--- a/app/android-src/MainActivity.kt
+++ b/app/android-src/MainActivity.kt
@@ -42,6 +42,27 @@ class MainActivity : TauriActivity() {
 
             json.put("filePath", tempFile.absolutePath)
             json.put("fileName", fileName)
+        } else if (mimeType == "text/html" || mimeType == "application/xhtml+xml") {
+            // HTML file share: try file stream first, fall back to text
+            val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
+            if (uri != null) {
+                val fileName = getFileName(uri) ?: "shared_page.html"
+                val tempFile = File(cacheDir, "shared_${System.currentTimeMillis()}.html")
+                try {
+                    contentResolver.openInputStream(uri)?.use { input ->
+                        tempFile.outputStream().use { output -> input.copyTo(output) }
+                    } ?: return
+                } catch (e: Exception) {
+                    return
+                }
+                json.put("filePath", tempFile.absolutePath)
+                json.put("fileName", fileName)
+            } else {
+                val text = intent.getStringExtra(Intent.EXTRA_TEXT) ?: return
+                json.put("text", text)
+                val subject = intent.getStringExtra(Intent.EXTRA_SUBJECT)
+                if (subject != null) json.put("subject", subject)
+            }
         } else if (mimeType.startsWith("text/")) {
             val text = intent.getStringExtra(Intent.EXTRA_TEXT) ?: return
             json.put("text", text)

--- a/app/src-tauri/src/share.rs
+++ b/app/src-tauri/src/share.rs
@@ -116,6 +116,8 @@ pub async fn read_shared_file(
         "ogg" => "audio/ogg",
         "flac" => "audio/flac",
         "webm" => "audio/webm",
+        "html" | "htm" => "text/html",
+        "xhtml" => "application/xhtml+xml",
         _ => "application/octet-stream",
     };
 

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -696,10 +696,10 @@
       <!-- Import section -->
       <div style="margin-bottom:1.5rem">
         <h3 style="font-size:0.85rem;color:var(--muted);margin-bottom:0.5rem">Import</h3>
-        <input type="file" id="import-file" accept=".zip,.json" style="display:none">
+        <input type="file" id="import-file" accept=".zip,.json,.html,.htm" style="display:none">
         <div class="import-dropzone" id="import-dropzone">
           Drop a file here or <a href="#" onclick="document.getElementById('import-file').click();return false">browse</a>
-          <div style="font-size:0.75rem;margin-top:0.4rem">JSON, Google Takeout (Gemini, Keep)</div>
+          <div style="font-size:0.75rem;margin-top:0.4rem">JSON, Google Takeout, HTML pages</div>
         </div>
         <div id="import-progress" style="display:none;padding:0.75rem;color:var(--muted)">
           <span class="spinner"></span> Importing...
@@ -876,6 +876,30 @@
       <div class="modal-actions">
         <button class="btn-cancel" onclick="closeCaptureDialog()">Cancel</button>
         <button class="btn-save" id="capture-save-btn" onclick="saveCaptureItem()">Save</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- HTML import dialog (file share / upload) -->
+  <div class="modal-overlay" id="html-import-modal">
+    <div class="modal" style="max-width:500px">
+      <h2>Import HTML Page</h2>
+      <div id="html-import-preview" style="font-size:0.8rem;color:var(--muted);margin-bottom:0.75rem;padding:0.5rem;background:var(--bg);border-radius:4px;border:1px solid var(--border)"></div>
+      <label for="html-import-type">Page type</label>
+      <select id="html-import-type" style="width:100%;padding:0.4rem 0.6rem;font-family:inherit;font-size:0.8rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;margin-bottom:0.75rem;cursor:pointer">
+        <option value="auto">Auto-detect</option>
+        <option value="gemini">Gemini conversation</option>
+        <option value="chatgpt">ChatGPT conversation</option>
+        <option value="article">Article</option>
+        <option value="unknown">Raw HTML</option>
+      </select>
+      <label for="html-import-url">Source URL (optional)</label>
+      <input type="url" id="html-import-url" placeholder="https://gemini.google.com/share/..." style="margin-bottom:0.75rem">
+      <label for="html-import-notes">Notes (optional)</label>
+      <textarea id="html-import-notes" style="width:100%;min-height:60px;font-family:inherit;font-size:0.8rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:0.4rem 0.6rem;resize:vertical;margin-bottom:0.75rem" placeholder="Your annotations..."></textarea>
+      <div class="modal-actions">
+        <button class="btn-cancel" onclick="closeHtmlImportDialog()">Cancel</button>
+        <button class="btn-save" id="html-import-save-btn" onclick="saveHtmlImport()">Import</button>
       </div>
     </div>
   </div>
@@ -2308,6 +2332,71 @@
       }
     }
 
+    /* ── HTML Import Dialog ─��� */
+    let _pendingHtmlFile = null; // File object for web upload, or {base64, fileName} for Android
+
+    function _detectHtmlType(html) {
+      if (html.includes('user-query') && html.includes('model-response')) return 'gemini';
+      if (html.includes('data-message-author-role')) return 'chatgpt';
+      if (html.includes('<article')) return 'article';
+      return 'unknown';
+    }
+
+    function _htmlTypeLabel(type) {
+      return { gemini: 'Gemini conversation', chatgpt: 'ChatGPT conversation', article: 'Article', unknown: 'Unknown' }[type] || type;
+    }
+
+    function openHtmlImportDialog(fileOrData, htmlText) {
+      _pendingHtmlFile = fileOrData;
+      const detected = _detectHtmlType(htmlText);
+      const preview = document.getElementById('html-import-preview');
+      const snippet = htmlText.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 200);
+      preview.textContent = `Detected: ${_htmlTypeLabel(detected)} — ${snippet}...`;
+      document.getElementById('html-import-type').value = detected === 'unknown' ? 'auto' : detected;
+      document.getElementById('html-import-url').value = '';
+      document.getElementById('html-import-notes').value = '';
+      document.getElementById('html-import-modal').classList.add('open');
+    }
+
+    function closeHtmlImportDialog() {
+      document.getElementById('html-import-modal').classList.remove('open');
+      _pendingHtmlFile = null;
+    }
+
+    async function saveHtmlImport() {
+      const btn = document.getElementById('html-import-save-btn');
+      btn.disabled = true;
+      btn.textContent = 'Importing...';
+      try {
+        const formData = new FormData();
+        if (_pendingHtmlFile instanceof File) {
+          formData.append('file', _pendingHtmlFile);
+        } else if (_pendingHtmlFile && _pendingHtmlFile.base64) {
+          const byteStr = atob(_pendingHtmlFile.base64);
+          const bytes = new Uint8Array(byteStr.length);
+          for (let i = 0; i < byteStr.length; i++) bytes[i] = byteStr.charCodeAt(i);
+          const file = new File([bytes], _pendingHtmlFile.fileName || 'shared_page.html', { type: 'text/html' });
+          formData.append('file', file);
+        }
+        formData.append('page_type', document.getElementById('html-import-type').value);
+        const sourceUrl = document.getElementById('html-import-url').value.trim();
+        if (sourceUrl) formData.append('source_url', sourceUrl);
+        const notes = document.getElementById('html-import-notes').value.trim();
+        if (notes) formData.append('notes', notes);
+
+        const res = await fetch(`${getApiBase()}/api/import`, { method: 'POST', body: formData });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.detail || res.status);
+        showToast(`Imported ${data.items_added} items from ${data.source_type}`, 'ok');
+        closeHtmlImportDialog();
+      } catch (e) {
+        showToast('Import failed: ' + e.message, 'error');
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Import';
+      }
+    }
+
     /* ── Share Intent Handling (Android) ── */
     async function handlePendingShare() {
       if (!IS_TAURI || !tauriInvoke) return;
@@ -2339,6 +2428,17 @@
           // Switch to Notes tab and use existing upload function
           document.querySelector('[data-tab="notes"]')?.click();
           transcribeAudioFile(file);
+        } else if (share.mimeType === 'text/html' && share.filePath) {
+          // HTML file shared — read and open import dialog
+          const fileName = share.fileName || 'shared_page.html';
+          addDebugLog('SHARE', 'read_shared_file', 'START', null, `html: ${share.filePath}`);
+          const fileData = await tauriInvoke('read_shared_file', {
+            filePath: share.filePath,
+            fileName: fileName,
+          });
+          addDebugLog('SHARE', 'read_shared_file', 'OK', null, `${fileName} (${(fileData.base64.length * 0.75 / 1024).toFixed(0)} KB)`);
+          const htmlText = atob(fileData.base64);
+          openHtmlImportDialog(fileData, htmlText);
         } else if (share.text) {
           openCaptureDialog(share);
         }
@@ -2430,6 +2530,13 @@
     });
 
     async function uploadImport(file) {
+      // HTML files get the type picker dialog
+      if (file.name.match(/\.html?$/i)) {
+        const htmlText = await file.text();
+        openHtmlImportDialog(file, htmlText);
+        return;
+      }
+
       const progress = document.getElementById('import-progress');
       const result = document.getElementById('import-result');
       progress.style.display = '';

--- a/packages/lestash-server/pyproject.toml
+++ b/packages/lestash-server/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
     "python-multipart>=0.0.9",
+    "beautifulsoup4>=4.12.0",
 ]
 
 [project.scripts]

--- a/packages/lestash-server/src/lestash_server/parsers/__init__.py
+++ b/packages/lestash-server/src/lestash_server/parsers/__init__.py
@@ -1,5 +1,6 @@
 """File parsers for import."""
 
+from lestash_server.parsers.html_page import parse_html_page
 from lestash_server.parsers.json_items import parse_json_items
 
-__all__ = ["parse_json_items"]
+__all__ = ["parse_json_items", "parse_html_page"]

--- a/packages/lestash-server/src/lestash_server/parsers/html_page.py
+++ b/packages/lestash-server/src/lestash_server/parsers/html_page.py
@@ -1,0 +1,201 @@
+"""Parse saved HTML pages into Le Stash items.
+
+Supports auto-detection of page type (Gemini, etc.) and extraction
+of structured content from the rendered DOM using BeautifulSoup.
+"""
+
+import hashlib
+import logging
+import re
+
+from bs4 import BeautifulSoup
+from lestash.models.item import ItemCreate
+
+logger = logging.getLogger(__name__)
+
+# Page type constants
+TYPE_GEMINI = "gemini"
+TYPE_CHATGPT = "chatgpt"
+TYPE_ARTICLE = "article"
+TYPE_UNKNOWN = "unknown"
+
+
+def _clean_html(html: str) -> str:
+    """Strip script, style, and SVG elements to reduce noise before parsing."""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup.find_all(["script", "style", "svg", "noscript"]):
+        tag.decompose()
+    return str(soup)
+
+
+def detect_html_type(html: str) -> str:
+    """Detect the type of HTML page from its content.
+
+    Uses lightweight string checks before full parsing.
+    """
+    # Gemini: custom elements used in the Angular app
+    if "user-query" in html and "model-response" in html:
+        return TYPE_GEMINI
+
+    # ChatGPT: stub for future implementation
+    if "data-message-author-role" in html:
+        return TYPE_CHATGPT
+
+    # Article: presence of <article> tag or og:type article
+    if "<article" in html or 'og:type" content="article' in html:
+        return TYPE_ARTICLE
+
+    return TYPE_UNKNOWN
+
+
+def parse_gemini_html(
+    html: str,
+    source_url: str | None = None,
+    notes: str | None = None,
+) -> list[ItemCreate]:
+    """Parse a saved Gemini conversation page.
+
+    Uses the same CSS selectors as the Chrome extension (gemini.js):
+    - div.conversation-container for turns
+    - user-query .query-text p.query-text-line for user prompts
+    - model-response .markdown.markdown-main-panel for responses
+    """
+    cleaned = _clean_html(html)
+    soup = BeautifulSoup(cleaned, "html.parser")
+
+    turns = soup.find_all("div", class_="conversation-container")
+    if not turns:
+        logger.warning("No conversation-container elements found in Gemini HTML")
+        return parse_generic_html(html, source_url, notes)
+
+    parts = []
+    first_prompt = None
+
+    for turn in turns:
+        # User prompt
+        query_el = turn.find("user-query")
+        if query_el:
+            lines = query_el.select(".query-text p.query-text-line")
+            if lines:
+                text = "\n".join(p.get_text(strip=True) for p in lines)
+                if text:
+                    parts.append(f"**User:** {text}")
+                    if not first_prompt:
+                        first_prompt = text
+
+        # Model response
+        response_el = turn.find("model-response")
+        if response_el:
+            md_el = response_el.select_one(".markdown.markdown-main-panel")
+            if md_el:
+                text = md_el.get_text(separator="\n", strip=True)
+                if text:
+                    parts.append(f"**Gemini:** {text}")
+
+    if not parts:
+        logger.warning("No turns extracted from Gemini HTML")
+        return parse_generic_html(html, source_url, notes)
+
+    content = "\n\n".join(parts)
+    if first_prompt:
+        title = first_prompt[:80] + ("..." if len(first_prompt) > 80 else "")
+    else:
+        title = "Untitled"
+    turn_count = len(turns)
+
+    # Generate stable source_id
+    content_hash = hashlib.sha256(content.encode()).hexdigest()[:12]
+    source_id = source_url or f"gemini-html-{content_hash}"
+
+    metadata: dict = {
+        "source": "html_import",
+        "turn_count": turn_count,
+    }
+    if source_url:
+        metadata["source_url"] = source_url
+    if notes:
+        metadata["notes"] = notes
+
+    return [
+        ItemCreate(
+            source_type="gemini",
+            source_id=source_id,
+            url=source_url,
+            title=title,
+            content=content,
+            is_own_content=False,
+            metadata=metadata,
+        )
+    ]
+
+
+def parse_generic_html(
+    html: str,
+    source_url: str | None = None,
+    notes: str | None = None,
+) -> list[ItemCreate]:
+    """Fallback parser: extract title and body text from any HTML page."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Strip noise
+    for tag in soup.find_all(["script", "style", "svg", "noscript"]):
+        tag.decompose()
+
+    title_el = soup.find("title")
+    title = title_el.get_text(strip=True) if title_el else "Untitled"
+
+    body = soup.find("body")
+    if body:
+        content = body.get_text(separator="\n", strip=True)
+    else:
+        content = soup.get_text(separator="\n", strip=True)
+
+    # Trim excessive whitespace
+    content = re.sub(r"\n{3,}", "\n\n", content)
+
+    content_hash = hashlib.sha256(content.encode()).hexdigest()[:12]
+    source_id = source_url or f"html-{content_hash}"
+
+    metadata: dict = {"source": "html_import"}
+    if source_url:
+        metadata["source_url"] = source_url
+    if notes:
+        metadata["notes"] = notes
+
+    return [
+        ItemCreate(
+            source_type="share",
+            source_id=source_id,
+            url=source_url,
+            title=title,
+            content=content,
+            is_own_content=False,
+            metadata=metadata,
+        )
+    ]
+
+
+def parse_html_page(
+    html: str,
+    page_type: str = "auto",
+    source_url: str | None = None,
+    notes: str | None = None,
+) -> tuple[list[ItemCreate], str]:
+    """Parse an HTML page, auto-detecting or using the specified type.
+
+    Returns (items, detected_type).
+    """
+    detected = detect_html_type(html) if page_type == "auto" else page_type
+
+    if detected == TYPE_GEMINI:
+        items = parse_gemini_html(html, source_url, notes)
+    elif detected == TYPE_CHATGPT:
+        # Stub: fall back to generic for now
+        logger.info("ChatGPT HTML parsing not yet implemented, using generic parser")
+        items = parse_generic_html(html, source_url, notes)
+    elif detected == TYPE_ARTICLE:
+        items = parse_generic_html(html, source_url, notes)
+    else:
+        items = parse_generic_html(html, source_url, notes)
+
+    return items, detected

--- a/packages/lestash-server/src/lestash_server/routes/imports.py
+++ b/packages/lestash-server/src/lestash_server/routes/imports.py
@@ -7,7 +7,7 @@ import zipfile
 from datetime import UTC
 from io import BytesIO
 
-from fastapi import APIRouter, HTTPException, UploadFile
+from fastapi import APIRouter, Form, HTTPException, UploadFile
 
 from lestash_server.deps import get_db
 from lestash_server.models import (
@@ -26,12 +26,23 @@ MAX_FILE_SIZE = 50 * 1024 * 1024  # 50MB
 
 
 @router.post("/api/import", response_model=ImportResponse)
-async def import_file(file: UploadFile):
+async def import_file(
+    file: UploadFile,
+    page_type: str = Form("auto"),
+    source_url: str | None = Form(None),
+    notes: str | None = Form(None),
+):
     """Import items from an uploaded file.
 
     Supports:
     - JSON array of items (.json)
     - ZIP files with known structures (Google Takeout, Claude export)
+    - HTML pages with auto-detection (Gemini, etc.)
+
+    Optional form fields for HTML imports:
+    - page_type: "auto", "gemini", "chatgpt", "article", or "unknown"
+    - source_url: original URL of the page
+    - notes: user annotations
     """
     data = await file.read()
     if len(data) > MAX_FILE_SIZE:
@@ -48,6 +59,16 @@ async def import_file(file: UploadFile):
             source_type = "json"
         elif filename.endswith(".zip"):
             items, source_type = _parse_zip(data)
+        elif filename.endswith((".html", ".htm")):
+            from lestash_server.parsers.html_page import parse_html_page
+
+            html_text = data.decode("utf-8", errors="replace")
+            items, source_type = parse_html_page(
+                html_text,
+                page_type=page_type,
+                source_url=source_url,
+                notes=notes,
+            )
         else:
             # Try JSON first, then fail
             try:
@@ -56,7 +77,7 @@ async def import_file(file: UploadFile):
             except ValueError:
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Unsupported file format: {filename}. Use .json or .zip",
+                    detail=f"Unsupported file format: {filename}. Use .json, .zip, or .html",
                 ) from None
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from None

--- a/uv.lock
+++ b/uv.lock
@@ -1093,7 +1093,7 @@ wheels = [
 
 [[package]]
 name = "le-stash-workspace"
-version = "1.39.0"
+version = "1.41.0"
 source = { virtual = "." }
 dependencies = [
     { name = "lestash" },
@@ -1144,7 +1144,7 @@ dev = [
 
 [[package]]
 name = "lestash"
-version = "1.39.0"
+version = "1.41.0"
 source = { editable = "packages/lestash" }
 dependencies = [
     { name = "docling" },
@@ -1177,7 +1177,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-arxiv"
-version = "1.39.0"
+version = "1.41.0"
 source = { editable = "packages/lestash-arxiv" }
 dependencies = [
     { name = "arxiv" },
@@ -1192,7 +1192,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-audible"
-version = "1.39.0"
+version = "1.41.0"
 source = { editable = "packages/lestash-audible" }
 dependencies = [
     { name = "audible" },
@@ -1207,7 +1207,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-bluesky"
-version = "1.39.0"
+version = "1.41.0"
 source = { editable = "packages/lestash-bluesky" }
 dependencies = [
     { name = "atproto" },
@@ -1222,7 +1222,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-linkedin"
-version = "1.39.0"
+version = "1.41.0"
 source = { editable = "packages/lestash-linkedin" }
 dependencies = [
     { name = "authlib" },
@@ -1239,7 +1239,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-microblog"
-version = "1.39.0"
+version = "1.41.0"
 source = { editable = "packages/lestash-microblog" }
 dependencies = [
     { name = "httpx" },
@@ -1254,9 +1254,10 @@ requires-dist = [
 
 [[package]]
 name = "lestash-server"
-version = "1.39.0"
+version = "1.41.0"
 source = { editable = "packages/lestash-server" }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "fastapi" },
     { name = "lestash" },
     { name = "lestash-voice" },
@@ -1266,6 +1267,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "lestash", editable = "packages/lestash" },
     { name = "lestash-voice", editable = "packages/lestash-voice" },
@@ -1275,7 +1277,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-voice"
-version = "1.39.0"
+version = "1.41.0"
 source = { editable = "packages/lestash-voice" }
 dependencies = [
     { name = "faster-whisper" },
@@ -1290,7 +1292,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-youtube"
-version = "1.39.0"
+version = "1.41.0"
 source = { editable = "packages/lestash-youtube" }
 dependencies = [
     { name = "google-api-python-client" },
@@ -1910,9 +1912,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "pyobjc-framework-vision" },
+    { name = "click", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pillow", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-vision", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -2441,7 +2443,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -2457,8 +2459,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -2474,8 +2476,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -2491,10 +2493,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreml" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-coreml", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Server-side HTML parser (`parsers/html_page.py`) using BeautifulSoup with the same CSS selectors as the Chrome extension
- Auto-detects Gemini conversations from saved HTML pages; extensible to ChatGPT, articles
- `POST /api/import` now accepts `.html`/`.htm` files with optional `page_type`, `source_url`, `notes` form fields
- Android share intent handles `text/html` files (before generic `text/` branch)
- Web UI: HTML uploads show type picker dialog with source URL and notes fields
- Explicit `beautifulsoup4` dependency added to lestash-server

Enables importing Gemini conversations from shared links by saving the page as HTML and sharing/uploading it — no headless browser needed.

## Files changed

| File | Change |
|---|---|
| `packages/lestash-server/src/lestash_server/parsers/html_page.py` | NEW — HTML parser with auto-detection |
| `packages/lestash-server/src/lestash_server/parsers/__init__.py` | Export new parser |
| `packages/lestash-server/src/lestash_server/routes/imports.py` | .html handling + Form fields |
| `packages/lestash-server/pyproject.toml` | Add beautifulsoup4 |
| `app/android-src/MainActivity.kt` | text/html MIME handling |
| `app/src-tauri/src/share.rs` | html MIME type mapping |
| `app/src/index.html` | HTML import modal, share handler, web upload |

## Test plan

- [ ] `curl -F "file=@gemini.html" -F "page_type=auto" https://...:8444/api/import` → detects Gemini, creates item
- [ ] Upload HTML via web UI → type picker shows, save works
- [ ] Upload non-Gemini HTML → falls back to "share" source_type
- [ ] Verify `source_url` and `notes` stored in metadata
- [ ] Share HTML file from Android to Le Stash → import dialog appears
- [ ] Re-import same HTML → upserts (no duplicate)