### PR TITLE
feat(app): share PDFs from Android with Docling extraction

### DIFF
--- a/app/android-src/MainActivity.kt
+++ b/app/android-src/MainActivity.kt
@@ -116,6 +116,19 @@ class MainActivity : TauriActivity() {
 
             json.put("filePath", tempFile.absolutePath)
             json.put("fileName", fileName)
+        } else if (mimeType == "application/pdf") {
+            val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM) ?: return
+            val fileName = getFileName(uri) ?: "shared.pdf"
+            val tempFile = File(cacheDir, "shared_${System.currentTimeMillis()}.pdf")
+            try {
+                contentResolver.openInputStream(uri)?.use { input ->
+                    tempFile.outputStream().use { output -> input.copyTo(output) }
+                } ?: return
+            } catch (e: Exception) {
+                return
+            }
+            json.put("filePath", tempFile.absolutePath)
+            json.put("fileName", fileName)
         } else if (mimeType == "text/html" || mimeType == "application/xhtml+xml") {
             // HTML file share: try file stream first, fall back to text
             val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)

--- a/app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -53,6 +53,11 @@
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/pdf" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="application/octet-stream" />
             </intent-filter>
         </activity>

--- a/app/src-tauri/gen/android/app/src/main/java/dev/lestash/app/MainActivity.kt
+++ b/app/src-tauri/gen/android/app/src/main/java/dev/lestash/app/MainActivity.kt
@@ -116,6 +116,19 @@ class MainActivity : TauriActivity() {
 
             json.put("filePath", tempFile.absolutePath)
             json.put("fileName", fileName)
+        } else if (mimeType == "application/pdf") {
+            val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM) ?: return
+            val fileName = getFileName(uri) ?: "shared.pdf"
+            val tempFile = File(cacheDir, "shared_${System.currentTimeMillis()}.pdf")
+            try {
+                contentResolver.openInputStream(uri)?.use { input ->
+                    tempFile.outputStream().use { output -> input.copyTo(output) }
+                } ?: return
+            } catch (e: Exception) {
+                return
+            }
+            json.put("filePath", tempFile.absolutePath)
+            json.put("fileName", fileName)
         } else if (mimeType == "text/html" || mimeType == "application/xhtml+xml") {
             // HTML file share: try file stream first, fall back to text
             val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
@@ -157,6 +170,18 @@ class MainActivity : TauriActivity() {
                         return
                     }
                     json.put("mimeType", "text/html")
+                    json.put("filePath", tempFile.absolutePath)
+                    json.put("fileName", fileName)
+                } else if (fileName.endsWith(".pdf", ignoreCase = true)) {
+                    val tempFile = File(cacheDir, "shared_${System.currentTimeMillis()}.pdf")
+                    try {
+                        contentResolver.openInputStream(uri)?.use { input ->
+                            tempFile.outputStream().use { output -> input.copyTo(output) }
+                        } ?: return
+                    } catch (e: Exception) {
+                        return
+                    }
+                    json.put("mimeType", "application/pdf")
                     json.put("filePath", tempFile.absolutePath)
                     json.put("fileName", fileName)
                 } else {

--- a/app/src-tauri/src/share.rs
+++ b/app/src-tauri/src/share.rs
@@ -131,6 +131,7 @@ pub async fn read_shared_file(
         "avif" => "image/avif",
         "bmp" => "image/bmp",
         "svg" => "image/svg+xml",
+        "pdf" => "application/pdf",
         _ => "application/octet-stream",
     };
 

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -755,10 +755,10 @@
       <!-- Import section -->
       <div style="margin-bottom:1.5rem">
         <h3 style="font-size:0.85rem;color:var(--muted);margin-bottom:0.5rem">Import</h3>
-        <input type="file" id="import-file" accept=".zip,.json,.html,.htm" style="display:none">
+        <input type="file" id="import-file" accept=".zip,.json,.html,.htm,.pdf" style="display:none">
         <div class="import-dropzone" id="import-dropzone">
           Drop a file here or <a href="#" onclick="document.getElementById('import-file').click();return false">browse</a>
-          <div style="font-size:0.75rem;margin-top:0.4rem">JSON, Google Takeout, HTML pages</div>
+          <div style="font-size:0.75rem;margin-top:0.4rem">JSON, Google Takeout, HTML pages, PDF</div>
         </div>
         <div id="import-progress" style="display:none;padding:0.75rem;color:var(--muted)">
           <span class="spinner"></span> Importing...
@@ -3268,6 +3268,20 @@
           addDebugLog('SHARE', 'read_shared_file', 'OK', null, `${fileName} (${(fileData.base64.length * 0.75 / 1024).toFixed(0)} KB)`);
           const htmlText = atob(fileData.base64);
           openHtmlImportDialog(fileData, htmlText);
+        } else if (share.mimeType === 'application/pdf' && share.filePath) {
+          const fileName = share.fileName || 'shared.pdf';
+          addDebugLog('SHARE', 'read_shared_file', 'START', null, `pdf: ${share.filePath}`);
+          const fileData = await tauriInvoke('read_shared_file', {
+            filePath: share.filePath,
+            fileName: fileName,
+          });
+          const byteStr = atob(fileData.base64);
+          const bytes = new Uint8Array(byteStr.length);
+          for (let i = 0; i < byteStr.length; i++) bytes[i] = byteStr.charCodeAt(i);
+          const file = new File([bytes], fileData.fileName, { type: 'application/pdf' });
+          addDebugLog('SHARE', 'read_shared_file', 'OK', null, `${file.name} (${(file.size / 1024).toFixed(0)} KB)`);
+          document.querySelector('[data-tab="sources"]')?.click();
+          await uploadImport(file);
         } else if (share.text) {
           openCaptureDialog(share);
         }

--- a/packages/lestash-server/src/lestash_server/routes/imports.py
+++ b/packages/lestash-server/src/lestash_server/routes/imports.py
@@ -1,15 +1,18 @@
 """File import endpoint."""
 
 import contextlib
+import hashlib
 import json
 import logging
+import tempfile
 import zipfile
 from datetime import UTC
 from io import BytesIO
+from pathlib import Path
 
 from fastapi import APIRouter, Form, HTTPException, UploadFile
 
-from lestash_server.deps import get_db
+from lestash_server.deps import get_config, get_db
 from lestash_server.models import (
     DriveImportRequest,
     DriveSyncRequest,
@@ -38,6 +41,7 @@ async def import_file(
     - JSON array of items (.json)
     - ZIP files with known structures (Google Takeout, Claude export)
     - HTML pages with auto-detection (Gemini, etc.)
+    - PDF documents (text extracted via Docling, original saved as media)
 
     Optional form fields for HTML imports:
     - page_type: "auto", "gemini", "chatgpt", "article", or "unknown"
@@ -69,6 +73,8 @@ async def import_file(
                 source_url=source_url,
                 notes=notes,
             )
+        elif filename.lower().endswith(".pdf"):
+            return _import_pdf(data, filename, errors)
         else:
             # Try JSON first, then fail
             try:
@@ -77,7 +83,9 @@ async def import_file(
             except ValueError:
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Unsupported file format: {filename}. Use .json, .zip, or .html",
+                    detail=(
+                        f"Unsupported file format: {filename}. Use .json, .zip, .html, or .pdf"
+                    ),
                 ) from None
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from None
@@ -189,6 +197,58 @@ def _insert_items_with_parents(conn, items):
     # Also handle items without parent markers (flat items)
     conn.commit()
     return items_added, errors
+
+
+def _import_pdf(data: bytes, filename: str, errors: list[str]) -> ImportResponse:
+    """Import a PDF: extract markdown via Docling, save original as media."""
+    from lestash.core.database import add_item_media, save_media_file
+    from lestash.core.text_extract import extract_content
+    from lestash.models.item import ItemCreate
+
+    sha = hashlib.sha256(data).hexdigest()[:16]
+    display_name = filename.rsplit("/", 1)[-1]
+    title = display_name[:-4] if display_name.lower().endswith(".pdf") else display_name
+
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tf:
+        tf.write(data)
+        tmp_path = Path(tf.name)
+    try:
+        markdown = extract_content(tmp_path, "application/pdf")
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    item = ItemCreate(
+        source_type="pdf",
+        source_id=sha,
+        title=title,
+        content=markdown or f"[PDF: {display_name}]",
+        is_own_content=True,
+        metadata={"filename": display_name, "size_bytes": len(data)},
+    )
+
+    items_added = 0
+    with get_db() as conn:
+        item_id = _upsert_item(conn, item)
+        if item_id:
+            rel_path = save_media_file(item_id, data, display_name, get_config())
+            add_item_media(
+                conn,
+                item_id,
+                media_type="pdf",
+                local_path=rel_path,
+                mime_type="application/pdf",
+                source_origin="upload",
+            )
+            items_added = 1
+        conn.commit()
+
+    return ImportResponse(
+        status="completed",
+        source_type="pdf",
+        items_added=items_added,
+        items_updated=0,
+        errors=errors,
+    )
 
 
 @router.post("/api/import/drive", response_model=list[ImportResponse])

--- a/packages/lestash-server/tests/test_api.py
+++ b/packages/lestash-server/tests/test_api.py
@@ -257,6 +257,104 @@ class TestImport:
         )
         assert resp.status_code == 400
 
+    def test_import_pdf_extracts_and_attaches_media(self, client, test_config):
+        """PDF import should extract markdown via Docling and save the
+        original as a media attachment of type 'pdf'."""
+        from lestash.core.database import get_connection, get_media_dir
+
+        pdf_bytes = b"%PDF-1.4 fake pdf contents for test"
+        with patch(
+            "lestash.core.text_extract.convert_to_markdown",
+            return_value="# Extracted\n\nhello",
+        ) as mock_conv:
+            resp = client.post(
+                "/api/import",
+                files={
+                    "file": ("report.pdf", io.BytesIO(pdf_bytes), "application/pdf"),
+                },
+            )
+
+        assert resp.status_code == 200
+        result = resp.json()
+        assert result["status"] == "completed"
+        assert result["source_type"] == "pdf"
+        assert result["items_added"] == 1
+        mock_conv.assert_called_once()
+
+        with get_connection(test_config) as conn:
+            row = conn.execute(
+                "SELECT id, title, content, source_type FROM items WHERE source_type = 'pdf'"
+            ).fetchone()
+            assert row is not None
+            assert row["title"] == "report"
+            assert "# Extracted" in row["content"]
+
+            media = conn.execute(
+                "SELECT media_type, mime_type, local_path, source_origin "
+                "FROM item_media WHERE item_id = ?",
+                (row["id"],),
+            ).fetchone()
+            assert media is not None
+            assert media["media_type"] == "pdf"
+            assert media["mime_type"] == "application/pdf"
+            assert media["source_origin"] == "upload"
+
+            saved = get_media_dir(test_config) / media["local_path"]
+            assert saved.is_file()
+            assert saved.read_bytes() == pdf_bytes
+
+    def test_import_pdf_docling_failure_keeps_original(self, client, test_config):
+        """If Docling returns nothing, the item is still created with a
+        placeholder body and the PDF is still saved as media."""
+        from lestash.core.database import get_connection
+
+        pdf_bytes = b"%PDF-1.4 unreadable"
+        with patch(
+            "lestash.core.text_extract.convert_to_markdown",
+            return_value="",
+        ):
+            resp = client.post(
+                "/api/import",
+                files={
+                    "file": ("scan.pdf", io.BytesIO(pdf_bytes), "application/pdf"),
+                },
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["items_added"] == 1
+
+        with get_connection(test_config) as conn:
+            row = conn.execute("SELECT content FROM items WHERE source_type = 'pdf'").fetchone()
+            assert row is not None
+            assert row["content"] == "[PDF: scan.pdf]"
+
+    def test_import_pdf_idempotent_by_content_hash(self, client, test_config):
+        """Re-importing the same PDF bytes must not create a duplicate item."""
+        from lestash.core.database import get_connection
+
+        pdf_bytes = b"%PDF-1.4 same-content"
+        with patch(
+            "lestash.core.text_extract.convert_to_markdown",
+            return_value="# md",
+        ):
+            r1 = client.post(
+                "/api/import",
+                files={"file": ("a.pdf", io.BytesIO(pdf_bytes), "application/pdf")},
+            )
+            r2 = client.post(
+                "/api/import",
+                files={"file": ("b.pdf", io.BytesIO(pdf_bytes), "application/pdf")},
+            )
+
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+
+        with get_connection(test_config) as conn:
+            rows = conn.execute(
+                "SELECT COUNT(*) AS n FROM items WHERE source_type = 'pdf'"
+            ).fetchone()
+            assert rows["n"] == 1
+
 
 class TestVoiceRefine:
     """Test POST /api/voice/refine endpoint."""

--- a/packages/lestash/tests/test_text_extract.py
+++ b/packages/lestash/tests/test_text_extract.py
@@ -1,0 +1,117 @@
+"""Tests for text_extract (Docling-backed document conversion)."""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from lestash.core.text_extract import convert_to_markdown, extract_content
+
+
+def _install_fake_docling(markdown: str) -> MagicMock:
+    """Install a fake `docling.document_converter` module so `convert_to_markdown`
+    can import it without the real (heavy) dependency being installed.
+
+    Returns the converter instance mock for assertions.
+    """
+    mock_converter_instance = MagicMock()
+    mock_result = MagicMock()
+    mock_result.document.export_to_markdown.return_value = markdown
+    mock_converter_instance.convert.return_value = mock_result
+
+    mock_class = MagicMock(return_value=mock_converter_instance)
+
+    fake_module = types.ModuleType("docling.document_converter")
+    fake_module.DocumentConverter = mock_class  # type: ignore[attr-defined]
+    fake_parent = types.ModuleType("docling")
+
+    sys.modules["docling"] = fake_parent
+    sys.modules["docling.document_converter"] = fake_module
+    return mock_converter_instance
+
+
+class TestConvertToMarkdown:
+    def test_returns_markdown_from_docling(self, tmp_path):
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"%PDF-1.4 dummy")
+
+        converter = _install_fake_docling("# Title\n\nhello")
+        try:
+            md = convert_to_markdown(pdf)
+        finally:
+            sys.modules.pop("docling.document_converter", None)
+            sys.modules.pop("docling", None)
+
+        assert md == "# Title\n\nhello"
+        converter.convert.assert_called_once_with(str(pdf))
+
+    def test_returns_empty_on_docling_failure(self, tmp_path):
+        pdf = tmp_path / "broken.pdf"
+        pdf.write_bytes(b"not really a pdf")
+
+        fake_module = types.ModuleType("docling.document_converter")
+
+        class _Boom:
+            def __init__(self):
+                raise RuntimeError("docling exploded")
+
+        fake_module.DocumentConverter = _Boom  # type: ignore[attr-defined]
+        sys.modules["docling"] = types.ModuleType("docling")
+        sys.modules["docling.document_converter"] = fake_module
+        try:
+            md = convert_to_markdown(pdf)
+        finally:
+            sys.modules.pop("docling.document_converter", None)
+            sys.modules.pop("docling", None)
+
+        assert md == ""
+
+
+class TestExtractContent:
+    def test_pdf_mime_dispatches_to_docling(self, tmp_path):
+        pdf = tmp_path / "a.pdf"
+        pdf.write_bytes(b"x")
+        with patch(
+            "lestash.core.text_extract.convert_to_markdown",
+            return_value="# md",
+        ) as mock_conv:
+            out = extract_content(pdf, "application/pdf")
+        assert out == "# md"
+        mock_conv.assert_called_once_with(pdf)
+
+    def test_docx_mime_dispatches_to_docling(self, tmp_path):
+        path = tmp_path / "a.docx"
+        path.write_bytes(b"x")
+        docx_mime = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        with patch(
+            "lestash.core.text_extract.convert_to_markdown",
+            return_value="ok",
+        ) as mock_conv:
+            out = extract_content(path, docx_mime)
+        assert out == "ok"
+        mock_conv.assert_called_once()
+
+    def test_plain_text_is_read_directly(self, tmp_path):
+        path = tmp_path / "note.txt"
+        path.write_text("hello world", encoding="utf-8")
+        assert extract_content(path, "text/plain") == "hello world"
+
+    def test_markdown_is_read_directly(self, tmp_path):
+        path = tmp_path / "note.md"
+        path.write_text("# h", encoding="utf-8")
+        assert extract_content(path, "text/markdown") == "# h"
+
+    def test_csv_is_read_directly(self, tmp_path):
+        path = tmp_path / "rows.csv"
+        path.write_text("a,b\n1,2\n", encoding="utf-8")
+        assert extract_content(path, "text/csv") == "a,b\n1,2\n"
+
+    def test_unsupported_mime_returns_empty(self, tmp_path):
+        path = tmp_path / "img.png"
+        path.write_bytes(b"\x89PNG")
+        assert extract_content(path, "image/png") == ""
+
+    def test_text_read_failure_returns_empty(self, tmp_path):
+        path = tmp_path / "missing.txt"
+        # File does not exist → read_text raises → caught → ""
+        assert extract_content(Path(path), "text/plain") == ""


### PR DESCRIPTION
## Summary
- Extend `/api/import` to accept PDFs — extract markdown via Docling and save the original as an `item_media` attachment of type `pdf`, deduped by SHA256 content hash.
- Wire the Android share intent end-to-end: `AndroidManifest.xml` intent-filter, `MainActivity.kt` PDF branch (+ `.pdf` detection in the `application/octet-stream` fallback), `share.rs` MIME map, and a PDF branch in `handlePendingShare` that switches to the Sources tab and reuses the existing `uploadImport` flow.
- Accept `.pdf` in the import file picker on the web UI.

## Tests
- `packages/lestash/tests/test_text_extract.py` — 9 unit tests for `convert_to_markdown` (success + Docling failure, via a fake `docling` module) and `extract_content` (PDF/DOCX dispatch, text/markdown/CSV direct reads, unsupported MIME, read failure).
- `packages/lestash-server/tests/test_api.py::TestImport` — 3 tests for the PDF endpoint: extraction + media attachment saved on disk, Docling-empty fallback with placeholder content, and re-import idempotency by content hash.

## Test plan
- [ ] CI green (ruff, mypy, pytest on Linux + macOS)
- [ ] Manual: `curl -F "file=@sample.pdf" https://localhost:8444/api/import -k` → item with extracted markdown + PDF at `GET /api/media/<id>`
- [ ] Manual: web UI Sources tab → Import → browse PDF → item appears in Feed with PDF attachment
- [ ] Manual: Android — share a PDF from a file manager / Drive / browser → app opens, Sources tab activates, toast shows items added, item visible in Feed with PDF attachment
- [ ] Manual: re-share same PDF → no duplicate item (source_id = sha256[:16])