### PR TITLE
feat(pdf): PDF enrichment pipeline — links, images, ink annotations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,661 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2025 Mark Thompson
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -216,4 +216,8 @@ level = "INFO"
 
 ## License
 
-[MIT](LICENSE)
+[GNU Affero General Public License v3.0 only](LICENSE) (AGPL-3.0-only).
+
+Copyright (C) 2025–2026 Matthew Thompson.
+
+LeStash uses [PyMuPDF](https://pymupdf.readthedocs.io/) (AGPL) for PDF enrichment, which obliges the project to use a compatible license. Practical implication of AGPL §13: if you run a *modified* copy of LeStash as a network service that other people interact with, you must offer those users access to the source. Personal single-user deployments are unaffected.

--- a/docs/adr/0001-pdf-enrichment-pipeline.md
+++ b/docs/adr/0001-pdf-enrichment-pipeline.md
@@ -85,16 +85,18 @@ Classification of ink strokes uses pure geometric heuristics (no ML, no external
 
 **Safety valve**: any annotation that does not match a known classifier falls through to `kind='ink_unclassified'` with raw geometry preserved. We never drop an annotation. Adding new classifiers in a later extractor version promotes existing `ink_unclassified` items on the next re-run — D4's versioning handles this cleanly.
 
-### D10: Handwriting OCR — separate, opt-in pass via external API
+### D10: Handwriting OCR — separate, opt-in pass via Claude multimodal vision
 
-Handwritten text in margin notes and unclassified ink is not OCR'd locally. A separate enrichment pass calls an external API (Google Cloud Vision / Document AI or equivalent) on demand:
+Handwritten text in margin notes and unclassified ink is not OCR'd locally. A separate enrichment pass sends the rendered annotation image to the **Claude API** (multimodal vision) on demand:
 
 - Invoked via `lestash enrich --ocr [--item-id N | --all]`.
 - Operates only on child items where `metadata.annotation_kind IN ('margin_note', 'ink_unclassified')`.
-- Renders the stroke geometry to a PNG using PyMuPDF, sends to the API, writes the OCR'd text to the child item's `content` field.
+- Renders the stroke geometry to a PNG using PyMuPDF, sends to Claude with a fixed transcription prompt, writes the OCR'd text to the child item's `content` field.
 - Idempotency keyed on `(stroke_geometry_hash, ocr_extractor_version)` — re-running does not re-spend.
 
-Kept separate from the main enricher because: it requires network + credentials + may incur cost, the main enricher must stay offline-capable, and OCR is independently versionable from the geometric extractor.
+**Why Claude vision, not Google Vision / Document AI / RapidOCR**: prior testing on real Kobo annotation samples showed RapidOCR scoring 0.50–0.70 on handwriting while Claude vision transcribed the same samples cleanly (e.g. "Add a title page", "reword this."). The `anthropic` SDK is already a project dependency, so this adds no new vendor surface area.
+
+Kept separate from the main enricher because: it requires network + API credentials + per-call cost, the main enricher must stay offline-capable, and OCR is independently versionable from the geometric extractor.
 
 ## Consequences
 

--- a/docs/adr/0001-pdf-enrichment-pipeline.md
+++ b/docs/adr/0001-pdf-enrichment-pipeline.md
@@ -1,0 +1,114 @@
+# ADR 0001: PDF Enrichment Pipeline
+
+*Status: Accepted — 2026-04-26*
+
+## Context
+
+Importing PDFs via Docling loses three classes of content that are present in the source:
+
+1. **Hyperlinks** — exist only as PDF link annotations (`/Type /Annot /Subtype /Link`), invisible to any text extractor.
+2. **Images** — replaced with `<!-- image -->` placeholders; the bytes are not retrieved.
+3. **Ink annotations** — pen marks (Kobo eReader, tablet apps) ignored entirely.
+
+Docling also injects unicode artifacts (`·` U+00B7, `◦` U+25E6) at list boundaries.
+
+We need a pipeline that:
+- recovers all three classes of content,
+- can run over previously-imported items as well as new ones,
+- is safe to re-run after extractor improvements.
+
+This ADR is the authoritative decision record. Implementation details live in [`docs/pdf-enrichment-design.md`](../pdf-enrichment-design.md).
+
+## Decisions
+
+### D1: Library — Docling + PyMuPDF
+
+Docling remains the primary extractor for its document-structure detection (headings, sections, tables, hierarchical markdown). PyMuPDF runs as a post-processing pass for the three gaps above.
+
+**Rejected:** pdfplumber (MIT) handles links well but exposes only image bounding boxes, not bytes, and has no usable ink-annotation API. pypdf (BSD) needs manual link↔text association. No MIT/BSD library covers all three gaps in one pass.
+
+### D2: License — AGPL-3.0
+
+PyMuPDF is AGPL-3.0. Adopting it as a core dependency requires the project to relicense from MIT to AGPL-3.0. Acceptable: LeStash is already public, the copyright holder is the sole contributor, and the AGPL §13 source-disclosure obligation only affects third parties who deploy modified copies as a network service — not the primary single-user use case.
+
+### D3: Pipeline shape — structured intermediate, not a string
+
+The extractor returns a structured artifact (`EnrichedPdf`), not just markdown. The artifact carries the markdown plus the lists of extracted images, links, and classified annotations. The caller decides how to persist them. This keeps `text_extract.py` pure, makes the pipeline testable without the database, and lets backfill reuse the exact same code path.
+
+### D4: Idempotency key — `(pdf_sha256, extractor_version)`
+
+Every enrichment run is keyed on the SHA-256 of the source PDF bytes plus the integer extractor version. Stored on the item. Re-running the enricher on an item whose stored key matches the current key is a no-op. Bumping `extractor_version` invalidates all prior runs and causes the next `lestash enrich --all` to reprocess everything.
+
+### D5: Source PDF retention — mandatory
+
+The original PDF must be available for re-extraction. Two cases:
+
+- **Drive-sourced**: store the Drive file ID and URL on an `item_media` row with `media_type='source_pdf'`. Re-extraction re-downloads from Drive. If the Drive file is gone, the item is marked unrunnable for that pass — never silently dropped.
+- **Direct upload**: store the PDF bytes locally via the existing media storage at `~/.lestash/media/{item_id}/{hash}.pdf`, also as `media_type='source_pdf'`.
+
+Backfill is meaningless without this — it is therefore a hard requirement, not a "nice to have".
+
+### D6: Ink annotations — child items, one per *semantic* annotation
+
+Each classified annotation (margin note, circled passage, underlined span, ink_unclassified) becomes a child item with `parent_id` set to the PDF item. Rationale:
+
+- Reuses the existing parent-child pattern (LinkedIn reactions/comments).
+- Searchable via FTS5 and embeddable for vector search out of the box.
+- Default listings already filter `parent_id IS NULL`, so they don't clutter views.
+- Each annotation can carry per-item metadata (page, bbox, color).
+
+**Important refinement**: a child item is created per *semantic annotation*, not per ink stroke. A single circle is typically 5–20 strokes — those become one child. Stroke geometries are preserved in the child's `metadata` JSON for full-fidelity replay.
+
+**Rejected:** JSON blob on `items.metadata` (annotations would not be searchable). Dedicated `item_annotations` table (additional join, no benefit over child items).
+
+### D7: Invocation — single code path, two surfaces
+
+The enricher is one function. It is called:
+
+- **Inline** from `sync()` when a new PDF item is imported.
+- **Standalone** via `lestash enrich [--item-id N | --all]` and `POST /api/items/{item_id}/enrich`.
+
+Idempotency (D4) makes it safe to call from sync and re-run later.
+
+### D8: Execution — synchronous
+
+The enricher runs synchronously in the calling process. No job queue. A 50-page PDF taking 5–10s is acceptable for a personal-scale system. Revisit only if measured pain emerges.
+
+### D9: Annotation classifier — geometric heuristics, with a safety valve
+
+Classification of ink strokes uses pure geometric heuristics (no ML, no external deps):
+
+- **Underline**: low y-variance, length above threshold.
+- **Circle/ellipse**: closed loop (endpoint distance below threshold), reasonable aspect ratio.
+- **Margin note**: bbox center in the outer X% of page width.
+- **Stroke grouping**: cluster strokes by spatial+temporal proximity before classifying.
+
+**Safety valve**: any annotation that does not match a known classifier falls through to `kind='ink_unclassified'` with raw geometry preserved. We never drop an annotation. Adding new classifiers in a later extractor version promotes existing `ink_unclassified` items on the next re-run — D4's versioning handles this cleanly.
+
+### D10: Handwriting OCR — separate, opt-in pass via external API
+
+Handwritten text in margin notes and unclassified ink is not OCR'd locally. A separate enrichment pass calls an external API (Google Cloud Vision / Document AI or equivalent) on demand:
+
+- Invoked via `lestash enrich --ocr [--item-id N | --all]`.
+- Operates only on child items where `metadata.annotation_kind IN ('margin_note', 'ink_unclassified')`.
+- Renders the stroke geometry to a PNG using PyMuPDF, sends to the API, writes the OCR'd text to the child item's `content` field.
+- Idempotency keyed on `(stroke_geometry_hash, ocr_extractor_version)` — re-running does not re-spend.
+
+Kept separate from the main enricher because: it requires network + credentials + may incur cost, the main enricher must stay offline-capable, and OCR is independently versionable from the geometric extractor.
+
+## Consequences
+
+**Positive**
+- Hyperlinks, images, and ink annotations all recovered in one pipeline.
+- Re-runnable over historical content with no special-case code.
+- Annotations are first-class searchable items.
+- Extractor improvements automatically reach old items via version bump + `lestash enrich --all`.
+
+**Negative**
+- AGPL-3.0 adoption is one-way: hard to switch back.
+- Extractor version bumps will trigger full re-processing on the next `enrich --all` run — by design, but expensive on large libraries.
+- Source PDF retention increases disk usage for direct-upload items (Drive items only store a reference).
+- Heavily-annotated PDFs may produce dozens of child items per parent.
+
+**Neutral**
+- A new `docs/adr/` convention is established. Future load-bearing decisions go here.

--- a/docs/pdf-enrichment-design.md
+++ b/docs/pdf-enrichment-design.md
@@ -1,0 +1,321 @@
+# PDF Enrichment Design
+
+*Designed 2026-04-26 — Implementation pending*
+
+Companion to [`docs/adr/0001-pdf-enrichment-pipeline.md`](adr/0001-pdf-enrichment-pipeline.md). The ADR fixes the load-bearing decisions; this document describes how to build it.
+
+## Overview
+
+A two-library pipeline that produces a fully enriched markdown item from a PDF:
+
+```
+PDF bytes ──> Docling ──> structured markdown (headings, sections, tables)
+         └─> PyMuPDF ──> links + images + ink annotations
+                    │
+                    └─> classifier ──> semantic annotations
+                                     (underline, circle, margin_note, ink_unclassified)
+
+merge ──> EnrichedPdf { content, images[], annotations[], pdf_sha256, extractor_version }
+        │
+        └─> persistence layer ──> items.content, item_media rows, child items
+```
+
+The pipeline is callable inline from sync and standalone for backfill. Idempotency is keyed on `(pdf_sha256, extractor_version)`.
+
+## Components
+
+### `lestash.core.pdf_enrich` (new module)
+
+Single public entry point:
+
+```python
+def enrich_pdf(pdf_path: Path) -> EnrichedPdf: ...
+```
+
+Pure: takes a path, returns a structured result. No DB access, no network. Trivially testable with fixture PDFs.
+
+```python
+@dataclass
+class EnrichedPdf:
+    content: str                          # markdown with [text](url) links and ![alt](placeholder:N) image refs
+    pdf_sha256: str
+    extractor_version: int
+    images: list[ExtractedImage]
+    annotations: list[ExtractedAnnotation]
+
+@dataclass
+class ExtractedImage:
+    placeholder_index: int                # which <!-- image --> in the markdown this replaces
+    page: int
+    bbox: tuple[float, float, float, float]
+    bytes: bytes
+    mime_type: str                        # 'image/png', 'image/jpeg'
+    xref_hash: str                        # sha256 of bytes — for dedup within a doc
+
+@dataclass
+class ExtractedAnnotation:
+    kind: Literal['underline', 'circle', 'margin_note', 'ink_unclassified']
+    page: int
+    bbox: tuple[float, float, float, float]
+    anchor_text: str                      # text the annotation points at, '' if none
+    color: str | None
+    strokes: list[list[tuple[float, float]]]   # raw geometry, preserved for replay
+```
+
+Internal layout:
+- `pdf_enrich/__init__.py` — `enrich_pdf` orchestrator
+- `pdf_enrich/links.py` — `extract_links(doc) -> list[Link]` and `apply_links(markdown, links) -> markdown`
+- `pdf_enrich/images.py` — `extract_images(doc) -> list[ExtractedImage]` with `xref_hash` dedup
+- `pdf_enrich/annotations.py` — `extract_annotations(doc) -> list[RawInk]` + `classify(strokes) -> ExtractedAnnotation`
+- `pdf_enrich/cleanup.py` — strip `·`/`◦` artifacts at list-item boundaries only
+- `pdf_enrich/version.py` — `EXTRACTOR_VERSION: int = 1`
+
+### `lestash.core.pdf_enrich.persistence` (DB-aware glue)
+
+Maps an `EnrichedPdf` to database mutations. Owned by the caller (CLI / API), not by the pure extractor.
+
+```python
+def persist_enrichment(conn: Connection, item_id: int, enriched: EnrichedPdf) -> None: ...
+```
+
+Responsibilities:
+- Upload images via existing `add_item_media` and rewrite `placeholder:N` refs to `/api/media/{id}`.
+- Delete prior enrichment-derived child items (`WHERE parent_id = ? AND source_type = 'pdf_annotation'`) before re-inserting the new set.
+- Write `items.content` and bump `metadata.pdf_sha256` + `metadata.extractor_version` + `metadata.enriched_at`.
+- Run inside a transaction.
+
+### `lestash.core.pdf_enrich.ocr` (separate, opt-in)
+
+```python
+def ocr_annotation(child_item_id: int, ocr_version: int) -> str | None: ...
+```
+
+Renders the stroke geometry to PNG via PyMuPDF, sends to Google Cloud Vision / Document AI, writes the result to the child item's `content`. Skipped if `metadata.ocr_version == current`. See "OCR pass" in flows.
+
+### Invocation surfaces
+
+- `lestash enrich [--item-id N | --all] [--ocr] [--force]` (CLI)
+- `POST /api/items/{item_id}/enrich` (server, idempotent body)
+- Inline call from `lestash.core.google_drive.sync()` after item insert
+
+All three resolve to the same `enrich_item(item_id)` function in `lestash.core.pdf_enrich.runner`.
+
+## Data Model Deltas
+
+### Migration 8: enrichment metadata + source-PDF role
+
+```sql
+-- No new columns: piggyback on items.metadata (JSON TEXT) and item_media.media_type.
+-- Documenting the conventions here:
+--
+-- items.metadata JSON keys (added):
+--   pdf_sha256          : str
+--   extractor_version   : int
+--   enriched_at         : ISO-8601 string
+--   enrichment_status   : 'ok' | 'source_unavailable' | 'failed'
+--
+-- item_media.media_type new values:
+--   'source_pdf'        : the original PDF, either local_path or url+Drive file ID
+--   'pdf_image'         : an image extracted from the PDF (existing 'image' continues for non-PDF media)
+--
+-- items.source_type new value for child annotations:
+--   'pdf_annotation'    : a child item created by the enricher
+--
+-- For pdf_annotation children, items.metadata JSON keys:
+--   annotation_kind     : 'underline' | 'circle' | 'margin_note' | 'ink_unclassified'
+--   page                : int
+--   bbox                : [x0, y0, x1, y1]
+--   color               : str | null
+--   strokes             : [[[x, y], ...], ...]
+--   stroke_geometry_hash: str   -- sha256 of canonicalised strokes, used as OCR cache key
+--   ocr_text            : str | null
+--   ocr_version         : int | null
+```
+
+No DDL changes are strictly required — every field fits the existing schema. The migration is a no-op SQL file whose purpose is to record the convention bump in `schema_migrations`.
+
+### Conventions, written down
+
+- **`source_type='pdf_annotation'`** identifies child items produced by the enricher. The persistence layer deletes-then-inserts these on every successful run.
+- **`media_type='source_pdf'`** identifies the original PDF. The enricher reads from this row's `local_path` or `url` (Drive ID).
+- **`media_type='pdf_image'`** identifies an enricher-produced image. These are deleted-then-inserted on every successful run, just like child items.
+- **`extractor_version`** is a single integer in `pdf_enrich/version.py`. Bump it when the extractor changes in a way that should trigger reprocessing.
+
+## Sequence Flows
+
+### Flow 1: New import (Google Drive PDF)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Sync as google_drive.sync()
+    participant DB as SQLite
+    participant FS as ~/.lestash/media
+    participant Enrich as enrich_item()
+    participant Docling
+    participant PyMuPDF
+
+    Sync->>FS: download PDF to temp path
+    Sync->>DB: INSERT item (raw Docling markdown)
+    Sync->>DB: INSERT item_media (media_type='source_pdf', url=DriveURL, drive_id)
+    Sync->>Enrich: enrich_item(item_id)
+    Enrich->>DB: SELECT source_pdf media for item
+    Enrich->>FS: read PDF bytes (or re-fetch from Drive)
+    Enrich->>Enrich: pdf_sha256 = sha256(bytes)
+    Enrich->>DB: skip if (sha256, version) matches stored
+    Enrich->>Docling: convert_to_markdown(path)
+    Enrich->>PyMuPDF: extract_links / extract_images / extract_annotations
+    PyMuPDF-->>Enrich: links, images, raw_ink
+    Enrich->>Enrich: classify(raw_ink) → semantic annotations
+    Enrich->>Enrich: apply_links + insert image placeholders + cleanup
+    Enrich->>DB: BEGIN
+    Enrich->>FS: write extracted images
+    Enrich->>DB: INSERT item_media (media_type='pdf_image') × N
+    Enrich->>DB: rewrite content with /api/media/{id}
+    Enrich->>DB: DELETE child items WHERE parent_id=? AND source_type='pdf_annotation'
+    Enrich->>DB: INSERT child items × M
+    Enrich->>DB: UPDATE items SET content=?, metadata=? WHERE id=?
+    Enrich->>DB: COMMIT
+```
+
+### Flow 2: Backfill (re-enrich existing item, same extractor version)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI as lestash enrich --item-id N
+    participant Enrich as enrich_item()
+    participant DB
+    participant FS
+
+    CLI->>Enrich: enrich_item(N, force=False)
+    Enrich->>DB: SELECT item, source_pdf media, current metadata
+    Enrich->>FS: read or re-fetch PDF
+    Enrich->>Enrich: pdf_sha256 = sha256(bytes)
+    alt sha256 + version match stored
+        Enrich-->>CLI: skip (no-op)
+    else
+        Enrich->>Enrich: run pipeline (as Flow 1, steps 7+)
+        Enrich-->>CLI: ok
+    end
+```
+
+### Flow 3: Re-extraction after extractor improvement
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Dev as Developer
+    participant CLI as lestash enrich --all
+    participant Enrich
+    participant DB
+
+    Dev->>Dev: bump EXTRACTOR_VERSION in pdf_enrich/version.py
+    Dev->>CLI: lestash enrich --all
+    CLI->>DB: SELECT items WHERE source mime is PDF
+    loop per item
+        CLI->>Enrich: enrich_item(item_id)
+        Enrich->>DB: stored extractor_version < current → run
+        Enrich->>Enrich: full pipeline
+        Note over Enrich: ink_unclassified items from old version<br/>get reclassified into richer kinds
+    end
+```
+
+### Flow 4: Handwriting OCR pass
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI as lestash enrich --ocr --all
+    participant OCR as ocr_annotation()
+    participant DB
+    participant FS
+    participant API as Google Vision / Document AI
+
+    CLI->>DB: SELECT children WHERE source_type='pdf_annotation'<br/>AND annotation_kind IN ('margin_note','ink_unclassified')<br/>AND (ocr_version IS NULL OR ocr_version < current)
+    loop per child
+        CLI->>OCR: ocr_annotation(child_id)
+        OCR->>DB: load strokes + bbox + parent's source PDF
+        OCR->>FS: render strokes to PNG via PyMuPDF
+        OCR->>API: POST image
+        API-->>OCR: text
+        OCR->>DB: UPDATE items SET content=?, metadata.ocr_text=?,<br/>metadata.ocr_version=current WHERE id=?
+    end
+```
+
+## Failure Modes
+
+| Mode | Behaviour |
+|---|---|
+| Source PDF unavailable (Drive 404, deleted, no auth) | `enrichment_status='source_unavailable'`, log warning, leave existing content intact, exit success. |
+| Docling crash | Fall through: keep prior `items.content` if any, set `enrichment_status='failed'`, log full exception. |
+| PyMuPDF crash on a single page | Page-level try/except; record empty results for that page, continue with others. |
+| Image upload fails | Roll back the entire enrichment transaction; item is left in its prior state. |
+| OCR API failure (rate limit, network, auth) | Skip child, leave its `content` unchanged, log; resumable on next `enrich --ocr` run. |
+| Image placeholder ↔ extracted-image count mismatch | Match by page-and-bbox order, not by global index; log unmatched placeholders as warnings. |
+| Stroke classifier disagreement on borderline cases | Default to `ink_unclassified` rather than guessing; safer than wrong classification. |
+
+## Edge Cases the Implementation Must Handle
+
+1. **Same image referenced multiple times in a PDF** — dedup by `xref_hash` (sha256 of bytes); upload once, reference the same media id from multiple positions in the markdown.
+2. **Anchor text appears multiple times in the document** — link replacement walks the markdown left-to-right with a cursor, consuming each link in document order, never `str.replace()` globally.
+3. **Docling DOCX inputs** — only PDF inputs go through PyMuPDF post-processing. The `convert_to_markdown` mime check stays as the gate.
+4. **Cleanup `·` / `◦`** — only stripped when they appear as the first non-whitespace character of a line that Docling marked as a list item, never globally. `m·s⁻¹` stays intact.
+5. **Drive PDFs whose file ID changes** — Drive can re-id a file on move. The enricher computes sha256 on bytes, not on Drive ID, so identity remains stable across moves.
+6. **Heavily-annotated PDFs** — a textbook with 200 highlights produces 200 child items. Acceptable; the FTS5 index and `parent_id` filter keep them out of normal listings.
+
+## Test Plan
+
+### Unit tests (no DB, no network)
+
+- `pdf_enrich/links.py` — given a doc with N links, returns N `Link` objects with correct anchor text. Anchor text appearing twice resolves to two separate replacements at distinct positions.
+- `pdf_enrich/images.py` — extracts bytes; deduplicates same xref; matches placeholder count.
+- `pdf_enrich/annotations.py` — classifier fixtures: one underline, one circle, one margin note, one scribble. Each must produce the expected `kind`. Borderline strokes must produce `ink_unclassified`, never crash.
+- `pdf_enrich/cleanup.py` — `·` inside `m·s⁻¹` survives; `·` at start of a list item is stripped.
+
+### Integration tests (DB, no network)
+
+- A small fixture PDF (2–3 pages, 5 links, 2 images, 3 annotations) committed to `packages/lestash/tests/fixtures/sample.pdf`. Full pipeline asserts: correct image count in `item_media`, correct child item count, links present in `items.content`.
+- Backfill test: insert an item with `extractor_version=0`, run `enrich_item`, assert metadata bumped and child items created.
+- Idempotency test: run `enrich_item` twice, assert second call is a no-op (no new media rows, no new children, no `items.updated_at` bump).
+
+### OCR tests
+
+- `ocr_annotation` mocked at the API client boundary; assert the rendered PNG bytes match a fixture for a known stroke set.
+- Skip-when-version-matches behaviour.
+
+### Manual verification
+
+- Run `lestash enrich --item-id 25114` ("Foundational and Canonical Works" PDF cited in #135). Assert: 23 hyperlinks rendered, 3 images served via `/api/media/`, no `<!-- image -->` placeholders left.
+
+## Dependencies
+
+```toml
+# packages/lestash/pyproject.toml — add to dependencies
+"pymupdf>=1.27.0",
+```
+
+OCR is opt-in and lives in `pdf_enrich/ocr.py`. Its API client (e.g. `google-cloud-vision`) is added as an extra so users who don't want it don't pull it:
+
+```toml
+[project.optional-dependencies]
+ocr = ["google-cloud-vision>=3.0.0"]
+```
+
+## Open Questions
+
+These are deliberately not decided yet. They are not blockers for the first implementation slice but should be answered before the second:
+
+1. **Annotation bbox stability across PDF revisions** — if a user re-uploads a slightly edited PDF, will old annotations still anchor correctly? Likely no; consider a `pdf_sha256` reference on each child to flag stale annotations.
+2. **Per-page enrichment progress** — for very large PDFs (200+ pages), should the enricher emit progress events? Out of scope for v1.
+3. **OCR cost management** — `lestash enrich --ocr --all` could cost money. Add a `--max-cost` or dry-run mode? Defer until we've measured.
+4. **Annotation rendering in the UI** — the app currently renders markdown content but not raw stroke geometry. The Tauri app may need an annotation-overlay view; tracked separately.
+
+## Implementation Slice Order
+
+1. License change + `pymupdf` dependency.
+2. `enrich_pdf` pure module: links, images, cleanup, classifier with `ink_unclassified` fallback only.
+3. Persistence layer + `lestash enrich` CLI + `POST /api/items/{id}/enrich`.
+4. Inline call from `google_drive.sync()`.
+5. Annotation classifiers (underline, circle, margin_note) — incremental, each is a `extractor_version` bump.
+6. OCR pass.

--- a/docs/pdf-enrichment-design.md
+++ b/docs/pdf-enrichment-design.md
@@ -60,6 +60,8 @@ class ExtractedAnnotation:
     anchor_text: str                      # text the annotation points at, '' if none
     color: str | None
     strokes: list[list[tuple[float, float]]]   # raw geometry, preserved for replay
+    annotation_id: str | None             # PDF /NM (annotation UUID) from annot.info["id"], used for cross-run dedup
+    created_at: str | None                # ISO-8601 from annot.info["creationDate"] (Kobo populates this)
 ```
 
 Internal layout:
@@ -67,7 +69,7 @@ Internal layout:
 - `pdf_enrich/links.py` — `extract_links(doc) -> list[Link]` and `apply_links(markdown, links) -> markdown`
 - `pdf_enrich/images.py` — `extract_images(doc) -> list[ExtractedImage]` with `xref_hash` dedup
 - `pdf_enrich/annotations.py` — `extract_annotations(doc) -> list[RawInk]` + `classify(strokes) -> ExtractedAnnotation`
-- `pdf_enrich/cleanup.py` — strip `·`/`◦` artifacts at list-item boundaries only
+- `pdf_enrich/cleanup.py` — strip `·`/`◦` artifacts when they appear as the **last** non-whitespace character of a line (Docling's actual output puts them at end-of-line, e.g. `"...and preprints. ·\n"`)
 - `pdf_enrich/version.py` — `EXTRACTOR_VERSION: int = 1`
 
 ### `lestash.core.pdf_enrich.persistence` (DB-aware glue)
@@ -90,15 +92,18 @@ Responsibilities:
 def ocr_annotation(child_item_id: int, ocr_version: int) -> str | None: ...
 ```
 
-Renders the stroke geometry to PNG via PyMuPDF, sends to Google Cloud Vision / Document AI, writes the result to the child item's `content`. Skipped if `metadata.ocr_version == current`. See "OCR pass" in flows.
+Renders the stroke geometry to PNG via PyMuPDF, sends to **Claude multimodal vision** via the existing `anthropic` SDK with a fixed transcription prompt, writes the result to the child item's `content`. Skipped if `metadata.ocr_version == current`. See "OCR pass" in flows.
+
+Claude was chosen over Google Cloud Vision / Document AI / RapidOCR because prior tests on real Kobo annotation samples showed RapidOCR scoring 0.50–0.70 on handwriting while Claude transcribed the same samples cleanly. The `anthropic` SDK is already a project dependency.
 
 ### Invocation surfaces
 
 - `lestash enrich [--item-id N | --all] [--ocr] [--force]` (CLI)
 - `POST /api/items/{item_id}/enrich` (server, idempotent body)
 - Inline call from `lestash.core.google_drive.sync()` after item insert
+- Inline call from the Kobo source plugin's sync path — Kobo-sourced PDFs arrive via either the differential USB backup (#133, dropping files into `~/.local/share/kobo-backup/pdfs/`) or the WiFi push (#134, hitting `POST /api/kobo/process-new`). Both create regular items and then call the same `enrich_item()`. Kobo PDFs are particularly valuable here because they typically carry the ink annotations the geometric classifier and OCR pass are designed for.
 
-All three resolve to the same `enrich_item(item_id)` function in `lestash.core.pdf_enrich.runner`.
+All surfaces resolve to the same `enrich_item(item_id)` function in `lestash.core.pdf_enrich.runner`. Source-of-PDF differences (Drive download, Kobo USB rsync, Kobo WiFi push, direct upload) only affect how the `source_pdf` `item_media` row is populated; the enricher itself is source-agnostic.
 
 ## Data Model Deltas
 
@@ -114,9 +119,13 @@ All three resolve to the same `enrich_item(item_id)` function in `lestash.core.p
 --   enriched_at         : ISO-8601 string
 --   enrichment_status   : 'ok' | 'source_unavailable' | 'failed'
 --
--- item_media.media_type new values:
+-- item_media.media_type new value:
 --   'source_pdf'        : the original PDF, either local_path or url+Drive file ID
---   'pdf_image'         : an image extracted from the PDF (existing 'image' continues for non-PDF media)
+--
+-- item_media.source_origin new value (existing column, default 'sync'):
+--   'enricher'          : marks an image extracted from a PDF by the enricher;
+--                         media_type stays 'image' (no new type needed — source_origin
+--                         already exists for exactly this kind of provenance distinction)
 --
 -- items.source_type new value for child annotations:
 --   'pdf_annotation'    : a child item created by the enricher
@@ -138,7 +147,7 @@ No DDL changes are strictly required — every field fits the existing schema. T
 
 - **`source_type='pdf_annotation'`** identifies child items produced by the enricher. The persistence layer deletes-then-inserts these on every successful run.
 - **`media_type='source_pdf'`** identifies the original PDF. The enricher reads from this row's `local_path` or `url` (Drive ID).
-- **`media_type='pdf_image'`** identifies an enricher-produced image. These are deleted-then-inserted on every successful run, just like child items.
+- **`media_type='image'` with `source_origin='enricher'`** identifies an enricher-produced image. These are deleted-then-inserted on every successful run, just like child items. The existing `source_origin` column already exists to distinguish provenance — no new media type is needed.
 - **`extractor_version`** is a single integer in `pdf_enrich/version.py`. Bump it when the extractor changes in a way that should trigger reprocessing.
 
 ## Sequence Flows
@@ -170,13 +179,41 @@ sequenceDiagram
     Enrich->>Enrich: apply_links + insert image placeholders + cleanup
     Enrich->>DB: BEGIN
     Enrich->>FS: write extracted images
-    Enrich->>DB: INSERT item_media (media_type='pdf_image') × N
+    Enrich->>DB: INSERT item_media (media_type='image', source_origin='enricher') × N
     Enrich->>DB: rewrite content with /api/media/{id}
     Enrich->>DB: DELETE child items WHERE parent_id=? AND source_type='pdf_annotation'
     Enrich->>DB: INSERT child items × M
     Enrich->>DB: UPDATE items SET content=?, metadata=? WHERE id=?
     Enrich->>DB: COMMIT
 ```
+
+### Flow 1.5: Source-PDF backfill for legacy items
+
+Approximately 250 PDF items already imported from Google Drive predate this pipeline and have no `source_pdf` `item_media` row. D5 makes that row mandatory, so a one-shot backfill is required before `enrich --all` can be run end-to-end.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI as lestash enrich-backfill-sources
+    participant DB
+    participant Drive as Google Drive API
+    participant FS as ~/.lestash/media
+
+    CLI->>DB: SELECT items WHERE source_type='google_drive'<br/>AND mime is PDF<br/>AND NOT EXISTS (item_media WHERE media_type='source_pdf')
+    loop per item
+        CLI->>DB: read drive_id from items.metadata
+        CLI->>Drive: download file by drive_id
+        alt Drive returns bytes
+            CLI->>FS: write to media dir
+            CLI->>DB: INSERT item_media (media_type='source_pdf', local_path=..., url=DriveURL)
+        else Drive 404 / no auth
+            CLI->>DB: UPDATE items SET metadata.enrichment_status='source_unavailable'
+            Note over CLI: log + continue
+        end
+    end
+```
+
+This command is idempotent (skips items that already have a `source_pdf` row) and runs once after the migration lands. After it completes, `enrich --all` is the canonical re-runner.
 
 ### Flow 2: Backfill (re-enrich existing item, same extractor version)
 
@@ -230,15 +267,15 @@ sequenceDiagram
     participant OCR as ocr_annotation()
     participant DB
     participant FS
-    participant API as Google Vision / Document AI
+    participant API as Claude API (anthropic SDK)
 
     CLI->>DB: SELECT children WHERE source_type='pdf_annotation'<br/>AND annotation_kind IN ('margin_note','ink_unclassified')<br/>AND (ocr_version IS NULL OR ocr_version < current)
     loop per child
         CLI->>OCR: ocr_annotation(child_id)
         OCR->>DB: load strokes + bbox + parent's source PDF
         OCR->>FS: render strokes to PNG via PyMuPDF
-        OCR->>API: POST image
-        API-->>OCR: text
+        OCR->>API: messages.create with image content block + transcription prompt
+        API-->>OCR: transcribed text
         OCR->>DB: UPDATE items SET content=?, metadata.ocr_text=?,<br/>metadata.ocr_version=current WHERE id=?
     end
 ```
@@ -251,16 +288,16 @@ sequenceDiagram
 | Docling crash | Fall through: keep prior `items.content` if any, set `enrichment_status='failed'`, log full exception. |
 | PyMuPDF crash on a single page | Page-level try/except; record empty results for that page, continue with others. |
 | Image upload fails | Roll back the entire enrichment transaction; item is left in its prior state. |
-| OCR API failure (rate limit, network, auth) | Skip child, leave its `content` unchanged, log; resumable on next `enrich --ocr` run. |
+| Claude API failure (rate limit, network, auth, content-policy refusal) | Skip child, leave its `content` unchanged, log; resumable on next `enrich --ocr` run. |
 | Image placeholder ↔ extracted-image count mismatch | Match by page-and-bbox order, not by global index; log unmatched placeholders as warnings. |
 | Stroke classifier disagreement on borderline cases | Default to `ink_unclassified` rather than guessing; safer than wrong classification. |
 
 ## Edge Cases the Implementation Must Handle
 
 1. **Same image referenced multiple times in a PDF** — dedup by `xref_hash` (sha256 of bytes); upload once, reference the same media id from multiple positions in the markdown.
-2. **Anchor text appears multiple times in the document** — link replacement walks the markdown left-to-right with a cursor, consuming each link in document order, never `str.replace()` globally.
+2. **Anchor text appears multiple times in the document** — link replacement walks the markdown left-to-right with a cursor, consuming each link in document order, never `str.replace()` globally. Comparison between the anchor text PyMuPDF reads from the link rect and the text Docling emitted is done on a normalised form (whitespace collapsed to single spaces, leading/trailing trimmed, soft hyphens removed) — Docling reflows lines and may insert line breaks the original PDF didn't have, so byte-exact matching would miss many real links.
 3. **Docling DOCX inputs** — only PDF inputs go through PyMuPDF post-processing. The `convert_to_markdown` mime check stays as the gate.
-4. **Cleanup `·` / `◦`** — only stripped when they appear as the first non-whitespace character of a line that Docling marked as a list item, never globally. `m·s⁻¹` stays intact.
+4. **Cleanup `·` / `◦`** — Docling emits these as trailing artifacts at end-of-line (e.g. `"...and preprints. ·\n"`, `"...E.W.Dijkstra Archive (PDF) ◦\n"`). Strip only when they are the last non-whitespace character of a line, never mid-line. `m·s⁻¹` and similar in-content uses stay intact.
 5. **Drive PDFs whose file ID changes** — Drive can re-id a file on move. The enricher computes sha256 on bytes, not on Drive ID, so identity remains stable across moves.
 6. **Heavily-annotated PDFs** — a textbook with 200 highlights produces 200 child items. Acceptable; the FTS5 index and `parent_id` filter keep them out of normal listings.
 
@@ -281,7 +318,7 @@ sequenceDiagram
 
 ### OCR tests
 
-- `ocr_annotation` mocked at the API client boundary; assert the rendered PNG bytes match a fixture for a known stroke set.
+- `ocr_annotation` mocked at the `anthropic` client boundary; assert the rendered PNG bytes match a fixture for a known stroke set, and that the prompt+image is constructed correctly.
 - Skip-when-version-matches behaviour.
 
 ### Manual verification
@@ -295,12 +332,7 @@ sequenceDiagram
 "pymupdf>=1.27.0",
 ```
 
-OCR is opt-in and lives in `pdf_enrich/ocr.py`. Its API client (e.g. `google-cloud-vision`) is added as an extra so users who don't want it don't pull it:
-
-```toml
-[project.optional-dependencies]
-ocr = ["google-cloud-vision>=3.0.0"]
-```
+OCR lives in `pdf_enrich/ocr.py` and uses the `anthropic` SDK, which is already a project dependency — so OCR adds no new optional-dependency group. The user supplies their `ANTHROPIC_API_KEY` via existing config and opts in by passing `--ocr` to the enrich command.
 
 ## Open Questions
 

--- a/packages/lestash-arxiv/pyproject.toml
+++ b/packages/lestash-arxiv/pyproject.toml
@@ -3,6 +3,7 @@ name = "lestash-arxiv"
 version = "1.54.0"
 description = "arXiv source plugin for Le Stash"
 readme = "README.md"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.12"
 dependencies = [
     "lestash",

--- a/packages/lestash-audible/pyproject.toml
+++ b/packages/lestash-audible/pyproject.toml
@@ -3,6 +3,7 @@ name = "lestash-audible"
 version = "1.54.0"
 description = "Audible source plugin for Le Stash"
 readme = "README.md"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.12"
 dependencies = [
     "lestash",

--- a/packages/lestash-bluesky/pyproject.toml
+++ b/packages/lestash-bluesky/pyproject.toml
@@ -3,6 +3,7 @@ name = "lestash-bluesky"
 version = "1.54.0"
 description = "Bluesky source plugin for Le Stash"
 readme = "README.md"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.12"
 dependencies = [
     "lestash",

--- a/packages/lestash-claude-code/pyproject.toml
+++ b/packages/lestash-claude-code/pyproject.toml
@@ -2,6 +2,7 @@
 name = "lestash-claude-code"
 version = "1.54.0"
 description = "Claude Code session source plugin for Le Stash"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.12"
 dependencies = [
     "lestash",

--- a/packages/lestash-linkedin/pyproject.toml
+++ b/packages/lestash-linkedin/pyproject.toml
@@ -3,6 +3,7 @@ name = "lestash-linkedin"
 version = "1.54.0"
 description = "LinkedIn source plugin for Le Stash"
 readme = "README.md"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.12"
 dependencies = [
     "lestash",

--- a/packages/lestash-microblog/pyproject.toml
+++ b/packages/lestash-microblog/pyproject.toml
@@ -3,6 +3,7 @@ name = "lestash-microblog"
 version = "1.54.0"
 description = "Micro.blog source plugin for Le Stash"
 readme = "README.md"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.12"
 dependencies = [
     "lestash",

--- a/packages/lestash-server/pyproject.toml
+++ b/packages/lestash-server/pyproject.toml
@@ -3,6 +3,7 @@ name = "lestash-server"
 version = "1.54.0"
 description = "HTTPS API server for Le Stash"
 readme = "README.md"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.12"
 dependencies = [
     "lestash",

--- a/packages/lestash-server/src/lestash_server/app.py
+++ b/packages/lestash-server/src/lestash_server/app.py
@@ -11,6 +11,7 @@ from lestash_server.routes import (
     audible_auth,
     collections,
     embeddings,
+    enrich,
     google_auth,
     imports,
     items,
@@ -67,6 +68,7 @@ def create_app(static_dir: str | None = None) -> FastAPI:
     app.include_router(collections.router)
     app.include_router(embeddings.router)
     app.include_router(media.router)
+    app.include_router(enrich.router)
     app.include_router(audible_auth.router)
     app.include_router(google_auth.router)
 

--- a/packages/lestash-server/src/lestash_server/routes/enrich.py
+++ b/packages/lestash-server/src/lestash_server/routes/enrich.py
@@ -93,3 +93,36 @@ def backfill() -> BackfillResponse:
         already_present=stats.already_present,
         unavailable=stats.unavailable,
     )
+
+
+class OcrRequest(BaseModel):
+    item_id: int | None = None
+
+
+class OcrResponse(BaseModel):
+    total: int
+    ocrd: int
+    skipped: int
+    unavailable: int
+    failed: int
+
+
+@router.post("/api/enrich/ocr", response_model=OcrResponse)
+def run_ocr(body: OcrRequest | None = None) -> OcrResponse:
+    """Transcribe handwritten ink annotations via Claude vision. Requires
+    ANTHROPIC_API_KEY. Idempotent at the (stroke_geometry_hash, ocr_version)
+    granularity."""
+    from lestash.core.pdf_enrich import ocr_pending_annotations
+
+    item_id = body.item_id if body else None
+    results = ocr_pending_annotations(item_id=item_id)
+    counts: dict[str, int] = {"transcribed": 0, "skipped": 0, "unavailable": 0, "failed": 0}
+    for r in results:
+        counts[r.status] = counts.get(r.status, 0) + 1
+    return OcrResponse(
+        total=len(results),
+        ocrd=counts["transcribed"],
+        skipped=counts["skipped"],
+        unavailable=counts["unavailable"],
+        failed=counts["failed"],
+    )

--- a/packages/lestash-server/src/lestash_server/routes/enrich.py
+++ b/packages/lestash-server/src/lestash_server/routes/enrich.py
@@ -1,0 +1,95 @@
+"""PDF enrichment API endpoints.
+
+POST /api/items/{item_id}/enrich      — enrich a single item (idempotent)
+POST /api/enrich/all                  — enrich every PDF item
+POST /api/enrich/backfill-sources     — Flow 1.5 source-PDF backfill
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+from lestash.core.database import get_connection
+from lestash.core.pdf_enrich import (
+    backfill_source_pdfs,
+    enrich_item,
+    list_pdf_items,
+)
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["enrich"])
+
+
+class EnrichRequest(BaseModel):
+    force: bool = False
+
+
+class EnrichResponse(BaseModel):
+    item_id: int
+    status: str
+    images: int = 0
+    annotations: int = 0
+    message: str | None = None
+
+
+class EnrichAllResponse(BaseModel):
+    total: int
+    enriched: int
+    skipped: int
+    source_unavailable: int
+    failed: int
+
+
+class BackfillResponse(BaseModel):
+    inspected: int
+    backfilled: int
+    already_present: int
+    unavailable: int
+
+
+@router.post("/api/items/{item_id}/enrich", response_model=EnrichResponse)
+def enrich_one(item_id: int, body: EnrichRequest | None = None) -> EnrichResponse:
+    force = bool(body and body.force)
+    result = enrich_item(item_id, force=force)
+    if result.status == "failed" and result.message == "item not found":
+        raise HTTPException(status_code=404, detail="item not found")
+    return EnrichResponse(
+        item_id=result.item_id,
+        status=result.status,
+        images=result.images,
+        annotations=result.annotations,
+        message=result.message,
+    )
+
+
+@router.post("/api/enrich/all", response_model=EnrichAllResponse)
+def enrich_all(body: EnrichRequest | None = None) -> EnrichAllResponse:
+    force = bool(body and body.force)
+    with get_connection() as conn:
+        ids = list_pdf_items(conn)
+
+    counts = {"enriched": 0, "skipped": 0, "source_unavailable": 0, "failed": 0}
+    for item_id in ids:
+        result = enrich_item(item_id, force=force)
+        counts[result.status] = counts.get(result.status, 0) + 1
+    return EnrichAllResponse(
+        total=len(ids),
+        enriched=counts["enriched"],
+        skipped=counts["skipped"],
+        source_unavailable=counts["source_unavailable"],
+        failed=counts["failed"],
+    )
+
+
+@router.post("/api/enrich/backfill-sources", response_model=BackfillResponse)
+def backfill() -> BackfillResponse:
+    stats = backfill_source_pdfs()
+    return BackfillResponse(
+        inspected=stats.inspected,
+        backfilled=stats.backfilled,
+        already_present=stats.already_present,
+        unavailable=stats.unavailable,
+    )

--- a/packages/lestash-server/src/lestash_server/routes/imports.py
+++ b/packages/lestash-server/src/lestash_server/routes/imports.py
@@ -227,6 +227,7 @@ def _import_pdf(data: bytes, filename: str, errors: list[str]) -> ImportResponse
     )
 
     items_added = 0
+    enrich_item_id: int | None = None
     with get_db() as conn:
         item_id = _upsert_item(conn, item)
         if item_id:
@@ -234,13 +235,23 @@ def _import_pdf(data: bytes, filename: str, errors: list[str]) -> ImportResponse
             add_item_media(
                 conn,
                 item_id,
-                media_type="pdf",
+                media_type="source_pdf",
                 local_path=rel_path,
                 mime_type="application/pdf",
                 source_origin="upload",
             )
             items_added = 1
+            enrich_item_id = item_id
         conn.commit()
+
+    if enrich_item_id is not None:
+        from lestash.core.pdf_enrich import enrich_item
+
+        try:
+            enrich_item(enrich_item_id)
+        except Exception as e:
+            logger.exception("Failed to enrich uploaded PDF item %d", enrich_item_id)
+            errors.append(f"enrich: {e}")
 
     return ImportResponse(
         status="completed",
@@ -332,10 +343,12 @@ async def sync_from_drive(body: DriveSyncRequest):
         sync_drive_folder,
         sync_single_file,
     )
+    from lestash.core.pdf_enrich import attach_source_pdf_and_enrich
 
     items_added = 0
     items_skipped = 0
     errors: list[str] = []
+    pdf_followups: list[tuple[int, bytes, str, str | None]] = []
 
     for url in body.urls:
         try:
@@ -343,25 +356,38 @@ async def sync_from_drive(body: DriveSyncRequest):
 
             if url_type == "folder":
                 with get_db() as conn:
-                    for item in sync_drive_folder(file_id, recursive=True):
+                    for item, pdf_bytes, filename in sync_drive_folder(file_id, recursive=True):
                         try:
-                            upsert_item(conn, item)
+                            item_id = upsert_item(conn, item)
                             items_added += 1
+                            if pdf_bytes:
+                                drive_url = (item.metadata or {}).get("drive_web_link")
+                                pdf_followups.append((item_id, pdf_bytes, filename, drive_url))
                         except Exception as e:
                             errors.append(f"{item.title}: {e}")
                     conn.commit()
             elif url_type == "file":
-                item = sync_single_file(file_id)
+                item, pdf_bytes, filename = sync_single_file(file_id)
                 with get_db() as conn:
-                    upsert_item(conn, item)
+                    item_id = upsert_item(conn, item)
                     conn.commit()
                 items_added += 1
+                if pdf_bytes:
+                    drive_url = (item.metadata or {}).get("drive_web_link")
+                    pdf_followups.append((item_id, pdf_bytes, filename, drive_url))
             else:
                 errors.append(f"Could not parse URL: {url}")
                 items_skipped += 1
         except Exception as e:
             logger.exception("Failed to sync %s", url)
             errors.append(f"{url}: {e}")
+
+    for item_id, pdf_bytes, filename, drive_url in pdf_followups:
+        try:
+            attach_source_pdf_and_enrich(item_id, pdf_bytes, filename, drive_url=drive_url)
+        except Exception as e:
+            logger.exception("Failed to enrich item %d", item_id)
+            errors.append(f"enrich item {item_id}: {e}")
 
     return DriveSyncResponse(
         status="completed" if not errors else "completed_with_errors",

--- a/packages/lestash-server/tests/test_api.py
+++ b/packages/lestash-server/tests/test_api.py
@@ -259,7 +259,8 @@ class TestImport:
 
     def test_import_pdf_extracts_and_attaches_media(self, client, test_config):
         """PDF import should extract markdown via Docling and save the
-        original as a media attachment of type 'pdf'."""
+        original as a media attachment of type 'source_pdf' (so the enricher
+        can find it for re-runs)."""
         from lestash.core.database import get_connection, get_media_dir
 
         pdf_bytes = b"%PDF-1.4 fake pdf contents for test"
@@ -295,7 +296,7 @@ class TestImport:
                 (row["id"],),
             ).fetchone()
             assert media is not None
-            assert media["media_type"] == "pdf"
+            assert media["media_type"] == "source_pdf"
             assert media["mime_type"] == "application/pdf"
             assert media["source_origin"] == "upload"
 

--- a/packages/lestash-voice/pyproject.toml
+++ b/packages/lestash-voice/pyproject.toml
@@ -3,6 +3,7 @@ name = "lestash-voice"
 version = "1.54.0"
 description = "Voice note transcription plugin for Le Stash"
 readme = "README.md"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.12"
 dependencies = [
     "lestash",

--- a/packages/lestash-youtube/pyproject.toml
+++ b/packages/lestash-youtube/pyproject.toml
@@ -3,6 +3,7 @@ name = "lestash-youtube"
 version = "1.54.0"
 description = "YouTube source plugin for Le Stash"
 readme = "README.md"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.12"
 dependencies = [
     "lestash",

--- a/packages/lestash/pyproject.toml
+++ b/packages/lestash/pyproject.toml
@@ -3,6 +3,7 @@ name = "lestash"
 version = "1.54.0"
 description = "Personal knowledge base CLI - aggregate content from multiple sources"
 readme = "README.md"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.12"
 dependencies = [
     "typer>=0.12.0",
@@ -16,6 +17,8 @@ dependencies = [
     "sqlite-vec>=0.1.6",
     "sentence-transformers>=3.0.0",
     "docling>=2.84.0",
+    "pymupdf>=1.27.0",
+    "anthropic>=0.40.0",
 ]
 
 [project.scripts]

--- a/packages/lestash/src/lestash/cli/enrich.py
+++ b/packages/lestash/src/lestash/cli/enrich.py
@@ -1,0 +1,96 @@
+"""PDF enrichment CLI commands.
+
+lestash enrich item N            # enrich a single item
+lestash enrich all               # enrich every PDF item
+lestash enrich backfill-sources  # one-shot legacy source-PDF backfill
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.progress import Progress
+
+app = typer.Typer(
+    help="PDF enrichment pipeline (links, images, ink annotations).", no_args_is_help=True
+)
+console = Console()
+
+
+@app.command("item")
+def enrich_one(
+    item_id: int = typer.Argument(..., help="Item ID to enrich"),
+    force: bool = typer.Option(False, "--force", help="Re-run even if already enriched"),
+) -> None:
+    """Enrich a single PDF item."""
+    from lestash.core.pdf_enrich import enrich_item
+
+    result = enrich_item(item_id, force=force)
+    _print_result(result)
+
+
+@app.command("all")
+def enrich_all(
+    force: bool = typer.Option(False, "--force", help="Re-run even when already enriched"),
+) -> None:
+    """Enrich every PDF item in the database. Idempotent — skips items whose
+    stored extractor_version + sha256 already matches."""
+    from lestash.core.database import get_connection
+    from lestash.core.pdf_enrich import enrich_item, list_pdf_items
+
+    with get_connection() as conn:
+        ids = list_pdf_items(conn)
+
+    if not ids:
+        console.print("[yellow]No PDF items found.[/yellow]")
+        return
+
+    counts = {"enriched": 0, "skipped": 0, "source_unavailable": 0, "failed": 0}
+
+    with Progress(console=console) as progress:
+        task = progress.add_task("Enriching", total=len(ids))
+        for item_id in ids:
+            result = enrich_item(item_id, force=force)
+            counts[result.status] = counts.get(result.status, 0) + 1
+            progress.update(task, advance=1)
+
+    console.print(
+        f"\n[bold]Done.[/bold] enriched={counts['enriched']} "
+        f"skipped={counts['skipped']} unavailable={counts['source_unavailable']} "
+        f"failed={counts['failed']}"
+    )
+
+
+@app.command("backfill-sources")
+def backfill_sources() -> None:
+    """One-shot: download any missing source PDFs from Google Drive and persist
+    them as `source_pdf` media rows. Required for items imported before the
+    enrichment pipeline existed.
+
+    Idempotent — items that already have a source_pdf row are skipped.
+    """
+    from lestash.core.pdf_enrich import backfill_source_pdfs
+
+    stats = backfill_source_pdfs()
+    console.print(
+        f"Inspected {stats.inspected} items: "
+        f"backfilled {stats.backfilled}, "
+        f"already-present {stats.already_present}, "
+        f"unavailable {stats.unavailable}."
+    )
+
+
+def _print_result(result) -> None:
+    colours = {
+        "enriched": "green",
+        "skipped": "blue",
+        "source_unavailable": "yellow",
+        "failed": "red",
+    }
+    colour = colours.get(result.status, "white")
+    console.print(
+        f"[{colour}]{result.status}[/{colour}] item={result.item_id} "
+        f"images={result.images} annotations={result.annotations}"
+    )
+    if result.message:
+        console.print(f"  {result.message}")

--- a/packages/lestash/src/lestash/cli/enrich.py
+++ b/packages/lestash/src/lestash/cli/enrich.py
@@ -61,6 +61,35 @@ def enrich_all(
     )
 
 
+@app.command("ocr")
+def ocr(
+    item_id: int | None = typer.Option(
+        None, "--item-id", help="Limit OCR to children of this parent (default: all)"
+    ),
+) -> None:
+    """Transcribe handwritten margin notes and unclassified ink via Claude
+    multimodal vision. Requires ANTHROPIC_API_KEY.
+
+    Idempotent: child items already OCR'd at the current ocr_version are
+    skipped.
+    """
+    from lestash.core.pdf_enrich import ocr_pending_annotations
+
+    results = ocr_pending_annotations(item_id=item_id)
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.status] = counts.get(r.status, 0) + 1
+    if not results:
+        console.print("[blue]No annotations needing OCR.[/blue]")
+        return
+    console.print(
+        f"transcribed {counts.get('transcribed', 0)}, "
+        f"skipped {counts.get('skipped', 0)}, "
+        f"unavailable {counts.get('unavailable', 0)}, "
+        f"failed {counts.get('failed', 0)}."
+    )
+
+
 @app.command("backfill-sources")
 def backfill_sources() -> None:
     """One-shot: download any missing source PDFs from Google Drive and persist

--- a/packages/lestash/src/lestash/cli/google.py
+++ b/packages/lestash/src/lestash/cli/google.py
@@ -175,24 +175,45 @@ def sync(
             console.print(f"  {name}  [dim]({size_str})[/dim]")
         return
 
+    from lestash.core.pdf_enrich import attach_source_pdf_and_enrich
+
     config = Config.load()
     added = 0
+    enriched = 0
     errors: list[str] = []
+    pdf_followups: list[tuple[int, bytes, str, str | None]] = []
 
     with (
         console.status("[bold]Syncing Google Drive folder...[/bold]") as status,
         get_connection(config) as conn,
     ):
-        for item in sync_drive_folder(folder_id, since=since, recursive=recursive):
+        for item, pdf_bytes, filename in sync_drive_folder(
+            folder_id, since=since, recursive=recursive
+        ):
             status.update(f"Processing: {item.title or 'unknown'}")
             try:
-                upsert_item(conn, item)
+                item_id = upsert_item(conn, item)
                 added += 1
+                if pdf_bytes:
+                    drive_url = (item.metadata or {}).get("drive_web_link")
+                    pdf_followups.append((item_id, pdf_bytes, filename, drive_url))
             except Exception as e:
                 errors.append(f"{item.title}: {e}")
         conn.commit()
 
+    for item_id, pdf_bytes, filename, drive_url in pdf_followups:
+        try:
+            result = attach_source_pdf_and_enrich(
+                item_id, pdf_bytes, filename, drive_url=drive_url, config=config
+            )
+            if result.status == "enriched":
+                enriched += 1
+        except Exception as e:
+            errors.append(f"enrich item {item_id}: {e}")
+
     console.print(f"\n[green]✓[/green] Imported {added} items from Google Drive")
+    if enriched:
+        console.print(f"[green]✓[/green] Enriched {enriched} PDFs")
     if errors:
         console.print(f"[yellow]  {len(errors)} errors:[/yellow]")
         for err in errors:

--- a/packages/lestash/src/lestash/cli/main.py
+++ b/packages/lestash/src/lestash/cli/main.py
@@ -3,7 +3,17 @@
 import typer
 
 from lestash import __version__
-from lestash.cli import config, db, embeddings, google, items, media, profiles, sources
+from lestash.cli import (
+    config,
+    db,
+    embeddings,
+    enrich,
+    google,
+    items,
+    media,
+    profiles,
+    sources,
+)
 from lestash.core.database import init_database
 from lestash.core.logging import get_console, get_logger, setup_logging
 from lestash.plugins.loader import load_plugins
@@ -25,6 +35,7 @@ app.add_typer(google.app, name="google")
 app.add_typer(embeddings.app, name="embeddings")
 app.add_typer(media.app, name="media")
 app.add_typer(db.app, name="db")
+app.add_typer(enrich.app, name="enrich")
 
 
 def register_plugin_commands() -> None:

--- a/packages/lestash/src/lestash/core/google_drive.py
+++ b/packages/lestash/src/lestash/core/google_drive.py
@@ -213,8 +213,15 @@ def file_to_item(file_meta: dict, content: str) -> ItemCreate:
     )
 
 
-def _process_file(service, file_meta: dict) -> ItemCreate:
-    """Download/export a single file, convert to markdown, return ItemCreate."""
+def _process_file(service, file_meta: dict) -> tuple[ItemCreate, bytes | None, str]:
+    """Download/export a single file, convert to markdown, return the
+    ItemCreate together with the source PDF bytes (if applicable) and the
+    original filename.
+
+    PDF bytes are retained so the caller can persist them as a `source_pdf`
+    media row and run the enrichment pipeline. For non-PDF inputs the second
+    return value is `None`.
+    """
     from lestash.core.text_extract import extract_content
 
     file_id = file_meta["id"]
@@ -224,6 +231,7 @@ def _process_file(service, file_meta: dict) -> ItemCreate:
     logger.info("Processing %s (%s)", name, mime_type)
 
     content = ""
+    pdf_bytes: bytes | None = None
     try:
         # Google Workspace files need export, not download
         if mime_type in EXPORTABLE_MIMES:
@@ -235,12 +243,17 @@ def _process_file(service, file_meta: dict) -> ItemCreate:
 
         try:
             content = extract_content(path, export_mime)
+            if export_mime == "application/pdf":
+                try:
+                    pdf_bytes = path.read_bytes()
+                except Exception:
+                    logger.exception("Failed to read PDF bytes for %s", name)
         finally:
             path.unlink(missing_ok=True)
     except Exception:
         logger.exception("Failed to download/extract %s", name)
 
-    return file_to_item(file_meta, content)
+    return file_to_item(file_meta, content), pdf_bytes, name
 
 
 def _filter_syncable(files: list[dict]) -> list[dict]:
@@ -257,16 +270,12 @@ def sync_drive_folder(
     folder_id: str,
     since: str | None = None,
     recursive: bool = False,
-) -> Iterator[ItemCreate]:
-    """Sync files from a Google Drive folder, yielding ItemCreate objects.
+) -> Iterator[tuple[ItemCreate, bytes | None, str]]:
+    """Sync files from a Google Drive folder.
 
-    Args:
-        folder_id: Google Drive folder ID or URL.
-        since: Optional ISO timestamp for incremental sync.
-        recursive: If True, recurse into subfolders.
-
-    Yields:
-        ItemCreate objects ready for database upsert.
+    Yields `(ItemCreate, pdf_bytes_or_None, filename)` tuples. PDF bytes are
+    surfaced so the caller can attach the source PDF as a media row and
+    trigger enrichment after upsert.
     """
     from lestash.core.google_auth import get_drive_service
 
@@ -279,14 +288,10 @@ def sync_drive_folder(
         yield _process_file(service, file_meta)
 
 
-def sync_single_file(file_id: str) -> ItemCreate:
-    """Download/export a single Drive file and return an ItemCreate.
+def sync_single_file(file_id: str) -> tuple[ItemCreate, bytes | None, str]:
+    """Download/export a single Drive file.
 
-    Args:
-        file_id: Google Drive file ID.
-
-    Returns:
-        ItemCreate with markdown content.
+    Returns `(ItemCreate, pdf_bytes_or_None, filename)`.
     """
     from lestash.core.google_auth import get_drive_service
 

--- a/packages/lestash/src/lestash/core/pdf_enrich/TUNING.md
+++ b/packages/lestash/src/lestash/core/pdf_enrich/TUNING.md
@@ -1,0 +1,40 @@
+# PDF Enrichment — Tuning Notes
+
+The annotation classifier in `annotations.py` uses pure geometric heuristics
+with constants chosen as sensible defaults. They have **not** been verified
+against a corpus of real Kobo / iPad Notes / xournal++ output. Expect to
+adjust them as soon as you have real samples.
+
+## Constants and what to look at
+
+| Constant | Default | What goes wrong if it's wrong |
+|---|---|---|
+| `UNDERLINE_Y_RATIO_MAX` | `0.10` | Too low: real Kobo underlines (often slightly slanted) classify as `ink_unclassified`. Too high: short scribbles look like underlines. |
+| `UNDERLINE_MIN_LENGTH_PT` | `20.0` | Too low: small dashes get tagged underline. Too high: short underlines for single words are missed. |
+| `CIRCLE_CLOSURE_RATIO_MAX` | `0.20` | Too low: hand-drawn open ovals miss. Too high: long curves get mis-tagged as circles. |
+| `CIRCLE_MIN_POINTS` | `12` | Too low: short squiggles look like circles. Too high: small circled words are missed. |
+| `MARGIN_OUTER_FRACTION` | `0.18` | Too low: notes near body text get tagged margin_note. Too high: real margin notes get tagged ink_unclassified. |
+| `STROKE_GROUPING_DISTANCE_PT` | `30.0` | Too low: a single circle stays as 8 separate annotations. Too high: distinct annotations on the same page merge. |
+
+## How to tune
+
+1. Take a real Kobo PDF (or whatever your dominant source is) with a known
+   set of annotations.
+2. Run `lestash enrich --item-id N`.
+3. Inspect `lestash items <child_id>` for each child created — confirm `kind`
+   matches your intent.
+4. Adjust the constant whose threshold the failing case is just outside.
+5. Bump `EXTRACTOR_VERSION` in `version.py`.
+6. Run `lestash enrich --all` — tuning improvements propagate to existing items.
+
+## Known limitations
+
+- **Strikethrough vs. underline** — both are roughly horizontal; we don't
+  distinguish them. Future work would compare the stroke's y-center to the
+  text's vertical midline.
+- **Highlighter pen strokes** — these often arrive as `Ink` annotations in
+  pen apps but as `Highlight` annotations from PDF readers. We only handle
+  `Ink` today.
+- **Handwritten margin notes** — text content is not OCR'd by the geometric
+  classifier. Use `lestash enrich --ocr` (Claude vision) to add transcribed
+  `content`.

--- a/packages/lestash/src/lestash/core/pdf_enrich/__init__.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/__init__.py
@@ -1,6 +1,13 @@
 """PDF enrichment pipeline. See `docs/pdf-enrichment-design.md`."""
 
 from .extractor import enrich_pdf
+from .runner import (
+    BackfillStats,
+    EnrichmentResult,
+    backfill_source_pdfs,
+    enrich_item,
+    list_pdf_items,
+)
 from .types import (
     AnnotationKind,
     EnrichedPdf,
@@ -12,8 +19,13 @@ from .version import EXTRACTOR_VERSION
 __all__ = [
     "AnnotationKind",
     "EXTRACTOR_VERSION",
+    "BackfillStats",
     "EnrichedPdf",
+    "EnrichmentResult",
     "ExtractedAnnotation",
     "ExtractedImage",
+    "backfill_source_pdfs",
+    "enrich_item",
     "enrich_pdf",
+    "list_pdf_items",
 ]

--- a/packages/lestash/src/lestash/core/pdf_enrich/__init__.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/__init__.py
@@ -4,6 +4,7 @@ from .extractor import enrich_pdf
 from .runner import (
     BackfillStats,
     EnrichmentResult,
+    attach_source_pdf_and_enrich,
     backfill_source_pdfs,
     enrich_item,
     list_pdf_items,
@@ -24,6 +25,7 @@ __all__ = [
     "EnrichmentResult",
     "ExtractedAnnotation",
     "ExtractedImage",
+    "attach_source_pdf_and_enrich",
     "backfill_source_pdfs",
     "enrich_item",
     "enrich_pdf",

--- a/packages/lestash/src/lestash/core/pdf_enrich/__init__.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/__init__.py
@@ -1,6 +1,7 @@
 """PDF enrichment pipeline. See `docs/pdf-enrichment-design.md`."""
 
 from .extractor import enrich_pdf
+from .ocr import OCR_EXTRACTOR_VERSION, OcrResult, ocr_annotation, ocr_pending_annotations
 from .runner import (
     BackfillStats,
     EnrichmentResult,
@@ -20,14 +21,18 @@ from .version import EXTRACTOR_VERSION
 __all__ = [
     "AnnotationKind",
     "EXTRACTOR_VERSION",
+    "OCR_EXTRACTOR_VERSION",
     "BackfillStats",
     "EnrichedPdf",
     "EnrichmentResult",
     "ExtractedAnnotation",
     "ExtractedImage",
+    "OcrResult",
     "attach_source_pdf_and_enrich",
     "backfill_source_pdfs",
     "enrich_item",
     "enrich_pdf",
     "list_pdf_items",
+    "ocr_annotation",
+    "ocr_pending_annotations",
 ]

--- a/packages/lestash/src/lestash/core/pdf_enrich/__init__.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/__init__.py
@@ -1,0 +1,19 @@
+"""PDF enrichment pipeline. See `docs/pdf-enrichment-design.md`."""
+
+from .extractor import enrich_pdf
+from .types import (
+    AnnotationKind,
+    EnrichedPdf,
+    ExtractedAnnotation,
+    ExtractedImage,
+)
+from .version import EXTRACTOR_VERSION
+
+__all__ = [
+    "AnnotationKind",
+    "EXTRACTOR_VERSION",
+    "EnrichedPdf",
+    "ExtractedAnnotation",
+    "ExtractedImage",
+    "enrich_pdf",
+]

--- a/packages/lestash/src/lestash/core/pdf_enrich/annotations.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/annotations.py
@@ -1,0 +1,341 @@
+"""Extract and classify ink annotations from a PDF.
+
+PyMuPDF exposes ink annotations (`/Type /Annot /Subtype /Ink`) with vertices
+(stroke point lists) and metadata (color, creation date, NM/UUID).
+
+Classification is pure geometry — no ML, no external deps. Each classifier
+returns a confident `kind` or falls through to `ink_unclassified` so we never
+drop an annotation. Adding new classifiers later promotes existing
+`ink_unclassified` items on the next re-run (handled by ADR D4 versioning).
+
+Tuning constants live at the top of this file. They were chosen as sensible
+defaults for Kobo-style strokes and may need adjustment against real samples;
+see TUNING.md.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+from typing import TYPE_CHECKING
+
+from .types import AnnotationKind, ExtractedAnnotation
+
+if TYPE_CHECKING:
+    import pymupdf
+
+logger = logging.getLogger(__name__)
+
+
+# --- Tuning constants ---------------------------------------------------
+# Underline: y-spread relative to bbox width must be this small.
+UNDERLINE_Y_RATIO_MAX = 0.10
+UNDERLINE_MIN_LENGTH_PT = 20.0
+
+# Circle: distance from first to last stroke point relative to bbox diagonal.
+CIRCLE_CLOSURE_RATIO_MAX = 0.20
+CIRCLE_MIN_POINTS = 12
+
+# Margin: bbox center x must lie outside (margin_x_min, margin_x_max) fraction
+# of page width. Default: anywhere left of the leftmost 18% or right of the
+# rightmost 82% counts as margin.
+MARGIN_OUTER_FRACTION = 0.18
+
+# Stroke grouping: two strokes belong to the same annotation if their bbox
+# centers are within this many points (PDF "user space" units, ~1pt = 1/72in).
+STROKE_GROUPING_DISTANCE_PT = 30.0
+
+
+def extract_annotations(doc: pymupdf.Document) -> list[ExtractedAnnotation]:
+    """Return one ExtractedAnnotation per *semantic* annotation.
+
+    A single circle is typically 5–20 ink strokes; we group spatially-adjacent
+    strokes from the same page+annotation source before classifying.
+    """
+    out: list[ExtractedAnnotation] = []
+    for page_num in range(doc.page_count):
+        page = doc[page_num]
+        try:
+            raw_inks = list(_iter_ink_annots(page, page_num))
+        except Exception:
+            logger.exception("Failed to enumerate annotations on page=%d", page_num)
+            continue
+
+        groups = _group_strokes(raw_inks)
+        for group in groups:
+            try:
+                annotation = _classify_group(group, page=page, page_num=page_num)
+            except Exception:
+                logger.exception("Classifier crashed on page=%d group; falling back", page_num)
+                annotation = _fallback_unclassified(group, page=page, page_num=page_num)
+            out.append(annotation)
+    return out
+
+
+# --- Internal: raw extraction -------------------------------------------
+
+
+class _RawInk:
+    __slots__ = ("strokes", "bbox", "color", "annotation_id", "created_at", "info")
+
+    def __init__(
+        self,
+        strokes: list[list[tuple[float, float]]],
+        bbox: tuple[float, float, float, float],
+        color: str | None,
+        annotation_id: str | None,
+        created_at: str | None,
+    ):
+        self.strokes = strokes
+        self.bbox = bbox
+        self.color = color
+        self.annotation_id = annotation_id
+        self.created_at = created_at
+
+
+def _iter_ink_annots(page: pymupdf.Page, page_num: int):
+    annots = page.annots() if hasattr(page, "annots") else None
+    if annots is None:
+        return
+    for annot in annots:
+        if annot.type[1] != "Ink":
+            continue
+        vertices = annot.vertices or []
+        # PyMuPDF returns a flat list of points; strokes are separated by None
+        # in older versions or are nested lists in newer. Handle both.
+        strokes = _normalise_vertices(vertices)
+        if not strokes:
+            continue
+        rect = annot.rect
+        bbox = (rect.x0, rect.y0, rect.x1, rect.y1)
+        info = annot.info or {}
+        color = _format_color(annot.colors)
+        yield _RawInk(
+            strokes=strokes,
+            bbox=bbox,
+            color=color,
+            annotation_id=info.get("id") or None,
+            created_at=info.get("creationDate") or None,
+        )
+
+
+def _normalise_vertices(vertices) -> list[list[tuple[float, float]]]:
+    """Coerce PyMuPDF's vertex output into a list-of-strokes-of-points."""
+    if not vertices:
+        return []
+    # New form: list of lists of (x, y).
+    if (
+        isinstance(vertices[0], (list, tuple))
+        and vertices[0]
+        and isinstance(vertices[0][0], (list, tuple))
+    ):
+        return [[(float(p[0]), float(p[1])) for p in stroke] for stroke in vertices if stroke]
+    # Flat form: list of (x, y) tuples — single stroke.
+    return [[(float(p[0]), float(p[1])) for p in vertices]]
+
+
+def _format_color(colors) -> str | None:
+    if not colors:
+        return None
+    stroke = colors.get("stroke")
+    if not stroke:
+        return None
+    if len(stroke) == 3:
+        r, g, b = (int(c * 255) for c in stroke)
+        return f"#{r:02x}{g:02x}{b:02x}"
+    return None
+
+
+# --- Internal: stroke grouping ------------------------------------------
+
+
+def _group_strokes(raw_inks: list[_RawInk]) -> list[list[_RawInk]]:
+    """Cluster nearby strokes into one semantic annotation each.
+
+    Many pen apps (Kobo included) emit one Ink annotation per pen-down event,
+    so a circle becomes 5–20 distinct annotations. Group them by spatial
+    proximity of bbox centers.
+    """
+    if not raw_inks:
+        return []
+
+    centers = [_bbox_center(ink.bbox) for ink in raw_inks]
+    n = len(raw_inks)
+    parent = list(range(n))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(i: int, j: int) -> None:
+        ri, rj = find(i), find(j)
+        if ri != rj:
+            parent[ri] = rj
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            if _dist(centers[i], centers[j]) <= STROKE_GROUPING_DISTANCE_PT:
+                union(i, j)
+
+    groups: dict[int, list[_RawInk]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(raw_inks[i])
+    return list(groups.values())
+
+
+# --- Internal: classification -------------------------------------------
+
+
+def _classify_group(
+    group: list[_RawInk], *, page: pymupdf.Page, page_num: int
+) -> ExtractedAnnotation:
+    bbox = _union_bbox([ink.bbox for ink in group])
+    all_points = [pt for ink in group for stroke in ink.strokes for pt in stroke]
+    all_strokes = [stroke for ink in group for stroke in ink.strokes]
+
+    page_width = page.rect.width
+    kind: AnnotationKind = _detect_kind(bbox, all_points, all_strokes, page_width)
+    anchor_text = _anchor_text_for(page, bbox, kind, page_width)
+
+    primary = group[0]
+    return ExtractedAnnotation(
+        kind=kind,
+        page=page_num,
+        bbox=bbox,
+        anchor_text=anchor_text,
+        color=primary.color,
+        strokes=all_strokes,
+        annotation_id=primary.annotation_id,
+        created_at=primary.created_at,
+        stroke_geometry_hash=_hash_strokes(all_strokes),
+    )
+
+
+def _detect_kind(
+    bbox: tuple[float, float, float, float],
+    points: list[tuple[float, float]],
+    strokes: list[list[tuple[float, float]]],
+    page_width: float,
+) -> AnnotationKind:
+    if not points:
+        return "ink_unclassified"
+
+    # Underline: low y-spread relative to width, sufficient length
+    width = bbox[2] - bbox[0]
+    height = bbox[3] - bbox[1]
+    if width >= UNDERLINE_MIN_LENGTH_PT and height <= width * UNDERLINE_Y_RATIO_MAX:
+        return "underline"
+
+    # Margin note: bbox center is in the outer band of the page
+    cx = (bbox[0] + bbox[2]) / 2.0
+    if cx <= page_width * MARGIN_OUTER_FRACTION or cx >= page_width * (1.0 - MARGIN_OUTER_FRACTION):
+        return "margin_note"
+
+    # Circle: closed loop, enough points
+    if _looks_like_closed_loop(strokes):
+        return "circle"
+
+    return "ink_unclassified"
+
+
+def _looks_like_closed_loop(strokes: list[list[tuple[float, float]]]) -> bool:
+    flat = [pt for stroke in strokes for pt in stroke]
+    if len(flat) < CIRCLE_MIN_POINTS:
+        return False
+    start = flat[0]
+    end = flat[-1]
+    closure = _dist(start, end)
+    bbox = _bbox(flat)
+    diag = math.hypot(bbox[2] - bbox[0], bbox[3] - bbox[1])
+    if diag <= 0:
+        return False
+    return closure / diag <= CIRCLE_CLOSURE_RATIO_MAX
+
+
+def _anchor_text_for(
+    page: pymupdf.Page,
+    bbox: tuple[float, float, float, float],
+    kind: AnnotationKind,
+    page_width: float,
+) -> str:
+    """Resolve the text the annotation points at, depending on the kind."""
+    import pymupdf as _pm
+
+    if kind == "underline":
+        # Text sits *above* the underline stroke; expand bbox upward.
+        clip = _pm.Rect(bbox[0], bbox[1] - 14.0, bbox[2], bbox[1] + 2.0)
+    elif kind == "circle":
+        clip = _pm.Rect(*bbox)
+    elif kind == "margin_note":
+        # Body text on the same vertical band as the margin scribble.
+        cx = (bbox[0] + bbox[2]) / 2.0
+        if cx <= page_width / 2.0:
+            clip = _pm.Rect(bbox[2], bbox[1], page_width, bbox[3])
+        else:
+            clip = _pm.Rect(0.0, bbox[1], bbox[0], bbox[3])
+    else:
+        return ""
+    try:
+        return page.get_text(clip=clip).strip()
+    except Exception:
+        return ""
+
+
+def _fallback_unclassified(group: list[_RawInk], *, page, page_num: int) -> ExtractedAnnotation:
+    bbox = _union_bbox([ink.bbox for ink in group])
+    all_strokes = [stroke for ink in group for stroke in ink.strokes]
+    primary = group[0]
+    return ExtractedAnnotation(
+        kind="ink_unclassified",
+        page=page_num,
+        bbox=bbox,
+        anchor_text="",
+        color=primary.color,
+        strokes=all_strokes,
+        annotation_id=primary.annotation_id,
+        created_at=primary.created_at,
+        stroke_geometry_hash=_hash_strokes(all_strokes),
+    )
+
+
+# --- Internal: geometry helpers -----------------------------------------
+
+
+def _bbox_center(bbox: tuple[float, float, float, float]) -> tuple[float, float]:
+    return ((bbox[0] + bbox[2]) / 2.0, (bbox[1] + bbox[3]) / 2.0)
+
+
+def _bbox(points: list[tuple[float, float]]) -> tuple[float, float, float, float]:
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def _union_bbox(
+    boxes: list[tuple[float, float, float, float]],
+) -> tuple[float, float, float, float]:
+    return (
+        min(b[0] for b in boxes),
+        min(b[1] for b in boxes),
+        max(b[2] for b in boxes),
+        max(b[3] for b in boxes),
+    )
+
+
+def _dist(a: tuple[float, float], b: tuple[float, float]) -> float:
+    return math.hypot(a[0] - b[0], a[1] - b[1])
+
+
+def _hash_strokes(strokes: list[list[tuple[float, float]]]) -> str:
+    """SHA-256 of canonicalised strokes — used as the OCR cache key.
+
+    Coordinates are rounded to 2 decimal places so subpixel jitter from
+    repeated extraction doesn't bust the cache.
+    """
+    canon = [[(round(p[0], 2), round(p[1], 2)) for p in stroke] for stroke in strokes]
+    blob = json.dumps(canon, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()

--- a/packages/lestash/src/lestash/core/pdf_enrich/cleanup.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/cleanup.py
@@ -1,0 +1,15 @@
+"""Strip Docling artifacts from extracted markdown.
+
+Docling emits `·` (U+00B7) and `◦` (U+25E6) at the **end** of lines as a
+list-parsing artifact, e.g. `"...and preprints. ·\n"`. We strip them only when
+they are the last non-whitespace character of a line, so in-content uses like
+`m·s⁻¹` survive intact.
+"""
+
+import re
+
+_TRAILING_BULLET_ARTIFACT = re.compile(r"[ \t]*[·◦][ \t]*$", re.MULTILINE)
+
+
+def strip_artifacts(markdown: str) -> str:
+    return _TRAILING_BULLET_ARTIFACT.sub("", markdown)

--- a/packages/lestash/src/lestash/core/pdf_enrich/extractor.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/extractor.py
@@ -1,0 +1,83 @@
+"""Pure PDF enrichment orchestrator.
+
+Takes a path to a PDF, returns a structured `EnrichedPdf` artifact. No
+database, no network, no media-storage side effects — those happen in the
+persistence layer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+from lestash.core.text_extract import convert_to_markdown
+
+from .annotations import extract_annotations
+from .cleanup import strip_artifacts
+from .images import count_placeholders, extract_images
+from .links import apply_links, extract_links
+from .types import EnrichedPdf
+from .version import EXTRACTOR_VERSION
+
+logger = logging.getLogger(__name__)
+
+
+def enrich_pdf(pdf_path: Path) -> EnrichedPdf:
+    """Run the full enrichment pipeline on a PDF file."""
+    import pymupdf
+
+    raw_bytes = pdf_path.read_bytes()
+    pdf_sha256 = hashlib.sha256(raw_bytes).hexdigest()
+
+    markdown = convert_to_markdown(pdf_path)
+
+    images: list = []
+    annotations: list = []
+    links: list = []
+
+    try:
+        doc = pymupdf.open(stream=raw_bytes, filetype="pdf")
+    except Exception:
+        logger.exception("PyMuPDF could not open %s; returning Docling-only output", pdf_path)
+        return EnrichedPdf(
+            content=strip_artifacts(markdown),
+            pdf_sha256=pdf_sha256,
+            extractor_version=EXTRACTOR_VERSION,
+        )
+
+    try:
+        try:
+            links = extract_links(doc)
+        except Exception:
+            logger.exception("Link extraction failed for %s", pdf_path)
+        try:
+            images = extract_images(doc)
+        except Exception:
+            logger.exception("Image extraction failed for %s", pdf_path)
+        try:
+            annotations = extract_annotations(doc)
+        except Exception:
+            logger.exception("Annotation extraction failed for %s", pdf_path)
+    finally:
+        doc.close()
+
+    enriched_md = apply_links(markdown, links)
+    enriched_md = strip_artifacts(enriched_md)
+
+    placeholder_count = count_placeholders(enriched_md)
+    if placeholder_count != len(images):
+        logger.warning(
+            "Image placeholder count mismatch for %s: %d placeholders vs %d images extracted",
+            pdf_path,
+            placeholder_count,
+            len(images),
+        )
+
+    return EnrichedPdf(
+        content=enriched_md,
+        pdf_sha256=pdf_sha256,
+        extractor_version=EXTRACTOR_VERSION,
+        images=images,
+        annotations=annotations,
+    )

--- a/packages/lestash/src/lestash/core/pdf_enrich/images.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/images.py
@@ -1,0 +1,114 @@
+"""Extract embedded images from a PDF.
+
+PyMuPDF returns image refs per page; the same xref may be referenced multiple
+times in a doc. We dedup by xref and by content hash (sha256 of bytes) so an
+image used as a header on every page becomes one stored asset.
+
+Images are matched to Docling's `<!-- image -->` placeholders later in
+`apply_images`. The matching is by reading order — Docling emits placeholders
+in document order, and PyMuPDF's `page.get_images()` is also in page order.
+This is best-effort; mis-matches are logged but never crash.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from .types import ExtractedImage
+
+if TYPE_CHECKING:
+    import pymupdf
+
+logger = logging.getLogger(__name__)
+
+_IMAGE_PLACEHOLDER = re.compile(r"<!-- image -->", re.IGNORECASE)
+
+
+def extract_images(doc: pymupdf.Document) -> list[ExtractedImage]:
+    """Return one ExtractedImage per (page, xref) tuple, deduped by content
+    hash within a document."""
+    seen_hashes: set[str] = set()
+    placeholder_idx = 0
+    images: list[ExtractedImage] = []
+
+    for page_num in range(doc.page_count):
+        page = doc[page_num]
+        page_images = page.get_images(full=True)
+        for img_info in page_images:
+            xref = img_info[0]
+            try:
+                extracted = doc.extract_image(xref)
+            except Exception:
+                logger.exception("Failed to extract image xref=%s on page=%d", xref, page_num)
+                continue
+
+            data: bytes = extracted["image"]
+            ext: str = extracted.get("ext", "png")
+            xref_hash = hashlib.sha256(data).hexdigest()
+
+            if xref_hash in seen_hashes:
+                continue
+            seen_hashes.add(xref_hash)
+
+            try:
+                rects = page.get_image_rects(xref)
+                rect = rects[0] if rects else None
+            except Exception:
+                rect = None
+            if rect is not None:
+                bbox = (rect.x0, rect.y0, rect.x1, rect.y1)
+            else:
+                bbox = (0.0, 0.0, 0.0, 0.0)
+
+            mime = _mime_for_ext(ext)
+            images.append(
+                ExtractedImage(
+                    placeholder_index=placeholder_idx,
+                    page=page_num,
+                    bbox=bbox,
+                    bytes_=data,
+                    mime_type=mime,
+                    xref_hash=xref_hash,
+                )
+            )
+            placeholder_idx += 1
+
+    return images
+
+
+def apply_images(markdown: str, replacements: dict[int, str]) -> str:
+    """Replace `<!-- image -->` placeholders in document order.
+
+    `replacements[i]` is the markdown to substitute for the i-th placeholder
+    (typically `![alt](/api/media/{id})`). Placeholders without a replacement
+    are left intact (logged as warnings by the caller).
+    """
+    counter = -1
+
+    def _sub(match: re.Match[str]) -> str:
+        nonlocal counter
+        counter += 1
+        return replacements.get(counter, match.group(0))
+
+    return _IMAGE_PLACEHOLDER.sub(_sub, markdown)
+
+
+def count_placeholders(markdown: str) -> int:
+    return len(_IMAGE_PLACEHOLDER.findall(markdown))
+
+
+def _mime_for_ext(ext: str) -> str:
+    ext = ext.lower().lstrip(".")
+    return {
+        "png": "image/png",
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "gif": "image/gif",
+        "tiff": "image/tiff",
+        "tif": "image/tiff",
+        "webp": "image/webp",
+        "bmp": "image/bmp",
+    }.get(ext, f"image/{ext}")

--- a/packages/lestash/src/lestash/core/pdf_enrich/images.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/images.py
@@ -1,8 +1,10 @@
 """Extract embedded images from a PDF.
 
 PyMuPDF returns image refs per page; the same xref may be referenced multiple
-times in a doc. We dedup by xref and by content hash (sha256 of bytes) so an
-image used as a header on every page becomes one stored asset.
+times in a doc. We emit **one ExtractedImage per page-occurrence** so each
+Docling `<!-- image -->` placeholder gets replaced — but the bytes are the
+same across occurrences (carry the same `xref_hash`) so the persistence layer
+can dedup the on-disk media row and reuse a single media_id for all copies.
 
 Images are matched to Docling's `<!-- image -->` placeholders later in
 `apply_images`. The matching is by reading order — Docling emits placeholders
@@ -28,9 +30,12 @@ _IMAGE_PLACEHOLDER = re.compile(r"<!-- image -->", re.IGNORECASE)
 
 
 def extract_images(doc: pymupdf.Document) -> list[ExtractedImage]:
-    """Return one ExtractedImage per (page, xref) tuple, deduped by content
-    hash within a document."""
-    seen_hashes: set[str] = set()
+    """Return one ExtractedImage per page-occurrence.
+
+    Repeated xrefs (e.g. a header image on every page) appear once per page
+    and carry the same `xref_hash`. Persistence dedups by hash and shares
+    the resulting media row across placeholder substitutions.
+    """
     placeholder_idx = 0
     images: list[ExtractedImage] = []
 
@@ -48,10 +53,6 @@ def extract_images(doc: pymupdf.Document) -> list[ExtractedImage]:
             data: bytes = extracted["image"]
             ext: str = extracted.get("ext", "png")
             xref_hash = hashlib.sha256(data).hexdigest()
-
-            if xref_hash in seen_hashes:
-                continue
-            seen_hashes.add(xref_hash)
 
             try:
                 rects = page.get_image_rects(xref)

--- a/packages/lestash/src/lestash/core/pdf_enrich/links.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/links.py
@@ -1,0 +1,161 @@
+"""Extract hyperlinks from a PDF and rewrite plain anchor text into markdown links.
+
+Links in PDFs live as annotation objects (`/Type /Annot /Subtype /Link` with
+`/A /URI`) — invisible to any text extractor including Docling. We get them
+from PyMuPDF's `page.get_links()`, then resolve their anchor text by clipping
+text from the link rectangle.
+
+Replacement walks the markdown left-to-right with a cursor, consuming each
+link in document order. Comparison is done on a normalised form (whitespace
+collapsed, soft hyphens removed, leading/trailing trimmed) because Docling
+reflows lines that PyMuPDF reads as one continuous string.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pymupdf
+
+
+@dataclass
+class Link:
+    page: int
+    bbox: tuple[float, float, float, float]
+    uri: str
+    anchor_text: str  # raw text PyMuPDF reads from the link rectangle
+
+
+_WS = re.compile(r"\s+")
+
+
+def _normalise(text: str) -> str:
+    """Canonicalise text for fuzzy comparison: collapse whitespace, strip soft
+    hyphens, trim, lowercase."""
+    text = text.replace("­", "")  # soft hyphen
+    text = _WS.sub(" ", text).strip()
+    return text.casefold()
+
+
+def extract_links(doc: pymupdf.Document) -> list[Link]:
+    """Return all URI links in the document, in page+reading order."""
+    links: list[Link] = []
+    for page_num in range(doc.page_count):
+        page = doc[page_num]
+        for raw in page.get_links():
+            uri = raw.get("uri")
+            if not uri:
+                continue
+            rect = raw.get("from")
+            if rect is None:
+                continue
+            bbox = (rect.x0, rect.y0, rect.x1, rect.y1)
+            anchor = page.get_text(clip=rect).strip()
+            links.append(Link(page=page_num, bbox=bbox, uri=uri, anchor_text=anchor))
+    return links
+
+
+def apply_links(markdown: str, links: list[Link]) -> str:
+    """Rewrite the first occurrence of each link's anchor text into a markdown
+    link, walking left-to-right.
+
+    If the anchor text cannot be located in the markdown (Docling reflowed it
+    away, or the anchor was empty), the link is appended at the very end of
+    the document inside a `<!-- unmatched-links -->` block so nothing is lost.
+    """
+    cursor = 0
+    out: list[str] = []
+    unmatched: list[Link] = []
+
+    for link in links:
+        anchor = link.anchor_text
+        if not anchor:
+            unmatched.append(link)
+            continue
+        match_start = _find_normalised(markdown, anchor, cursor)
+        if match_start is None:
+            unmatched.append(link)
+            continue
+        match_end = _find_normalised_end(markdown, anchor, match_start)
+        out.append(markdown[cursor:match_start])
+        out.append(f"[{markdown[match_start:match_end]}]({link.uri})")
+        cursor = match_end
+
+    out.append(markdown[cursor:])
+    rewritten = "".join(out)
+
+    if unmatched:
+        rewritten = (
+            rewritten.rstrip()
+            + "\n\n<!-- unmatched-links -->\n"
+            + "\n".join(f"- [{link.anchor_text or link.uri}]({link.uri})" for link in unmatched)
+            + "\n"
+        )
+
+    return rewritten
+
+
+def _find_normalised(haystack: str, needle: str, start: int) -> int | None:
+    """Locate `needle` in `haystack[start:]` using normalised comparison.
+
+    Returns the byte offset in `haystack` where the match begins, or None.
+    Implementation: walk forward through `haystack[start:]` accumulating
+    normalised characters and compare against the normalised needle.
+    """
+    norm_needle = _normalise(needle)
+    if not norm_needle:
+        return None
+
+    # Build a parallel array: for each non-whitespace char in haystack[start:],
+    # record (haystack_index, normalised_char).
+    norm_chars: list[tuple[int, str]] = []
+    prev_was_space = True
+    for i in range(start, len(haystack)):
+        ch = haystack[i]
+        if ch == "­":
+            continue
+        if ch.isspace():
+            if not prev_was_space:
+                norm_chars.append((i, " "))
+            prev_was_space = True
+        else:
+            norm_chars.append((i, ch.casefold()))
+            prev_was_space = False
+
+    norm_str = "".join(c for _, c in norm_chars).strip()
+    # Re-derive offset map after strip
+    while norm_chars and norm_chars[0][1] == " ":
+        norm_chars.pop(0)
+    while norm_chars and norm_chars[-1][1] == " ":
+        norm_chars.pop()
+
+    idx = norm_str.find(norm_needle)
+    if idx < 0:
+        return None
+    return norm_chars[idx][0]
+
+
+def _find_normalised_end(haystack: str, needle: str, match_start: int) -> int:
+    """Given a match start in `haystack`, return the end offset that covers
+    enough characters to span the normalised `needle`."""
+    norm_needle = _normalise(needle)
+    consumed_norm = 0
+    i = match_start
+    prev_was_space = True
+    while i < len(haystack) and consumed_norm < len(norm_needle):
+        ch = haystack[i]
+        if ch == "­":
+            i += 1
+            continue
+        if ch.isspace():
+            if not prev_was_space:
+                consumed_norm += 1
+            prev_was_space = True
+        else:
+            consumed_norm += 1
+            prev_was_space = False
+        i += 1
+    return i

--- a/packages/lestash/src/lestash/core/pdf_enrich/links.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/links.py
@@ -10,14 +10,21 @@ link in document order. Comparison is two-pass:
 
 1. **Strict normalisation** — collapse whitespace, drop soft hyphens, casefold.
    Catches the common case where Docling reflowed the anchor across newlines.
-2. **Aggressive fallback** (only if strict misses) — NFKC unicode normalise
-   then treat any non-alphanumeric character as whitespace. Catches Barnes &
-   Noble, DOIs with internal punctuation, smart-quoted apostrophes, and other
-   reformatting Docling does to surrounding markup. See #143.
+2. **Aggressive fallback** (only if strict misses) — HTML entity decode (so
+   `&amp;` matches `&`), NFKC unicode normalise (so smart-quoted `O’Reilly`
+   matches `O'Reilly`), then treat all non-alphanumeric chars as whitespace.
+   See #143.
+
+The matcher uses a span-aware stream — every normalised char carries the
+original `(orig_start, orig_end)` half-open span in the markdown that
+produced it, so the rewrite always wraps the correct source text even when
+the normalisation step expanded or collapsed character counts (e.g. `&amp;`
+collapsing 5 chars to 1, or NFKC expanding `ﬁ` to two).
 """
 
 from __future__ import annotations
 
+import html
 import re
 import unicodedata
 from dataclasses import dataclass
@@ -36,29 +43,16 @@ class Link:
 
 
 _WS = re.compile(r"\s+")
+_ENTITY_RE = re.compile(r"&(?:#x?[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);")
 
 
-def _normalise(text: str, *, aggressive: bool = False) -> str:
-    """Canonicalise text for fuzzy comparison.
+@dataclass
+class _StreamChar:
+    """A single normalised character carrying back its source span."""
 
-    Strict mode: collapse whitespace, drop soft hyphens, casefold.
-    Aggressive mode: NFKC normalise (smart quotes/ligatures/&amp;), then
-    treat all non-alphanumeric chars as whitespace before collapsing.
-    """
-    if aggressive:
-        text = unicodedata.normalize("NFKC", text)
-        text = "".join(ch if ch.isalnum() or ch.isspace() else " " for ch in text)
-    text = text.replace("­", "")  # soft hyphen
-    text = _WS.sub(" ", text).strip()
-    return text.casefold()
-
-
-def _is_kept(ch: str, *, aggressive: bool) -> bool:
-    """True if `ch` should appear in the normalised stream as itself (vs being
-    treated as whitespace or dropped)."""
-    if ch == "­" or ch.isspace():
-        return False
-    return not (aggressive and not ch.isalnum())
+    orig_start: int
+    orig_end: int
+    char: str
 
 
 def extract_links(doc: pymupdf.Document) -> list[Link]:
@@ -97,18 +91,14 @@ def apply_links(markdown: str, links: list[Link]) -> str:
             unmatched.append(link)
             continue
 
-        match_start = _find_normalised(markdown, anchor, cursor, aggressive=False)
-        if match_start is None:
-            match_start = _find_normalised(markdown, anchor, cursor, aggressive=True)
-        if match_start is None:
+        span = _locate(markdown, anchor, cursor, aggressive=False)
+        if span is None:
+            span = _locate(markdown, anchor, cursor, aggressive=True)
+        if span is None:
             unmatched.append(link)
             continue
 
-        # Use aggressive end-finder iff strict didn't find a start. This keeps
-        # the fast/precise path on the strict-match cases and only relaxes for
-        # the awkward ones.
-        used_aggressive = _find_normalised(markdown, anchor, cursor, aggressive=False) is None
-        match_end = _find_normalised_end(markdown, anchor, match_start, aggressive=used_aggressive)
+        match_start, match_end = span
         out.append(markdown[cursor:match_start])
         out.append(f"[{markdown[match_start:match_end]}]({link.uri})")
         cursor = match_end
@@ -127,75 +117,99 @@ def apply_links(markdown: str, links: list[Link]) -> str:
     return rewritten
 
 
-def _find_normalised(haystack: str, needle: str, start: int, *, aggressive: bool) -> int | None:
-    """Locate `needle` in `haystack[start:]` using normalised comparison.
+# --- Internal: matching --------------------------------------------------
 
-    Returns the byte offset in `haystack` where the match begins, or None.
+
+def _normalise(text: str, *, aggressive: bool) -> str:
+    """Canonicalise text for comparison.
+
+    Strict: collapse whitespace, drop soft hyphens, casefold.
+    Aggressive: also HTML-entity-decode + NFKC normalise + treat all
+    non-alphanumeric chars as whitespace.
     """
+    if aggressive:
+        text = html.unescape(text)
+        text = unicodedata.normalize("NFKC", text)
+        text = "".join(ch if ch.isalnum() or ch.isspace() else " " for ch in text)
+    text = text.replace("­", "")  # soft hyphen
+    text = _WS.sub(" ", text).strip()
+    return text.casefold()
+
+
+def _is_kept(ch: str, *, aggressive: bool) -> bool:
+    """True if `ch` should appear in the normalised stream as itself."""
+    if ch == "­" or ch.isspace():
+        return False
+    return not (aggressive and not ch.isalnum())
+
+
+def _locate(haystack: str, needle: str, cursor: int, *, aggressive: bool) -> tuple[int, int] | None:
+    """Find the first occurrence of `needle` in `haystack[cursor:]` under the
+    chosen normalisation. Returns the (start, end) half-open span in the
+    *original* haystack covering the matched source text, or None."""
     norm_needle = _normalise(needle, aggressive=aggressive)
     if not norm_needle:
         return None
-
-    if aggressive:
-        haystack_for_chars = unicodedata.normalize("NFKC", haystack[start:])
-        offset_to_orig = _build_nfkc_offset_map(haystack, start)
-    else:
-        haystack_for_chars = haystack[start:]
-        offset_to_orig = list(range(start, len(haystack)))
-
-    norm_chars: list[tuple[int, str]] = []
-    prev_was_space = True
-    for local_idx, ch in enumerate(haystack_for_chars):
-        orig_idx = offset_to_orig[local_idx] if local_idx < len(offset_to_orig) else len(haystack)
-        if not _is_kept(ch, aggressive=aggressive):
-            if not prev_was_space:
-                norm_chars.append((orig_idx, " "))
-            prev_was_space = True
-        else:
-            norm_chars.append((orig_idx, ch.casefold()))
-            prev_was_space = False
-
-    while norm_chars and norm_chars[0][1] == " ":
-        norm_chars.pop(0)
-    while norm_chars and norm_chars[-1][1] == " ":
-        norm_chars.pop()
-    norm_str = "".join(c for _, c in norm_chars)
-
+    stream = _normalise_stream(
+        _build_stream(haystack, cursor, aggressive=aggressive), aggressive=aggressive
+    )
+    norm_str = "".join(s.char for s in stream)
     idx = norm_str.find(norm_needle)
     if idx < 0:
         return None
-    return norm_chars[idx][0]
+    start_orig = stream[idx].orig_start
+    end_orig = stream[idx + len(norm_needle) - 1].orig_end
+    return (start_orig, end_orig)
 
 
-def _find_normalised_end(haystack: str, needle: str, match_start: int, *, aggressive: bool) -> int:
-    """Given a match start in `haystack`, return the end offset that covers
-    enough characters to span the normalised `needle`."""
-    norm_needle = _normalise(needle, aggressive=aggressive)
-    consumed_norm = 0
-    i = match_start
+def _build_stream(haystack: str, start: int, *, aggressive: bool) -> list[_StreamChar]:
+    """Produce a stream of (orig_start, orig_end, char) triples from
+    `haystack[start:]`. In aggressive mode, HTML entities are decoded into
+    their target characters and NFKC normalisation is applied — the
+    `(orig_start, orig_end)` span always covers the source text in the
+    original haystack so a downstream rewrite hits the right region.
+    """
+    out: list[_StreamChar] = []
+    i = start
+    end = len(haystack)
+    while i < end:
+        if aggressive:
+            m = _ENTITY_RE.match(haystack, i)
+            if m:
+                decoded = html.unescape(m.group())
+                if decoded != m.group():
+                    nfkc = unicodedata.normalize("NFKC", decoded)
+                    span_end = i + len(m.group())
+                    for ch in nfkc:
+                        out.append(_StreamChar(i, span_end, ch))
+                    i = span_end
+                    continue
+            ch = haystack[i]
+            nfkc = unicodedata.normalize("NFKC", ch)
+            for n_ch in nfkc:
+                out.append(_StreamChar(i, i + 1, n_ch))
+        else:
+            out.append(_StreamChar(i, i + 1, haystack[i]))
+        i += 1
+    return out
+
+
+def _normalise_stream(stream: list[_StreamChar], *, aggressive: bool) -> list[_StreamChar]:
+    """Apply whitespace-collapse / soft-hyphen-drop / casefold (and in
+    aggressive mode treat non-alphanumeric as whitespace), preserving the
+    source spans on each kept char."""
+    out: list[_StreamChar] = []
     prev_was_space = True
-    while i < len(haystack) and consumed_norm < len(norm_needle):
-        ch = haystack[i]
-        if not _is_kept(ch, aggressive=aggressive):
+    for sc in stream:
+        if not _is_kept(sc.char, aggressive=aggressive):
             if not prev_was_space:
-                consumed_norm += 1
+                out.append(_StreamChar(sc.orig_start, sc.orig_end, " "))
             prev_was_space = True
         else:
-            consumed_norm += 1
+            out.append(_StreamChar(sc.orig_start, sc.orig_end, sc.char.casefold()))
             prev_was_space = False
-        i += 1
-    return i
-
-
-def _build_nfkc_offset_map(haystack: str, start: int) -> list[int]:
-    """For each character index in `NFKC(haystack[start:])`, return the
-    corresponding original byte offset in `haystack`. NFKC may expand single
-    code points (e.g. ligatures `ﬁ` → `fi`); we map every expanded char back
-    to the original source position so the markdown rewrite hits the right
-    span."""
-    out: list[int] = []
-    for orig_local, ch in enumerate(haystack[start:]):
-        nfkc = unicodedata.normalize("NFKC", ch)
-        for _ in nfkc:
-            out.append(start + orig_local)
+    while out and out[0].char == " ":
+        out.pop(0)
+    while out and out[-1].char == " ":
+        out.pop()
     return out

--- a/packages/lestash/src/lestash/core/pdf_enrich/links.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/links.py
@@ -6,14 +6,20 @@ from PyMuPDF's `page.get_links()`, then resolve their anchor text by clipping
 text from the link rectangle.
 
 Replacement walks the markdown left-to-right with a cursor, consuming each
-link in document order. Comparison is done on a normalised form (whitespace
-collapsed, soft hyphens removed, leading/trailing trimmed) because Docling
-reflows lines that PyMuPDF reads as one continuous string.
+link in document order. Comparison is two-pass:
+
+1. **Strict normalisation** — collapse whitespace, drop soft hyphens, casefold.
+   Catches the common case where Docling reflowed the anchor across newlines.
+2. **Aggressive fallback** (only if strict misses) — NFKC unicode normalise
+   then treat any non-alphanumeric character as whitespace. Catches Barnes &
+   Noble, DOIs with internal punctuation, smart-quoted apostrophes, and other
+   reformatting Docling does to surrounding markup. See #143.
 """
 
 from __future__ import annotations
 
 import re
+import unicodedata
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -32,12 +38,27 @@ class Link:
 _WS = re.compile(r"\s+")
 
 
-def _normalise(text: str) -> str:
-    """Canonicalise text for fuzzy comparison: collapse whitespace, strip soft
-    hyphens, trim, lowercase."""
+def _normalise(text: str, *, aggressive: bool = False) -> str:
+    """Canonicalise text for fuzzy comparison.
+
+    Strict mode: collapse whitespace, drop soft hyphens, casefold.
+    Aggressive mode: NFKC normalise (smart quotes/ligatures/&amp;), then
+    treat all non-alphanumeric chars as whitespace before collapsing.
+    """
+    if aggressive:
+        text = unicodedata.normalize("NFKC", text)
+        text = "".join(ch if ch.isalnum() or ch.isspace() else " " for ch in text)
     text = text.replace("­", "")  # soft hyphen
     text = _WS.sub(" ", text).strip()
     return text.casefold()
+
+
+def _is_kept(ch: str, *, aggressive: bool) -> bool:
+    """True if `ch` should appear in the normalised stream as itself (vs being
+    treated as whitespace or dropped)."""
+    if ch == "­" or ch.isspace():
+        return False
+    return not (aggressive and not ch.isalnum())
 
 
 def extract_links(doc: pymupdf.Document) -> list[Link]:
@@ -62,9 +83,9 @@ def apply_links(markdown: str, links: list[Link]) -> str:
     """Rewrite the first occurrence of each link's anchor text into a markdown
     link, walking left-to-right.
 
-    If the anchor text cannot be located in the markdown (Docling reflowed it
-    away, or the anchor was empty), the link is appended at the very end of
-    the document inside a `<!-- unmatched-links -->` block so nothing is lost.
+    Tries strict matching first, falls back to aggressive matching for that
+    one link if strict fails. If both miss, the link is appended in a
+    `<!-- unmatched-links -->` block at the end so nothing is lost.
     """
     cursor = 0
     out: list[str] = []
@@ -75,11 +96,19 @@ def apply_links(markdown: str, links: list[Link]) -> str:
         if not anchor:
             unmatched.append(link)
             continue
-        match_start = _find_normalised(markdown, anchor, cursor)
+
+        match_start = _find_normalised(markdown, anchor, cursor, aggressive=False)
+        if match_start is None:
+            match_start = _find_normalised(markdown, anchor, cursor, aggressive=True)
         if match_start is None:
             unmatched.append(link)
             continue
-        match_end = _find_normalised_end(markdown, anchor, match_start)
+
+        # Use aggressive end-finder iff strict didn't find a start. This keeps
+        # the fast/precise path on the strict-match cases and only relaxes for
+        # the awkward ones.
+        used_aggressive = _find_normalised(markdown, anchor, cursor, aggressive=False) is None
+        match_end = _find_normalised_end(markdown, anchor, match_start, aggressive=used_aggressive)
         out.append(markdown[cursor:match_start])
         out.append(f"[{markdown[match_start:match_end]}]({link.uri})")
         cursor = match_end
@@ -98,39 +127,39 @@ def apply_links(markdown: str, links: list[Link]) -> str:
     return rewritten
 
 
-def _find_normalised(haystack: str, needle: str, start: int) -> int | None:
+def _find_normalised(haystack: str, needle: str, start: int, *, aggressive: bool) -> int | None:
     """Locate `needle` in `haystack[start:]` using normalised comparison.
 
     Returns the byte offset in `haystack` where the match begins, or None.
-    Implementation: walk forward through `haystack[start:]` accumulating
-    normalised characters and compare against the normalised needle.
     """
-    norm_needle = _normalise(needle)
+    norm_needle = _normalise(needle, aggressive=aggressive)
     if not norm_needle:
         return None
 
-    # Build a parallel array: for each non-whitespace char in haystack[start:],
-    # record (haystack_index, normalised_char).
+    if aggressive:
+        haystack_for_chars = unicodedata.normalize("NFKC", haystack[start:])
+        offset_to_orig = _build_nfkc_offset_map(haystack, start)
+    else:
+        haystack_for_chars = haystack[start:]
+        offset_to_orig = list(range(start, len(haystack)))
+
     norm_chars: list[tuple[int, str]] = []
     prev_was_space = True
-    for i in range(start, len(haystack)):
-        ch = haystack[i]
-        if ch == "­":
-            continue
-        if ch.isspace():
+    for local_idx, ch in enumerate(haystack_for_chars):
+        orig_idx = offset_to_orig[local_idx] if local_idx < len(offset_to_orig) else len(haystack)
+        if not _is_kept(ch, aggressive=aggressive):
             if not prev_was_space:
-                norm_chars.append((i, " "))
+                norm_chars.append((orig_idx, " "))
             prev_was_space = True
         else:
-            norm_chars.append((i, ch.casefold()))
+            norm_chars.append((orig_idx, ch.casefold()))
             prev_was_space = False
 
-    norm_str = "".join(c for _, c in norm_chars).strip()
-    # Re-derive offset map after strip
     while norm_chars and norm_chars[0][1] == " ":
         norm_chars.pop(0)
     while norm_chars and norm_chars[-1][1] == " ":
         norm_chars.pop()
+    norm_str = "".join(c for _, c in norm_chars)
 
     idx = norm_str.find(norm_needle)
     if idx < 0:
@@ -138,19 +167,16 @@ def _find_normalised(haystack: str, needle: str, start: int) -> int | None:
     return norm_chars[idx][0]
 
 
-def _find_normalised_end(haystack: str, needle: str, match_start: int) -> int:
+def _find_normalised_end(haystack: str, needle: str, match_start: int, *, aggressive: bool) -> int:
     """Given a match start in `haystack`, return the end offset that covers
     enough characters to span the normalised `needle`."""
-    norm_needle = _normalise(needle)
+    norm_needle = _normalise(needle, aggressive=aggressive)
     consumed_norm = 0
     i = match_start
     prev_was_space = True
     while i < len(haystack) and consumed_norm < len(norm_needle):
         ch = haystack[i]
-        if ch == "­":
-            i += 1
-            continue
-        if ch.isspace():
+        if not _is_kept(ch, aggressive=aggressive):
             if not prev_was_space:
                 consumed_norm += 1
             prev_was_space = True
@@ -159,3 +185,17 @@ def _find_normalised_end(haystack: str, needle: str, match_start: int) -> int:
             prev_was_space = False
         i += 1
     return i
+
+
+def _build_nfkc_offset_map(haystack: str, start: int) -> list[int]:
+    """For each character index in `NFKC(haystack[start:])`, return the
+    corresponding original byte offset in `haystack`. NFKC may expand single
+    code points (e.g. ligatures `ﬁ` → `fi`); we map every expanded char back
+    to the original source position so the markdown rewrite hits the right
+    span."""
+    out: list[int] = []
+    for orig_local, ch in enumerate(haystack[start:]):
+        nfkc = unicodedata.normalize("NFKC", ch)
+        for _ in nfkc:
+            out.append(start + orig_local)
+    return out

--- a/packages/lestash/src/lestash/core/pdf_enrich/ocr.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/ocr.py
@@ -1,0 +1,248 @@
+"""Handwriting OCR via Claude multimodal vision (separate, opt-in pass).
+
+Per ADR 0001 D10: handwritten text in `margin_note` and `ink_unclassified`
+child items is not OCR'd locally. We render the stroke geometry to a PNG and
+ask Claude to transcribe it.
+
+Idempotent: keyed on (stroke_geometry_hash, ocr_extractor_version). Children
+whose stored ocr_version matches the current run are skipped, so re-running
+`lestash enrich --ocr` does not re-spend on already-transcribed annotations.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import sqlite3
+from dataclasses import dataclass
+from typing import Literal
+
+from lestash.core.config import Config
+from lestash.core.database import get_connection
+
+OCR_EXTRACTOR_VERSION: int = 1
+OCR_TARGET_KINDS = ("margin_note", "ink_unclassified")
+ANTHROPIC_MODEL = "claude-sonnet-4-6"
+OCR_PROMPT = (
+    "Transcribe the handwritten text in this image. "
+    "Return only the transcribed text, with no preamble, quotes, or commentary. "
+    "If the image contains no legible handwriting, return the single word UNREADABLE."
+)
+PNG_RENDER_PADDING_PT = 12.0
+PNG_RENDER_DPI = 200
+
+logger = logging.getLogger(__name__)
+
+OcrStatus = Literal["transcribed", "skipped", "unavailable", "failed"]
+
+
+@dataclass
+class OcrResult:
+    child_id: int
+    status: OcrStatus
+    text: str | None = None
+    message: str | None = None
+
+
+def ocr_pending_annotations(
+    *, item_id: int | None = None, config: Config | None = None
+) -> list[OcrResult]:
+    """Run OCR on every child annotation that needs it.
+
+    If `item_id` is given, only descendants of that parent are processed.
+    Otherwise scans all `pdf_annotation` items in the database.
+    """
+    config = config or Config.load()
+    results: list[OcrResult] = []
+    with get_connection(config) as conn:
+        candidates = _candidate_children(conn, parent_id=item_id)
+    for child_id in candidates:
+        results.append(ocr_annotation(child_id, config=config))
+    return results
+
+
+def ocr_annotation(child_id: int, *, config: Config | None = None) -> OcrResult:
+    """OCR a single child annotation. Idempotent and side-effect-free if
+    `metadata.ocr_version` already matches the current version."""
+    config = config or Config.load()
+    with get_connection(config) as conn:
+        row = conn.execute(
+            "SELECT id, parent_id, metadata FROM items WHERE id = ?", (child_id,)
+        ).fetchone()
+        if not row:
+            return OcrResult(child_id=child_id, status="failed", message="not found")
+        try:
+            meta = json.loads(row["metadata"]) if row["metadata"] else {}
+        except (TypeError, json.JSONDecodeError):
+            meta = {}
+
+        if meta.get("annotation_kind") not in OCR_TARGET_KINDS:
+            return OcrResult(child_id=child_id, status="skipped", message="kind not eligible")
+        if meta.get("ocr_version") == OCR_EXTRACTOR_VERSION:
+            return OcrResult(child_id=child_id, status="skipped", text=meta.get("ocr_text"))
+
+        try:
+            png_bytes = _render_annotation_png(conn, config, row["parent_id"], meta)
+        except _OcrUnavailable as exc:
+            return OcrResult(child_id=child_id, status="unavailable", message=str(exc))
+
+        try:
+            text = _transcribe_with_claude(png_bytes)
+        except _OcrUnavailable as exc:
+            return OcrResult(child_id=child_id, status="unavailable", message=str(exc))
+        except Exception as exc:
+            logger.exception("Claude OCR call failed for child %d", child_id)
+            return OcrResult(child_id=child_id, status="failed", message=str(exc))
+
+        meta["ocr_text"] = text
+        meta["ocr_version"] = OCR_EXTRACTOR_VERSION
+        conn.execute(
+            "UPDATE items SET content = ?, metadata = ? WHERE id = ?",
+            (text or row["metadata"], json.dumps(meta), child_id),
+        )
+        conn.commit()
+        return OcrResult(child_id=child_id, status="transcribed", text=text)
+
+
+# --- Internal -----------------------------------------------------------
+
+
+class _OcrUnavailable(Exception):
+    """Raised when OCR cannot proceed for environmental reasons (no API key,
+    source PDF missing, geometry malformed). Distinct from a model error."""
+
+
+def _candidate_children(conn: sqlite3.Connection, *, parent_id: int | None) -> list[int]:
+    """Return child item IDs that are eligible for OCR but haven't been done
+    at the current version."""
+    base = """
+        SELECT id, metadata FROM items
+        WHERE source_type = 'pdf_annotation'
+    """
+    params: tuple = ()
+    if parent_id is not None:
+        base += " AND parent_id = ?"
+        params = (parent_id,)
+    rows = conn.execute(base, params).fetchall()
+
+    out: list[int] = []
+    for row in rows:
+        try:
+            meta = json.loads(row["metadata"]) if row["metadata"] else {}
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if meta.get("annotation_kind") not in OCR_TARGET_KINDS:
+            continue
+        if meta.get("ocr_version") == OCR_EXTRACTOR_VERSION:
+            continue
+        out.append(row["id"])
+    return out
+
+
+def _render_annotation_png(
+    conn: sqlite3.Connection, config: Config, parent_id: int, meta: dict
+) -> bytes:
+    """Render the annotation's stroke geometry to a PNG by clipping the
+    parent PDF page at the annotation's bbox.
+
+    Strokes themselves are not redrawn — we let PyMuPDF render the page
+    region (which already contains the ink as part of the PDF) and let
+    Claude see the actual pen marks rather than a synthetic re-render.
+    """
+    bbox = meta.get("bbox")
+    page_num = meta.get("page", 0)
+    if not bbox or len(bbox) != 4:
+        raise _OcrUnavailable("annotation metadata missing bbox")
+
+    pdf_path = _resolve_parent_pdf(conn, config, parent_id)
+
+    import pymupdf
+
+    try:
+        doc = pymupdf.open(pdf_path)
+    except Exception as exc:
+        raise _OcrUnavailable(f"could not open source PDF: {exc}") from exc
+    try:
+        if page_num < 0 or page_num >= doc.page_count:
+            raise _OcrUnavailable(f"page {page_num} out of range")
+        page = doc[page_num]
+        clip = pymupdf.Rect(
+            max(bbox[0] - PNG_RENDER_PADDING_PT, 0),
+            max(bbox[1] - PNG_RENDER_PADDING_PT, 0),
+            min(bbox[2] + PNG_RENDER_PADDING_PT, page.rect.width),
+            min(bbox[3] + PNG_RENDER_PADDING_PT, page.rect.height),
+        )
+        zoom = PNG_RENDER_DPI / 72.0
+        matrix = pymupdf.Matrix(zoom, zoom)
+        pix = page.get_pixmap(clip=clip, matrix=matrix, alpha=False)
+        return pix.tobytes("png")
+    finally:
+        doc.close()
+
+
+def _resolve_parent_pdf(conn: sqlite3.Connection, config: Config, parent_id: int):
+    from lestash.core.database import get_media_dir
+
+    row = conn.execute(
+        """
+        SELECT local_path FROM item_media
+        WHERE item_id = ? AND media_type = 'source_pdf'
+        ORDER BY id LIMIT 1
+        """,
+        (parent_id,),
+    ).fetchone()
+    if not row or not row["local_path"]:
+        raise _OcrUnavailable("parent has no source_pdf media row")
+    candidate = get_media_dir(config) / row["local_path"]
+    if not candidate.exists():
+        raise _OcrUnavailable(f"source PDF missing on disk: {candidate}")
+    return candidate
+
+
+def _transcribe_with_claude(png_bytes: bytes) -> str:
+    """Send the PNG to Claude and return the transcribed text.
+
+    Raises `_OcrUnavailable` if the SDK is not installed or no API key is
+    configured. Other failures bubble up.
+    """
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise _OcrUnavailable("ANTHROPIC_API_KEY is not set")
+    try:
+        import anthropic
+    except ImportError as exc:
+        raise _OcrUnavailable(f"anthropic SDK not installed: {exc}") from exc
+
+    client = anthropic.Anthropic()
+    encoded = base64.standard_b64encode(png_bytes).decode("ascii")
+    message = client.messages.create(
+        model=ANTHROPIC_MODEL,
+        max_tokens=512,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": encoded,
+                        },
+                    },
+                    {"type": "text", "text": OCR_PROMPT},
+                ],
+            }
+        ],
+    )
+
+    text_parts: list[str] = []
+    for block in message.content:
+        # Each content block is a tagged union; only TextBlock has `.text`.
+        if getattr(block, "type", None) == "text":
+            text_parts.append(getattr(block, "text", ""))
+    text = "".join(text_parts).strip()
+    if text == "UNREADABLE":
+        return ""
+    return text

--- a/packages/lestash/src/lestash/core/pdf_enrich/persistence.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/persistence.py
@@ -121,24 +121,35 @@ def _store_images(
 ) -> dict[int, str]:
     """Save image bytes to media storage and create item_media rows.
 
+    Dedups by `xref_hash`: a header image appearing on N pages becomes one
+    media row whose media_id is reused for all N placeholder replacements.
+    Without this, only the first placeholder would be replaced — see #143.
+
     Returns a map {placeholder_index: markdown-link} for `apply_images`.
     """
     replacements: dict[int, str] = {}
+    hash_to_media_id: dict[str, int] = {}
+
     for image in images:
-        ext = _ext_for_mime(image.mime_type)
-        filename = f"{image.xref_hash[:12]}{ext}"
-        rel_path = save_media_file(item_id, image.bytes_, filename, config=config)
-        media_id = add_item_media(
-            conn,
-            item_id,
-            media_type="image",
-            local_path=rel_path,
-            mime_type=image.mime_type,
-            alt_text=f"PDF image (page {image.page + 1})",
-            position=image.placeholder_index,
-            source_origin=ENRICHER_ORIGIN,
-            _commit=False,
-        )
+        if image.xref_hash in hash_to_media_id:
+            media_id = hash_to_media_id[image.xref_hash]
+        else:
+            ext = _ext_for_mime(image.mime_type)
+            filename = f"{image.xref_hash[:12]}{ext}"
+            rel_path = save_media_file(item_id, image.bytes_, filename, config=config)
+            media_id = add_item_media(
+                conn,
+                item_id,
+                media_type="image",
+                local_path=rel_path,
+                mime_type=image.mime_type,
+                alt_text=f"PDF image (page {image.page + 1})",
+                position=image.placeholder_index,
+                source_origin=ENRICHER_ORIGIN,
+                _commit=False,
+            )
+            hash_to_media_id[image.xref_hash] = media_id
+
         replacements[image.placeholder_index] = (
             f"![PDF image (page {image.page + 1})](/api/media/{media_id})"
         )

--- a/packages/lestash/src/lestash/core/pdf_enrich/persistence.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/persistence.py
@@ -1,0 +1,249 @@
+"""Database persistence for the PDF enrichment pipeline.
+
+Owned by the caller (CLI / API), not by the pure extractor. Maps an
+`EnrichedPdf` to:
+
+- `item_media` rows for extracted images (media_type='image',
+  source_origin='enricher')
+- child `items` rows for classified annotations (source_type='pdf_annotation')
+- updated parent item with rewritten content + enrichment metadata
+
+Idempotent and re-runnable: prior enricher-derived images and child items are
+deleted-then-inserted on every run. The parent's `metadata.pdf_sha256` and
+`metadata.extractor_version` track which run produced the current state.
+
+All work happens in a single transaction.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import UTC, datetime
+
+from lestash.core.config import Config
+from lestash.core.database import (
+    add_item_media,
+    save_media_file,
+)
+
+from .images import apply_images
+from .types import EnrichedPdf, ExtractedAnnotation, ExtractedImage
+
+logger = logging.getLogger(__name__)
+
+ANNOTATION_SOURCE_TYPE = "pdf_annotation"
+ENRICHER_ORIGIN = "enricher"
+
+
+def is_already_enriched(
+    conn: sqlite3.Connection, item_id: int, current_version: int, current_sha256: str
+) -> bool:
+    """Return True if the stored (sha256, extractor_version) matches the
+    current run — i.e. re-running would be a no-op."""
+    row = conn.execute("SELECT metadata FROM items WHERE id = ?", (item_id,)).fetchone()
+    if not row or not row[0]:
+        return False
+    try:
+        meta = json.loads(row[0])
+    except (TypeError, json.JSONDecodeError):
+        return False
+    return (
+        meta.get("pdf_sha256") == current_sha256
+        and meta.get("extractor_version") == current_version
+    )
+
+
+def persist_enrichment(
+    conn: sqlite3.Connection,
+    config: Config,
+    item_id: int,
+    enriched: EnrichedPdf,
+) -> None:
+    """Write the EnrichedPdf to the database in one transaction."""
+    try:
+        _delete_prior_enricher_artifacts(conn, item_id)
+        image_replacements = _store_images(conn, config, item_id, enriched.images)
+        rewritten_content = apply_images(enriched.content, image_replacements)
+        _store_annotations(conn, item_id, enriched.annotations)
+        _update_parent_item(conn, item_id, rewritten_content, enriched, status="ok")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def mark_source_unavailable(conn: sqlite3.Connection, item_id: int) -> None:
+    """Flag an item as unrunnable because its source PDF can't be read.
+
+    Leaves existing content intact; only updates the metadata block.
+    """
+    row = conn.execute("SELECT metadata FROM items WHERE id = ?", (item_id,)).fetchone()
+    meta: dict = {}
+    if row and row[0]:
+        try:
+            meta = json.loads(row[0])
+        except (TypeError, json.JSONDecodeError):
+            meta = {}
+    meta["enrichment_status"] = "source_unavailable"
+    meta["enriched_at"] = _now_iso()
+    conn.execute("UPDATE items SET metadata = ? WHERE id = ?", (json.dumps(meta), item_id))
+    conn.commit()
+
+
+# --- Internal -----------------------------------------------------------
+
+
+def _delete_prior_enricher_artifacts(conn: sqlite3.Connection, item_id: int) -> None:
+    """Remove enricher-derived media and child items so the new run is clean.
+
+    Does not touch:
+    - the source_pdf media row (the original PDF must survive re-runs)
+    - non-pdf_annotation children (e.g. unrelated linked items)
+    - non-enricher media (uploaded by the user, sync'd from Drive, etc.)
+    """
+    conn.execute(
+        "DELETE FROM item_media WHERE item_id = ? AND source_origin = ?",
+        (item_id, ENRICHER_ORIGIN),
+    )
+    conn.execute(
+        "DELETE FROM items WHERE parent_id = ? AND source_type = ?",
+        (item_id, ANNOTATION_SOURCE_TYPE),
+    )
+
+
+def _store_images(
+    conn: sqlite3.Connection,
+    config: Config,
+    item_id: int,
+    images: list[ExtractedImage],
+) -> dict[int, str]:
+    """Save image bytes to media storage and create item_media rows.
+
+    Returns a map {placeholder_index: markdown-link} for `apply_images`.
+    """
+    replacements: dict[int, str] = {}
+    for image in images:
+        ext = _ext_for_mime(image.mime_type)
+        filename = f"{image.xref_hash[:12]}{ext}"
+        rel_path = save_media_file(item_id, image.bytes_, filename, config=config)
+        media_id = add_item_media(
+            conn,
+            item_id,
+            media_type="image",
+            local_path=rel_path,
+            mime_type=image.mime_type,
+            alt_text=f"PDF image (page {image.page + 1})",
+            position=image.placeholder_index,
+            source_origin=ENRICHER_ORIGIN,
+            _commit=False,
+        )
+        replacements[image.placeholder_index] = (
+            f"![PDF image (page {image.page + 1})](/api/media/{media_id})"
+        )
+    return replacements
+
+
+def _store_annotations(
+    conn: sqlite3.Connection,
+    parent_id: int,
+    annotations: list[ExtractedAnnotation],
+) -> None:
+    """Insert one child item per semantic annotation."""
+    parent_row = conn.execute(
+        "SELECT source_type, source_id FROM items WHERE id = ?", (parent_id,)
+    ).fetchone()
+    if not parent_row:
+        return
+    parent_source_id = parent_row[1] or str(parent_id)
+
+    for ann in annotations:
+        title = _annotation_title(ann)
+        content = ann.anchor_text or _human_kind(ann.kind)
+        meta = {
+            "annotation_kind": ann.kind,
+            "page": ann.page,
+            "bbox": list(ann.bbox),
+            "color": ann.color,
+            "strokes": ann.strokes,
+            "stroke_geometry_hash": ann.stroke_geometry_hash,
+            "annotation_id": ann.annotation_id,
+        }
+        # Synthesise a stable source_id so re-runs upsert to the same row even
+        # though we delete-then-insert above (defensive: stable identity is
+        # cheap insurance if delete-then-insert is ever softened).
+        source_id = ann.annotation_id or f"{parent_source_id}:{ann.stroke_geometry_hash}"
+        conn.execute(
+            """
+            INSERT INTO items (
+                source_type, source_id, title, content,
+                created_at, metadata, parent_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                ANNOTATION_SOURCE_TYPE,
+                source_id,
+                title,
+                content,
+                ann.created_at,
+                json.dumps(meta),
+                parent_id,
+            ),
+        )
+
+
+def _update_parent_item(
+    conn: sqlite3.Connection,
+    item_id: int,
+    content: str,
+    enriched: EnrichedPdf,
+    *,
+    status: str,
+) -> None:
+    row = conn.execute("SELECT metadata FROM items WHERE id = ?", (item_id,)).fetchone()
+    meta: dict = {}
+    if row and row[0]:
+        try:
+            meta = json.loads(row[0])
+        except (TypeError, json.JSONDecodeError):
+            meta = {}
+    meta["pdf_sha256"] = enriched.pdf_sha256
+    meta["extractor_version"] = enriched.extractor_version
+    meta["enrichment_status"] = status
+    meta["enriched_at"] = _now_iso()
+    conn.execute(
+        "UPDATE items SET content = ?, metadata = ? WHERE id = ?",
+        (content, json.dumps(meta), item_id),
+    )
+
+
+def _annotation_title(ann: ExtractedAnnotation) -> str:
+    if ann.anchor_text:
+        snippet = ann.anchor_text.strip().splitlines()[0][:60]
+        return f"{_human_kind(ann.kind)}: {snippet}"
+    return f"{_human_kind(ann.kind)} (page {ann.page + 1})"
+
+
+def _human_kind(kind: str) -> str:
+    return {
+        "underline": "Underline",
+        "circle": "Circled",
+        "margin_note": "Margin note",
+        "ink_unclassified": "Ink annotation",
+    }.get(kind, kind)
+
+
+def _ext_for_mime(mime: str) -> str:
+    return {
+        "image/png": ".png",
+        "image/jpeg": ".jpg",
+        "image/gif": ".gif",
+        "image/tiff": ".tiff",
+        "image/webp": ".webp",
+        "image/bmp": ".bmp",
+    }.get(mime, ".bin")
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()

--- a/packages/lestash/src/lestash/core/pdf_enrich/runner.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/runner.py
@@ -1,0 +1,258 @@
+"""End-to-end runner: from item ID to persisted enrichment.
+
+Public entry points:
+
+    enrich_item(item_id) -> EnrichmentResult
+    backfill_source_pdfs() -> BackfillStats
+
+Both are idempotent. `enrich_item` skips when the stored
+(pdf_sha256, extractor_version) matches the current run unless `force=True`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from lestash.core.config import Config
+from lestash.core.database import (
+    add_item_media,
+    get_connection,
+    get_media_dir,
+    save_media_file,
+)
+
+from .extractor import enrich_pdf
+from .persistence import (
+    is_already_enriched,
+    mark_source_unavailable,
+    persist_enrichment,
+)
+from .version import EXTRACTOR_VERSION
+
+logger = logging.getLogger(__name__)
+
+SOURCE_PDF_MEDIA_TYPE = "source_pdf"
+PDF_MIME = "application/pdf"
+
+EnrichmentStatus = Literal["enriched", "skipped", "source_unavailable", "failed"]
+
+
+@dataclass
+class EnrichmentResult:
+    item_id: int
+    status: EnrichmentStatus
+    images: int = 0
+    annotations: int = 0
+    message: str | None = None
+
+
+@dataclass
+class BackfillStats:
+    inspected: int = 0
+    backfilled: int = 0
+    already_present: int = 0
+    unavailable: int = 0
+
+
+def enrich_item(
+    item_id: int, *, config: Config | None = None, force: bool = False
+) -> EnrichmentResult:
+    """Enrich a single item by ID. Resolves the source PDF, runs the
+    extractor, persists the result. Idempotent unless `force=True`."""
+    config = config or Config.load()
+    with get_connection(config) as conn:
+        item_row = conn.execute(
+            "SELECT id, source_type, source_id, metadata FROM items WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        if not item_row:
+            return EnrichmentResult(item_id=item_id, status="failed", message="item not found")
+
+        try:
+            pdf_path = _resolve_source_pdf(conn, config, item_row)
+        except _SourceUnavailable as exc:
+            mark_source_unavailable(conn, item_id)
+            return EnrichmentResult(item_id=item_id, status="source_unavailable", message=str(exc))
+
+        try:
+            enriched = enrich_pdf(pdf_path)
+        except Exception as exc:
+            logger.exception("Extractor crashed for item %d", item_id)
+            return EnrichmentResult(item_id=item_id, status="failed", message=str(exc))
+
+        if not force and is_already_enriched(conn, item_id, EXTRACTOR_VERSION, enriched.pdf_sha256):
+            return EnrichmentResult(item_id=item_id, status="skipped")
+
+        try:
+            persist_enrichment(conn, config, item_id, enriched)
+        except Exception as exc:
+            logger.exception("Persistence failed for item %d", item_id)
+            return EnrichmentResult(item_id=item_id, status="failed", message=str(exc))
+
+        return EnrichmentResult(
+            item_id=item_id,
+            status="enriched",
+            images=len(enriched.images),
+            annotations=len(enriched.annotations),
+        )
+
+
+def list_pdf_items(conn: sqlite3.Connection) -> list[int]:
+    """Return IDs of items whose source is a PDF (Google Drive or otherwise).
+
+    Filters by metadata.mime_type or by the presence of a source_pdf media row.
+    """
+    rows = conn.execute(
+        """
+        SELECT DISTINCT i.id FROM items i
+        LEFT JOIN item_media m ON m.item_id = i.id AND m.media_type = ?
+        WHERE m.id IS NOT NULL
+           OR (i.metadata IS NOT NULL AND i.metadata LIKE '%application/pdf%')
+        ORDER BY i.id
+        """,
+        (SOURCE_PDF_MEDIA_TYPE,),
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def backfill_source_pdfs(*, config: Config | None = None) -> BackfillStats:
+    """One-shot backfill: for every Google-Drive-sourced PDF item that lacks a
+    `source_pdf` media row, download the file from Drive and create the row.
+
+    Idempotent: items that already have a source_pdf row are skipped.
+    """
+    config = config or Config.load()
+    stats = BackfillStats()
+    with get_connection(config) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, metadata FROM items
+            WHERE source_type = 'google-drive'
+              AND metadata IS NOT NULL
+              AND metadata LIKE '%application/pdf%'
+            ORDER BY id
+            """
+        ).fetchall()
+        for row in rows:
+            stats.inspected += 1
+            item_id = row[0]
+            existing = conn.execute(
+                "SELECT 1 FROM item_media WHERE item_id = ? AND media_type = ?",
+                (item_id, SOURCE_PDF_MEDIA_TYPE),
+            ).fetchone()
+            if existing:
+                stats.already_present += 1
+                continue
+            try:
+                meta = json.loads(row[1])
+            except (TypeError, json.JSONDecodeError):
+                stats.unavailable += 1
+                continue
+            try:
+                _create_source_pdf_row_from_drive(conn, config, item_id, meta)
+                stats.backfilled += 1
+            except _SourceUnavailable:
+                mark_source_unavailable(conn, item_id)
+                stats.unavailable += 1
+    return stats
+
+
+# --- Internal -----------------------------------------------------------
+
+
+class _SourceUnavailable(Exception):
+    pass
+
+
+def _resolve_source_pdf(conn: sqlite3.Connection, config: Config, item_row: sqlite3.Row) -> Path:
+    """Return a filesystem path to the item's source PDF.
+
+    Order of resolution:
+        1. local_path on a source_pdf media row
+        2. drive_id on either the source_pdf row's url or items.metadata
+           — download into the cache and persist a source_pdf row.
+
+    Raises `_SourceUnavailable` if neither path works.
+    """
+    item_id = item_row[0]
+    media_dir = get_media_dir(config)
+
+    media_row = conn.execute(
+        """
+        SELECT local_path, url FROM item_media
+        WHERE item_id = ? AND media_type = ?
+        ORDER BY id LIMIT 1
+        """,
+        (item_id, SOURCE_PDF_MEDIA_TYPE),
+    ).fetchone()
+    if media_row:
+        local = media_row[0]
+        if local:
+            candidate = media_dir / local
+            if candidate.exists():
+                return candidate
+        # Fall through to Drive re-download
+
+    metadata = {}
+    if item_row[3]:
+        try:
+            metadata = json.loads(item_row[3])
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+    drive_id = metadata.get("drive_id")
+    if not drive_id:
+        raise _SourceUnavailable("no source_pdf row and no drive_id in metadata")
+
+    return _create_source_pdf_row_from_drive(conn, config, item_id, metadata)
+
+
+def _create_source_pdf_row_from_drive(
+    conn: sqlite3.Connection,
+    config: Config,
+    item_id: int,
+    metadata: dict,
+) -> Path:
+    drive_id = metadata.get("drive_id")
+    if not drive_id:
+        raise _SourceUnavailable("metadata has no drive_id")
+
+    title = metadata.get("title") or f"{drive_id}.pdf"
+    name = title if title.lower().endswith(".pdf") else f"{title}.pdf"
+
+    try:
+        from lestash.core.google_auth import get_drive_service
+        from lestash.core.google_drive import _download_file
+    except Exception as exc:
+        raise _SourceUnavailable(f"drive helpers unavailable: {exc}") from exc
+
+    try:
+        service = get_drive_service()
+        cached_path = _download_file(service, drive_id, name)
+    except Exception as exc:
+        raise _SourceUnavailable(f"drive download failed: {exc}") from exc
+
+    try:
+        data = cached_path.read_bytes()
+    except Exception as exc:
+        raise _SourceUnavailable(f"could not read downloaded PDF: {exc}") from exc
+
+    rel_path = save_media_file(item_id, data, name, config=config)
+    add_item_media(
+        conn,
+        item_id,
+        media_type=SOURCE_PDF_MEDIA_TYPE,
+        url=metadata.get("drive_web_link"),
+        local_path=rel_path,
+        mime_type=PDF_MIME,
+        alt_text="original PDF",
+        position=0,
+        source_origin="sync",
+        _commit=False,
+    )
+    conn.commit()
+    return get_media_dir(config) / rel_path

--- a/packages/lestash/src/lestash/core/pdf_enrich/runner.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/runner.py
@@ -102,6 +102,38 @@ def enrich_item(
         )
 
 
+def attach_source_pdf_and_enrich(
+    item_id: int,
+    pdf_bytes: bytes,
+    filename: str,
+    *,
+    drive_url: str | None = None,
+    config: Config | None = None,
+) -> EnrichmentResult:
+    """Inline import path: persist the source PDF as a media row and run the
+    enricher in one shot.
+
+    Called from `sync()` (Drive) and the Kobo backup ingestion paths after
+    the item has been upserted.
+    """
+    config = config or Config.load()
+    with get_connection(config) as conn:
+        rel_path = save_media_file(item_id, pdf_bytes, filename, config=config)
+        add_item_media(
+            conn,
+            item_id,
+            media_type=SOURCE_PDF_MEDIA_TYPE,
+            url=drive_url,
+            local_path=rel_path,
+            mime_type=PDF_MIME,
+            alt_text="original PDF",
+            position=0,
+            source_origin="sync",
+            _commit=True,
+        )
+    return enrich_item(item_id, config=config)
+
+
 def list_pdf_items(conn: sqlite3.Connection) -> list[int]:
     """Return IDs of items whose source is a PDF (Google Drive or otherwise).
 

--- a/packages/lestash/src/lestash/core/pdf_enrich/types.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/types.py
@@ -1,0 +1,45 @@
+"""Dataclasses for the PDF enrichment pipeline.
+
+These are the public interface between the pure extractor and the persistence
+layer. The extractor knows nothing about the database; persistence knows
+nothing about PyMuPDF.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+AnnotationKind = Literal["underline", "circle", "margin_note", "ink_unclassified"]
+
+
+@dataclass
+class ExtractedImage:
+    placeholder_index: int
+    page: int
+    bbox: tuple[float, float, float, float]
+    bytes_: bytes
+    mime_type: str
+    xref_hash: str  # sha256 of bytes_, used to dedup repeated images within a doc
+
+
+@dataclass
+class ExtractedAnnotation:
+    kind: AnnotationKind
+    page: int
+    bbox: tuple[float, float, float, float]
+    anchor_text: str
+    color: str | None
+    strokes: list[list[tuple[float, float]]]
+    annotation_id: str | None  # PDF /NM (annot.info["id"])
+    created_at: str | None  # ISO-8601 from annot.info["creationDate"]
+    stroke_geometry_hash: str  # sha256 of canonicalised strokes; OCR cache key
+
+
+@dataclass
+class EnrichedPdf:
+    content: str
+    pdf_sha256: str
+    extractor_version: int
+    images: list[ExtractedImage] = field(default_factory=list)
+    annotations: list[ExtractedAnnotation] = field(default_factory=list)

--- a/packages/lestash/src/lestash/core/pdf_enrich/version.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/version.py
@@ -1,0 +1,9 @@
+"""Single source of truth for the PDF enrichment extractor version.
+
+Bump when the extractor's behaviour changes in a way that should trigger
+re-processing of previously enriched items via `lestash enrich --all`.
+
+The OCR pass has its own version (see `ocr.py`) so it can evolve independently.
+"""
+
+EXTRACTOR_VERSION: int = 1

--- a/packages/lestash/src/lestash/core/pdf_enrich/version.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/version.py
@@ -6,4 +6,4 @@ re-processing of previously enriched items via `lestash enrich --all`.
 The OCR pass has its own version (see `ocr.py`) so it can evolve independently.
 """
 
-EXTRACTOR_VERSION: int = 2
+EXTRACTOR_VERSION: int = 3

--- a/packages/lestash/src/lestash/core/pdf_enrich/version.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/version.py
@@ -6,4 +6,4 @@ re-processing of previously enriched items via `lestash enrich --all`.
 The OCR pass has its own version (see `ocr.py`) so it can evolve independently.
 """
 
-EXTRACTOR_VERSION: int = 1
+EXTRACTOR_VERSION: int = 2

--- a/packages/lestash/tests/pdf_enrich/conftest.py
+++ b/packages/lestash/tests/pdf_enrich/conftest.py
@@ -1,0 +1,75 @@
+"""Test fixtures for the PDF enrichment pipeline.
+
+Uses PyMuPDF to synthesise small PDFs at test time so we don't need to commit
+binary fixture files. Each builder produces a minimal PDF that exercises one
+extractor (links / images / ink annotations).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def make_pdf(tmp_path: Path):
+    """Factory: returns a function `build(pages)` that produces a PDF file.
+
+    Each `page` is a dict with optional keys:
+        text:   list of (rect, content) — drawn text spans
+        links:  list of (rect, uri, anchor) — URI link annotations + their text
+        images: list of (rect, png_bytes) — embedded raster images
+        ink:    list of stroke-lists, each stroke a list of (x, y) points
+    """
+    import pymupdf
+
+    def build(pages, name: str = "test.pdf") -> Path:
+        doc = pymupdf.open()
+        for page_spec in pages:
+            page = doc.new_page(width=612, height=792)  # US Letter
+
+            for rect, content in page_spec.get("text", []):
+                r = pymupdf.Rect(*rect)
+                page.insert_textbox(r, content, fontsize=11)
+
+            for rect, uri, anchor in page_spec.get("links", []):
+                r = pymupdf.Rect(*rect)
+                # Render the anchor text first so PyMuPDF has something to clip.
+                page.insert_textbox(r, anchor, fontsize=11, color=(0, 0, 1))
+                page.insert_link({"kind": pymupdf.LINK_URI, "from": r, "uri": uri})
+
+            for rect, png_bytes in page_spec.get("images", []):
+                r = pymupdf.Rect(*rect)
+                page.insert_image(r, stream=png_bytes)
+
+            for stroke_list in page_spec.get("ink", []):
+                annot = page.add_ink_annot([stroke_list])
+                annot.set_border(width=1.0)
+                annot.update()
+
+        out = tmp_path / name
+        doc.save(out)
+        doc.close()
+        return out
+
+    return build
+
+
+def _solid_png(rgb: tuple[int, int, int]) -> bytes:
+    """Build a tiny solid-colour PNG using PyMuPDF's pixmap API."""
+    import pymupdf
+
+    pix = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 8, 8), False)
+    pix.set_rect(pix.irect, rgb)
+    return pix.tobytes("png")
+
+
+@pytest.fixture
+def red_dot_png() -> bytes:
+    return _solid_png((255, 0, 0))
+
+
+@pytest.fixture
+def blue_dot_png() -> bytes:
+    return _solid_png((0, 0, 255))

--- a/packages/lestash/tests/pdf_enrich/test_annotations.py
+++ b/packages/lestash/tests/pdf_enrich/test_annotations.py
@@ -1,0 +1,119 @@
+"""Unit tests for the ink-annotation classifier.
+
+Drives the classifier directly with synthetic stroke fixtures rather than
+through PyMuPDF, since constructing a PDF with ink annotations is brittle and
+the classifier itself is what we care about here. End-to-end coverage against
+real PyMuPDF Ink output lives in test_extractor.py.
+"""
+
+import math
+
+from lestash.core.pdf_enrich import annotations as ann_mod
+
+
+class _FakePage:
+    """Minimal stand-in for pymupdf.Page used by `_classify_group`."""
+
+    def __init__(self, width: float = 612.0, height: float = 792.0):
+        self.rect = type("R", (), {"width": width, "height": height})()
+
+    def get_text(self, clip=None):
+        return ""
+
+
+def _ink(strokes, bbox=None, color=None, ann_id=None, created_at=None):
+    points = [pt for s in strokes for pt in s]
+    if bbox is None:
+        xs = [p[0] for p in points]
+        ys = [p[1] for p in points]
+        bbox = (min(xs), min(ys), max(xs), max(ys))
+    return ann_mod._RawInk(
+        strokes=strokes,
+        bbox=bbox,
+        color=color,
+        annotation_id=ann_id,
+        created_at=created_at,
+    )
+
+
+def test_underline_is_classified():
+    stroke = [(100, 500), (160, 501), (220, 500), (280, 500.5)]
+    group = [_ink([stroke])]
+    out = ann_mod._classify_group(group, page=_FakePage(), page_num=0)
+    assert out.kind == "underline"
+
+
+def test_circle_is_classified():
+    cx, cy, r = 300.0, 400.0, 30.0
+    stroke = [
+        (cx + r * math.cos(t), cy + r * math.sin(t))
+        for t in [i * (2 * math.pi / 24) for i in range(24)]
+    ]
+    stroke.append(stroke[0])  # close the loop
+    group = [_ink([stroke])]
+    out = ann_mod._classify_group(group, page=_FakePage(), page_num=0)
+    assert out.kind == "circle"
+
+
+def test_margin_note_is_classified():
+    # In the leftmost band of a 612pt-wide page (< 18% from left)
+    stroke = [(20, 100), (24, 110), (28, 120), (32, 130)]
+    group = [_ink([stroke])]
+    out = ann_mod._classify_group(group, page=_FakePage(), page_num=0)
+    assert out.kind == "margin_note"
+
+
+def test_unrecognised_strokes_fall_through_to_unclassified():
+    # Random scribble in the middle of the page
+    stroke = [(300, 400), (305, 410), (315, 405), (310, 415), (320, 420)]
+    group = [_ink([stroke])]
+    out = ann_mod._classify_group(group, page=_FakePage(), page_num=0)
+    assert out.kind == "ink_unclassified"
+
+
+def test_classification_propagates_metadata():
+    stroke = [(100, 500), (200, 500.5), (300, 500)]
+    group = [
+        _ink(
+            [stroke],
+            color="#ff0000",
+            ann_id="abc-123",
+            created_at="D:20260415120000Z",
+        )
+    ]
+    out = ann_mod._classify_group(group, page=_FakePage(), page_num=2)
+    assert out.color == "#ff0000"
+    assert out.annotation_id == "abc-123"
+    assert out.created_at == "D:20260415120000Z"
+    assert out.page == 2
+    assert out.stroke_geometry_hash  # non-empty hash
+
+
+def test_stroke_grouping_merges_nearby_strokes():
+    # Two strokes whose bbox centers are 10pt apart — should merge
+    s1 = [(100, 100), (110, 100)]
+    s2 = [(115, 100), (125, 100)]
+    groups = ann_mod._group_strokes([_ink([s1]), _ink([s2])])
+    assert len(groups) == 1
+    assert len(groups[0]) == 2
+
+
+def test_stroke_grouping_keeps_distant_strokes_separate():
+    # Two strokes 200pt apart — distinct annotations
+    s1 = [(100, 100), (110, 100)]
+    s2 = [(400, 100), (410, 100)]
+    groups = ann_mod._group_strokes([_ink([s1]), _ink([s2])])
+    assert len(groups) == 2
+
+
+def test_geometry_hash_is_stable_across_jitter():
+    # Same shape, sub-2-decimal jitter → same hash
+    a = [[(10.001, 20.002), (30.003, 40.004)]]
+    b = [[(10.0009, 20.0021), (30.0029, 40.0041)]]
+    assert ann_mod._hash_strokes(a) == ann_mod._hash_strokes(b)
+
+
+def test_geometry_hash_changes_with_real_difference():
+    a = [[(10.0, 20.0), (30.0, 40.0)]]
+    b = [[(10.0, 20.0), (30.0, 41.0)]]
+    assert ann_mod._hash_strokes(a) != ann_mod._hash_strokes(b)

--- a/packages/lestash/tests/pdf_enrich/test_cleanup.py
+++ b/packages/lestash/tests/pdf_enrich/test_cleanup.py
@@ -1,0 +1,21 @@
+from lestash.core.pdf_enrich.cleanup import strip_artifacts
+
+
+def test_strips_trailing_interpunct():
+    assert strip_artifacts("foo bar ·\n") == "foo bar\n"
+    assert strip_artifacts("foo bar ◦\n") == "foo bar\n"
+
+
+def test_preserves_inline_interpunct():
+    assert strip_artifacts("m·s⁻¹") == "m·s⁻¹"
+    assert strip_artifacts("a·b·c\n") == "a·b·c\n"
+
+
+def test_strips_only_at_end_of_line():
+    src = "first ·\nsecond ◦\nthird line\n"
+    assert strip_artifacts(src) == "first\nsecond\nthird line\n"
+
+
+def test_leaves_normal_content_intact():
+    src = "## Heading\n\n- list item\n- another\n"
+    assert strip_artifacts(src) == src

--- a/packages/lestash/tests/pdf_enrich/test_extractor.py
+++ b/packages/lestash/tests/pdf_enrich/test_extractor.py
@@ -1,0 +1,128 @@
+"""End-to-end tests for `enrich_pdf` against synthesised PDFs.
+
+These exercise the real PyMuPDF surface (links, images, ink annotations) with
+Docling stubbed out — Docling is large, slow, and tested separately in
+`test_text_extract.py`. We replace `convert_to_markdown` so each test can
+control the markdown the enricher post-processes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _stub_docling(markdown: str):
+    return patch(
+        "lestash.core.pdf_enrich.extractor.convert_to_markdown",
+        return_value=markdown,
+    )
+
+
+def test_enrich_pdf_returns_artifact_with_sha_and_version(make_pdf):
+    pdf: Path = make_pdf([{"text": [((50, 50, 500, 100), "hello world")]}])
+    from lestash.core.pdf_enrich import enrich_pdf
+
+    with _stub_docling("hello world\n"):
+        result = enrich_pdf(pdf)
+    assert result.content == "hello world\n"
+    assert len(result.pdf_sha256) == 64
+    assert result.extractor_version >= 1
+
+
+def test_enrich_pdf_extracts_link_and_rewrites_anchor(make_pdf):
+    pdf = make_pdf(
+        [
+            {
+                "text": [((50, 50, 500, 80), "see the docs")],
+                "links": [((50, 90, 500, 110), "https://docs.example", "the docs")],
+            }
+        ]
+    )
+    from lestash.core.pdf_enrich import enrich_pdf
+
+    with _stub_docling("see the docs page\n"):
+        result = enrich_pdf(pdf)
+    assert "(https://docs.example)" in result.content
+
+
+def test_enrich_pdf_extracts_image_bytes(make_pdf, red_dot_png):
+    pdf = make_pdf(
+        [
+            {
+                "text": [((50, 50, 500, 80), "report")],
+                "images": [((100, 200, 200, 300), red_dot_png)],
+            }
+        ]
+    )
+    from lestash.core.pdf_enrich import enrich_pdf
+
+    with _stub_docling("report\n\n<!-- image -->\n"):
+        result = enrich_pdf(pdf)
+    assert len(result.images) == 1
+    img = result.images[0]
+    assert img.bytes_  # non-empty bytes
+    assert img.mime_type.startswith("image/")
+    assert len(img.xref_hash) == 64
+
+
+def test_enrich_pdf_dedups_repeated_image_xref(make_pdf, red_dot_png):
+    # Same PNG inserted twice — should appear once in the output
+    pdf = make_pdf(
+        [
+            {
+                "images": [
+                    ((100, 200, 150, 250), red_dot_png),
+                    ((300, 200, 350, 250), red_dot_png),
+                ]
+            }
+        ]
+    )
+    from lestash.core.pdf_enrich import enrich_pdf
+
+    with _stub_docling("<!-- image -->\n<!-- image -->\n"):
+        result = enrich_pdf(pdf)
+    assert len(result.images) == 1
+
+
+def test_enrich_pdf_extracts_ink_annotation(make_pdf):
+    horizontal_underline = [(100, 500), (160, 500), (220, 500), (280, 500)]
+    pdf = make_pdf(
+        [
+            {
+                "text": [((50, 480, 500, 510), "underlined phrase here")],
+                "ink": [horizontal_underline],
+            }
+        ]
+    )
+    from lestash.core.pdf_enrich import enrich_pdf
+
+    with _stub_docling("underlined phrase here\n"):
+        result = enrich_pdf(pdf)
+    assert len(result.annotations) >= 1
+    # Long thin horizontal stroke → underline
+    assert result.annotations[0].kind == "underline"
+
+
+def test_enrich_pdf_strips_trailing_bullet_artifacts(make_pdf):
+    pdf = make_pdf([{"text": [((50, 50, 500, 100), "x")]}])
+    from lestash.core.pdf_enrich import enrich_pdf
+
+    with _stub_docling("- first ·\n- second ◦\n"):
+        result = enrich_pdf(pdf)
+    assert "·" not in result.content
+    assert "◦" not in result.content
+
+
+def test_enrich_pdf_handles_corrupt_input_gracefully(tmp_path: Path):
+    bad = tmp_path / "broken.pdf"
+    bad.write_bytes(b"not a pdf at all")
+    from lestash.core.pdf_enrich import enrich_pdf
+
+    with _stub_docling("fallback content\n"):
+        result = enrich_pdf(bad)
+    # Even when PyMuPDF can't open the file, we still return a result with
+    # Docling's content and a sha256 — never raise.
+    assert "fallback content" in result.content
+    assert result.images == []
+    assert result.annotations == []

--- a/packages/lestash/tests/pdf_enrich/test_extractor.py
+++ b/packages/lestash/tests/pdf_enrich/test_extractor.py
@@ -66,8 +66,11 @@ def test_enrich_pdf_extracts_image_bytes(make_pdf, red_dot_png):
     assert len(img.xref_hash) == 64
 
 
-def test_enrich_pdf_dedups_repeated_image_xref(make_pdf, red_dot_png):
-    # Same PNG inserted twice — should appear once in the output
+def test_enrich_pdf_emits_one_entry_per_image_occurrence(make_pdf, red_dot_png):
+    """Same PNG used twice should produce two ExtractedImage entries (so each
+    Docling placeholder gets a replacement) but they share an xref_hash —
+    persistence dedups by hash to a single media row. See #143.
+    """
     pdf = make_pdf(
         [
             {
@@ -82,7 +85,8 @@ def test_enrich_pdf_dedups_repeated_image_xref(make_pdf, red_dot_png):
 
     with _stub_docling("<!-- image -->\n<!-- image -->\n"):
         result = enrich_pdf(pdf)
-    assert len(result.images) == 1
+    assert len(result.images) == 2
+    assert result.images[0].xref_hash == result.images[1].xref_hash
 
 
 def test_enrich_pdf_extracts_ink_annotation(make_pdf):

--- a/packages/lestash/tests/pdf_enrich/test_images.py
+++ b/packages/lestash/tests/pdf_enrich/test_images.py
@@ -27,3 +27,29 @@ def test_apply_images_leaves_unmatched_placeholders_intact():
 def test_apply_images_no_placeholders_is_noop():
     md = "no images here"
     assert apply_images(md, {}) == md
+
+
+def test_extract_images_emits_one_entry_per_page_occurrence(make_pdf, red_dot_png):
+    """Regression for #143: same image used on multiple pages must produce
+    one ExtractedImage per page-occurrence (so each Docling placeholder gets
+    a replacement) but the entries share an xref_hash so persistence dedups."""
+    import pymupdf
+    from lestash.core.pdf_enrich.images import extract_images
+
+    pdf = make_pdf(
+        [
+            {"images": [((100, 100, 200, 200), red_dot_png)]},
+            {"images": [((100, 100, 200, 200), red_dot_png)]},
+            {"images": [((100, 100, 200, 200), red_dot_png)]},
+        ]
+    )
+    doc = pymupdf.open(pdf)
+    try:
+        images = extract_images(doc)
+    finally:
+        doc.close()
+
+    assert len(images) == 3
+    assert {img.xref_hash for img in images} == {images[0].xref_hash}
+    assert [img.placeholder_index for img in images] == [0, 1, 2]
+    assert [img.page for img in images] == [0, 1, 2]

--- a/packages/lestash/tests/pdf_enrich/test_images.py
+++ b/packages/lestash/tests/pdf_enrich/test_images.py
@@ -1,0 +1,29 @@
+from lestash.core.pdf_enrich.images import apply_images, count_placeholders
+
+
+def test_count_placeholders():
+    assert count_placeholders("") == 0
+    assert count_placeholders("<!-- image -->") == 1
+    assert count_placeholders("a <!-- image --> b <!-- image --> c") == 2
+    # Case-insensitive
+    assert count_placeholders("<!-- IMAGE -->") == 1
+
+
+def test_apply_images_replaces_in_order():
+    md = "first <!-- image --> middle <!-- image --> last"
+    out = apply_images(
+        md,
+        {0: "![a](/api/media/1)", 1: "![b](/api/media/2)"},
+    )
+    assert out == "first ![a](/api/media/1) middle ![b](/api/media/2) last"
+
+
+def test_apply_images_leaves_unmatched_placeholders_intact():
+    md = "<!-- image --> A <!-- image --> B"
+    out = apply_images(md, {0: "![only](/api/media/9)"})
+    assert out == "![only](/api/media/9) A <!-- image --> B"
+
+
+def test_apply_images_no_placeholders_is_noop():
+    md = "no images here"
+    assert apply_images(md, {}) == md

--- a/packages/lestash/tests/pdf_enrich/test_links.py
+++ b/packages/lestash/tests/pdf_enrich/test_links.py
@@ -60,3 +60,41 @@ def test_soft_hyphen_is_ignored_in_match():
     links = [_link("https://x", "Dijkstra Archive")]
     out = apply_links(md, links)
     assert "(https://x)" in out
+
+
+# --- Aggressive fallback (regression for #143) -------------------------------
+
+
+def test_aggressive_match_recovers_ampersand_anchor():
+    """Anchor 'Barnes & Noble' should match Docling's reformatted output
+    where the ampersand was rendered or escaped differently."""
+    md = "available at Barnes  Noble (online)"
+    links = [_link("https://barnes-noble.example", "Barnes & Noble")]
+    out = apply_links(md, links)
+    assert "(https://barnes-noble.example)" in out
+    assert "<!-- unmatched-links -->" not in out
+
+
+def test_aggressive_match_recovers_doi_with_punctuation():
+    """A DOI anchor 'DOI: 10.1007/11568285_9' should match a stripped form."""
+    md = "see DOI 10 1007 11568285 9 in the references"
+    links = [_link("https://doi.example/x", "DOI: 10.1007/11568285_9")]
+    out = apply_links(md, links)
+    assert "(https://doi.example/x)" in out
+
+
+def test_aggressive_match_handles_smart_quotes():
+    """O’Reilly (curly apostrophe) → O'Reilly via NFKC."""
+    md = "the O’Reilly handbook"
+    links = [_link("https://oreilly.example", "O'Reilly")]
+    out = apply_links(md, links)
+    assert "(https://oreilly.example)" in out
+
+
+def test_strict_match_still_wins_when_both_pass():
+    """If a strict match exists, the strict span (not the aggressive one) is
+    used so we don't accidentally widen the rewritten anchor."""
+    md = "click here for docs"
+    links = [_link("https://x", "click here")]
+    out = apply_links(md, links)
+    assert out == "[click here](https://x) for docs"

--- a/packages/lestash/tests/pdf_enrich/test_links.py
+++ b/packages/lestash/tests/pdf_enrich/test_links.py
@@ -1,0 +1,62 @@
+from lestash.core.pdf_enrich.links import Link, apply_links
+
+
+def _link(uri: str, anchor: str) -> Link:
+    return Link(page=0, bbox=(0, 0, 0, 0), uri=uri, anchor_text=anchor)
+
+
+def test_replaces_first_occurrence_only():
+    md = "click here and click here again"
+    links = [_link("https://a.example", "click here")]
+    out = apply_links(md, links)
+    assert out == "[click here](https://a.example) and click here again"
+
+
+def test_two_links_same_anchor_walk_left_to_right():
+    md = "see here and then see here at the bottom"
+    links = [
+        _link("https://1.example", "see here"),
+        _link("https://2.example", "see here"),
+    ]
+    out = apply_links(md, links)
+    assert (
+        out == "[see here](https://1.example) and then [see here](https://2.example) at the bottom"
+    )
+
+
+def test_normalised_match_across_line_breaks():
+    # Docling reflowed the anchor — newline + extra whitespace
+    md = "Visit the\n  Dijkstra Archive  for the source."
+    links = [_link("https://cs.utexas.edu/EWD", "Dijkstra Archive")]
+    out = apply_links(md, links)
+    assert "[Dijkstra Archive" in out
+    assert "(https://cs.utexas.edu/EWD)" in out
+
+
+def test_unmatched_link_is_appended_not_dropped():
+    md = "no anchor here"
+    links = [_link("https://lost.example", "ghost text")]
+    out = apply_links(md, links)
+    assert "no anchor here" in out
+    assert "<!-- unmatched-links -->" in out
+    assert "https://lost.example" in out
+
+
+def test_empty_anchor_text_is_unmatched():
+    md = "hello world"
+    links = [_link("https://empty.example", "")]
+    out = apply_links(md, links)
+    assert "<!-- unmatched-links -->" in out
+    assert "https://empty.example" in out
+
+
+def test_no_links_returns_markdown_unchanged():
+    md = "## Heading\n\nbody text"
+    assert apply_links(md, []) == md
+
+
+def test_soft_hyphen_is_ignored_in_match():
+    md = "the Dij­kstra Archive"
+    links = [_link("https://x", "Dijkstra Archive")]
+    out = apply_links(md, links)
+    assert "(https://x)" in out

--- a/packages/lestash/tests/pdf_enrich/test_links.py
+++ b/packages/lestash/tests/pdf_enrich/test_links.py
@@ -98,3 +98,33 @@ def test_strict_match_still_wins_when_both_pass():
     links = [_link("https://x", "click here")]
     out = apply_links(md, links)
     assert out == "[click here](https://x) for docs"
+
+
+def test_aggressive_match_decodes_html_entities_in_haystack():
+    """Docling sometimes encodes ampersands as &amp; in its markdown output.
+    The aggressive pass must decode entities so the anchor 'Barnes & Noble'
+    matches a 'Barnes &amp; Noble' span. Regression for #143."""
+    md = "available at Barnes &amp; Noble (online)"
+    links = [_link("https://barnes-noble.example", "Barnes & Noble")]
+    out = apply_links(md, links)
+    assert "[Barnes &amp; Noble](https://barnes-noble.example)" in out
+    assert "<!-- unmatched-links -->" not in out
+
+
+def test_aggressive_match_decodes_numeric_entity():
+    """`&#39;` (numeric entity for `'`) should also decode and match."""
+    md = "the O&#39;Reilly handbook"
+    links = [_link("https://oreilly.example", "O'Reilly")]
+    out = apply_links(md, links)
+    assert "(https://oreilly.example)" in out
+    # Span must wrap the original entity-encoded source, not just the apostrophe
+    assert "[O&#39;Reilly]" in out
+
+
+def test_aggressive_span_covers_full_entity_run():
+    """When the matched span starts inside a multi-char entity, the rewrite
+    must wrap the whole entity (so we never split `&amp;` mid-token)."""
+    md = "AT&amp;T inside"
+    links = [_link("https://att.example", "AT&T")]
+    out = apply_links(md, links)
+    assert out == "[AT&amp;T](https://att.example) inside"

--- a/packages/lestash/tests/pdf_enrich/test_ocr.py
+++ b/packages/lestash/tests/pdf_enrich/test_ocr.py
@@ -1,0 +1,226 @@
+"""Tests for the Claude-vision OCR pass.
+
+The `anthropic` SDK is mocked at the client boundary — no network calls.
+Stroke rendering is exercised against real PyMuPDF.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from lestash.core.config import Config, GeneralConfig
+from lestash.core.database import (
+    add_item_media,
+    get_connection,
+    init_database,
+    save_media_file,
+    upsert_item,
+)
+from lestash.core.pdf_enrich import ocr as ocr_module
+from lestash.core.pdf_enrich.ocr import (
+    OCR_EXTRACTOR_VERSION,
+    ocr_annotation,
+    ocr_pending_annotations,
+)
+from lestash.models.item import ItemCreate
+
+
+@pytest.fixture
+def config():
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = Config(general=GeneralConfig(database_path=str(Path(tmp) / "t.db")))
+        init_database(cfg)
+        yield cfg
+
+
+@pytest.fixture
+def annotated_item(config: Config, make_pdf):
+    """A parent PDF item with one margin_note child needing OCR."""
+    pdf_path = make_pdf([{"text": [((50, 50, 500, 100), "body of doc")]}], name="parent.pdf")
+    pdf_bytes = pdf_path.read_bytes()
+
+    with get_connection(config) as conn:
+        parent_id = upsert_item(
+            conn,
+            ItemCreate(
+                source_type="pdf",
+                source_id="parent-1",
+                title="Parent PDF",
+                content="body",
+            ),
+        )
+        rel = save_media_file(parent_id, pdf_bytes, "parent.pdf", config=config)
+        add_item_media(
+            conn,
+            parent_id,
+            media_type="source_pdf",
+            local_path=rel,
+            mime_type="application/pdf",
+        )
+        # Margin note child
+        child_id = conn.execute(
+            """
+            INSERT INTO items (source_type, source_id, title, content, metadata, parent_id)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "pdf_annotation",
+                "child-1",
+                "Margin note",
+                "ink",
+                json.dumps(
+                    {
+                        "annotation_kind": "margin_note",
+                        "page": 0,
+                        "bbox": [10, 60, 60, 90],
+                        "color": "#000000",
+                        "strokes": [[[12, 65], [55, 70]]],
+                        "stroke_geometry_hash": "h" * 64,
+                        "annotation_id": "mn-1",
+                    }
+                ),
+                parent_id,
+            ),
+        ).lastrowid
+        conn.commit()
+    assert child_id is not None
+    return parent_id, child_id
+
+
+def _mock_anthropic(text: str):
+    """Patch ocr._transcribe_with_claude to return `text` without touching
+    the SDK or environment at all."""
+    return patch.object(ocr_module, "_transcribe_with_claude", return_value=text)
+
+
+def test_ocr_writes_transcription_to_child_content(config, annotated_item):
+    parent_id, child_id = annotated_item
+    with _mock_anthropic("Add a title page"):
+        result = ocr_annotation(child_id, config=config)
+    assert result.status == "transcribed"
+    assert result.text == "Add a title page"
+
+    with get_connection(config) as conn:
+        row = conn.execute(
+            "SELECT content, metadata FROM items WHERE id = ?", (child_id,)
+        ).fetchone()
+    assert row["content"] == "Add a title page"
+    meta = json.loads(row["metadata"])
+    assert meta["ocr_text"] == "Add a title page"
+    assert meta["ocr_version"] == OCR_EXTRACTOR_VERSION
+
+
+def test_ocr_is_idempotent_when_version_matches(config, annotated_item):
+    parent_id, child_id = annotated_item
+    with _mock_anthropic("first run") as patched:
+        first = ocr_annotation(child_id, config=config)
+        second = ocr_annotation(child_id, config=config)
+    assert first.status == "transcribed"
+    assert second.status == "skipped"
+    # Mock should have been called exactly once
+    assert patched.call_count == 1
+
+
+def test_ocr_skips_kinds_outside_target(config, annotated_item):
+    parent_id, child_id = annotated_item
+    # Promote the child to an underline (not in OCR_TARGET_KINDS)
+    with get_connection(config) as conn:
+        meta = json.loads(
+            conn.execute("SELECT metadata FROM items WHERE id = ?", (child_id,)).fetchone()[0]
+        )
+        meta["annotation_kind"] = "underline"
+        conn.execute(
+            "UPDATE items SET metadata = ? WHERE id = ?",
+            (json.dumps(meta), child_id),
+        )
+        conn.commit()
+
+    with _mock_anthropic("never called") as patched:
+        result = ocr_annotation(child_id, config=config)
+    assert result.status == "skipped"
+    assert patched.call_count == 0
+
+
+def test_ocr_unavailable_when_source_pdf_missing(config):
+    """A child whose parent has no source_pdf media row → unavailable, not crash."""
+    with get_connection(config) as conn:
+        parent_id = upsert_item(
+            conn,
+            ItemCreate(
+                source_type="pdf",
+                source_id="orphan-parent",
+                title="orphan",
+                content="x",
+            ),
+        )
+        child_id = conn.execute(
+            "INSERT INTO items (source_type, source_id, content, metadata, parent_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                "pdf_annotation",
+                "orphan-child",
+                "ink",
+                json.dumps(
+                    {
+                        "annotation_kind": "margin_note",
+                        "page": 0,
+                        "bbox": [10, 10, 50, 50],
+                        "stroke_geometry_hash": "z" * 64,
+                    }
+                ),
+                parent_id,
+            ),
+        ).lastrowid
+        conn.commit()
+
+    result = ocr_annotation(child_id, config=config)
+    assert result.status == "unavailable"
+
+
+def test_ocr_pending_annotations_filters_by_parent(config, annotated_item):
+    parent_id, child_id = annotated_item
+    # Create a second parent with its own margin note that should NOT be touched
+    with get_connection(config) as conn:
+        other_parent = upsert_item(
+            conn,
+            ItemCreate(source_type="pdf", source_id="other-parent", content="x"),
+        )
+        conn.execute(
+            "INSERT INTO items (source_type, source_id, content, metadata, parent_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                "pdf_annotation",
+                "other-child",
+                "ink",
+                json.dumps(
+                    {
+                        "annotation_kind": "margin_note",
+                        "page": 0,
+                        "bbox": [10, 10, 50, 50],
+                        "stroke_geometry_hash": "y" * 64,
+                    }
+                ),
+                other_parent,
+            ),
+        )
+        conn.commit()
+
+    with _mock_anthropic("transcribed"):
+        results = ocr_pending_annotations(item_id=parent_id, config=config)
+
+    assert len(results) == 1
+    assert results[0].child_id == child_id
+
+
+def test_ocr_unreadable_response_yields_empty_string(config, annotated_item):
+    parent_id, child_id = annotated_item
+    # The function under _transcribe_with_claude maps "UNREADABLE" → ""; we
+    # mock at the same boundary and test the behaviour at the public edge.
+    with patch.object(ocr_module, "_transcribe_with_claude", return_value=""):
+        result = ocr_annotation(child_id, config=config)
+    assert result.status == "transcribed"
+    assert result.text == ""

--- a/packages/lestash/tests/pdf_enrich/test_persistence.py
+++ b/packages/lestash/tests/pdf_enrich/test_persistence.py
@@ -160,6 +160,46 @@ def test_idempotent_rerun_replaces_prior_artifacts(config, parent_pdf_item):
     assert json.loads(children[0]["metadata"])["annotation_kind"] == "circle"
 
 
+def test_repeated_image_dedups_to_one_media_row_but_replaces_all_placeholders(
+    config, parent_pdf_item
+):
+    """Regression for #143: the same image (same xref_hash) appearing on
+    multiple pages must produce one media row whose ID is reused for every
+    placeholder, not just the first.
+    """
+    shared_hash = "share" * 12 + "share1234"  # 64 chars
+    images = [
+        ExtractedImage(
+            placeholder_index=i,
+            page=i,
+            bbox=(0, 0, 10, 10),
+            bytes_=b"identical-png-bytes",
+            mime_type="image/png",
+            xref_hash=shared_hash,
+        )
+        for i in range(3)
+    ]
+    enriched = _enriched(
+        content="<!-- image -->\nA\n<!-- image -->\nB\n<!-- image -->\n",
+        images=images,
+    )
+
+    with get_connection(config) as conn:
+        persist_enrichment(conn, config, parent_pdf_item, enriched)
+        media_rows = conn.execute(
+            "SELECT id FROM item_media WHERE item_id = ? AND source_origin = 'enricher'",
+            (parent_pdf_item,),
+        ).fetchall()
+        item = conn.execute("SELECT content FROM items WHERE id = ?", (parent_pdf_item,)).fetchone()
+
+    assert len(media_rows) == 1
+    media_id = media_rows[0]["id"]
+    # All three placeholders should have been substituted with the same
+    # media_id link, leaving zero `<!-- image -->` markers behind.
+    assert "<!-- image -->" not in item["content"]
+    assert item["content"].count(f"/api/media/{media_id}") == 3
+
+
 def test_persist_does_not_delete_source_pdf_media_row(config, parent_pdf_item):
     with get_connection(config) as conn:
         add_item_media(

--- a/packages/lestash/tests/pdf_enrich/test_persistence.py
+++ b/packages/lestash/tests/pdf_enrich/test_persistence.py
@@ -1,0 +1,230 @@
+"""Tests for the persistence layer.
+
+Drive an `EnrichedPdf` artifact directly into a real SQLite database and
+verify the resulting rows. The extractor is not exercised here.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+from lestash.core.config import Config, GeneralConfig
+from lestash.core.database import (
+    add_item_media,
+    get_connection,
+    init_database,
+    upsert_item,
+)
+from lestash.core.pdf_enrich.persistence import (
+    is_already_enriched,
+    mark_source_unavailable,
+    persist_enrichment,
+)
+from lestash.core.pdf_enrich.types import (
+    EnrichedPdf,
+    ExtractedAnnotation,
+    ExtractedImage,
+)
+from lestash.models.item import ItemCreate
+
+
+@pytest.fixture
+def config():
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = Config(general=GeneralConfig(database_path=str(Path(tmp) / "t.db")))
+        init_database(cfg)
+        yield cfg
+
+
+@pytest.fixture
+def parent_pdf_item(config: Config) -> int:
+    with get_connection(config) as conn:
+        item_id = upsert_item(
+            conn,
+            ItemCreate(
+                source_type="google-drive",
+                source_id="drive-fixture-1",
+                title="A Document",
+                content="<!-- image -->\noriginal docling output",
+                metadata={"drive_id": "drive-fixture-1", "mime_type": "application/pdf"},
+            ),
+        )
+    return item_id
+
+
+def _enriched(content: str = "<!-- image -->\nbody", **kwargs) -> EnrichedPdf:
+    return EnrichedPdf(
+        content=content,
+        pdf_sha256=kwargs.get("sha", "a" * 64),
+        extractor_version=kwargs.get("version", 1),
+        images=kwargs.get("images", []),
+        annotations=kwargs.get("annotations", []),
+    )
+
+
+def _image(idx: int = 0) -> ExtractedImage:
+    return ExtractedImage(
+        placeholder_index=idx,
+        page=0,
+        bbox=(0, 0, 10, 10),
+        bytes_=b"fake-png-bytes",
+        mime_type="image/png",
+        xref_hash="abc" * 21 + "d",
+    )
+
+
+def _annotation(kind: str = "underline", anchor: str = "key phrase") -> ExtractedAnnotation:
+    return ExtractedAnnotation(
+        kind=kind,  # type: ignore[arg-type]
+        page=0,
+        bbox=(100, 200, 300, 220),
+        anchor_text=anchor,
+        color="#ff0000",
+        strokes=[[(100, 200), (300, 200)]],
+        annotation_id="annot-uuid-1",
+        created_at="D:20260415120000Z",
+        stroke_geometry_hash="h" * 64,
+    )
+
+
+def test_persist_writes_image_media_row_and_rewrites_content(config, parent_pdf_item):
+    enriched = _enriched(content="<!-- image -->\nbody", images=[_image(0)])
+    with get_connection(config) as conn:
+        persist_enrichment(conn, config, parent_pdf_item, enriched)
+
+        rows = conn.execute(
+            "SELECT media_type, source_origin FROM item_media WHERE item_id = ?",
+            (parent_pdf_item,),
+        ).fetchall()
+        assert any(r["media_type"] == "image" and r["source_origin"] == "enricher" for r in rows)
+
+        item = conn.execute("SELECT content FROM items WHERE id = ?", (parent_pdf_item,)).fetchone()
+    assert "/api/media/" in item["content"]
+    assert "<!-- image -->" not in item["content"]
+
+
+def test_persist_creates_child_annotation_items(config, parent_pdf_item):
+    enriched = _enriched(annotations=[_annotation()])
+    with get_connection(config) as conn:
+        persist_enrichment(conn, config, parent_pdf_item, enriched)
+        children = conn.execute(
+            "SELECT source_type, content, metadata, parent_id FROM items WHERE parent_id = ?",
+            (parent_pdf_item,),
+        ).fetchall()
+    assert len(children) == 1
+    child = children[0]
+    assert child["source_type"] == "pdf_annotation"
+    assert child["content"] == "key phrase"
+    meta = json.loads(child["metadata"])
+    assert meta["annotation_kind"] == "underline"
+    assert meta["page"] == 0
+    assert meta["color"] == "#ff0000"
+
+
+def test_persist_updates_parent_metadata_with_sha_and_version(config, parent_pdf_item):
+    enriched = _enriched(sha="cafe" * 16, version=7)
+    with get_connection(config) as conn:
+        persist_enrichment(conn, config, parent_pdf_item, enriched)
+        row = conn.execute("SELECT metadata FROM items WHERE id = ?", (parent_pdf_item,)).fetchone()
+    meta = json.loads(row["metadata"])
+    assert meta["pdf_sha256"] == "cafe" * 16
+    assert meta["extractor_version"] == 7
+    assert meta["enrichment_status"] == "ok"
+    assert meta["enriched_at"]
+
+
+def test_idempotent_rerun_replaces_prior_artifacts(config, parent_pdf_item):
+    first = _enriched(images=[_image(0)], annotations=[_annotation(kind="underline")])
+    second = _enriched(
+        images=[],
+        annotations=[_annotation(kind="circle", anchor="other phrase")],
+    )
+
+    with get_connection(config) as conn:
+        persist_enrichment(conn, config, parent_pdf_item, first)
+        persist_enrichment(conn, config, parent_pdf_item, second)
+
+        media_count = conn.execute(
+            "SELECT COUNT(*) FROM item_media WHERE item_id = ? AND source_origin = 'enricher'",
+            (parent_pdf_item,),
+        ).fetchone()[0]
+        children = conn.execute(
+            "SELECT metadata FROM items WHERE parent_id = ? AND source_type = 'pdf_annotation'",
+            (parent_pdf_item,),
+        ).fetchall()
+    assert media_count == 0  # second run had no images; first run's image was deleted
+    assert len(children) == 1
+    assert json.loads(children[0]["metadata"])["annotation_kind"] == "circle"
+
+
+def test_persist_does_not_delete_source_pdf_media_row(config, parent_pdf_item):
+    with get_connection(config) as conn:
+        add_item_media(
+            conn,
+            parent_pdf_item,
+            media_type="source_pdf",
+            local_path="42/abc.pdf",
+            mime_type="application/pdf",
+            source_origin="sync",
+        )
+        persist_enrichment(conn, config, parent_pdf_item, _enriched())
+        survivors = conn.execute(
+            "SELECT media_type FROM item_media WHERE item_id = ?",
+            (parent_pdf_item,),
+        ).fetchall()
+    assert any(r["media_type"] == "source_pdf" for r in survivors)
+
+
+def test_is_already_enriched(config, parent_pdf_item):
+    enriched = _enriched(sha="d" * 64, version=3)
+    with get_connection(config) as conn:
+        assert not is_already_enriched(conn, parent_pdf_item, 3, "d" * 64)
+        persist_enrichment(conn, config, parent_pdf_item, enriched)
+        assert is_already_enriched(conn, parent_pdf_item, 3, "d" * 64)
+        assert not is_already_enriched(conn, parent_pdf_item, 4, "d" * 64)
+        assert not is_already_enriched(conn, parent_pdf_item, 3, "e" * 64)
+
+
+def test_mark_source_unavailable_preserves_content(config, parent_pdf_item):
+    with get_connection(config) as conn:
+        mark_source_unavailable(conn, parent_pdf_item)
+        row = conn.execute(
+            "SELECT content, metadata FROM items WHERE id = ?", (parent_pdf_item,)
+        ).fetchone()
+    assert "original docling output" in row["content"]
+    meta = json.loads(row["metadata"])
+    assert meta["enrichment_status"] == "source_unavailable"
+
+
+def test_persist_rolls_back_on_failure(config, parent_pdf_item, monkeypatch):
+    """If persistence raises mid-transaction, prior state must be untouched."""
+    # First a successful run for a baseline
+    baseline = _enriched(annotations=[_annotation(anchor="baseline phrase")])
+    with get_connection(config) as conn:
+        persist_enrichment(conn, config, parent_pdf_item, baseline)
+        baseline_count = conn.execute(
+            "SELECT COUNT(*) FROM items WHERE parent_id = ?", (parent_pdf_item,)
+        ).fetchone()[0]
+    assert baseline_count == 1
+
+    # Now break image storage and confirm rollback
+    from lestash.core.pdf_enrich import persistence
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(persistence, "save_media_file", boom)
+
+    bad = _enriched(images=[_image(0)])
+    with get_connection(config) as conn:
+        with pytest.raises(RuntimeError):
+            persist_enrichment(conn, config, parent_pdf_item, bad)
+
+        # Baseline child must still be present — rollback worked
+        survivors = conn.execute(
+            "SELECT COUNT(*) FROM items WHERE parent_id = ?", (parent_pdf_item,)
+        ).fetchone()[0]
+    assert survivors == baseline_count

--- a/packages/lestash/tests/pdf_enrich/test_runner.py
+++ b/packages/lestash/tests/pdf_enrich/test_runner.py
@@ -1,0 +1,184 @@
+"""Tests for `enrich_item` runner — the integration glue between extractor,
+persistence, and source-PDF resolution."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from lestash.core.config import Config, GeneralConfig
+from lestash.core.database import (
+    add_item_media,
+    get_connection,
+    init_database,
+    save_media_file,
+    upsert_item,
+)
+from lestash.core.pdf_enrich.runner import enrich_item
+from lestash.core.pdf_enrich.types import (
+    EnrichedPdf,
+    ExtractedAnnotation,
+    ExtractedImage,
+)
+from lestash.models.item import ItemCreate
+
+
+@pytest.fixture
+def config():
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = Config(general=GeneralConfig(database_path=str(Path(tmp) / "t.db")))
+        init_database(cfg)
+        yield cfg
+
+
+@pytest.fixture
+def item_with_local_source_pdf(config: Config, make_pdf):
+    """An item with a real (synthesised) source_pdf media row pointing at a
+    PDF on disk."""
+    pdf_path = make_pdf([{"text": [((50, 50, 500, 100), "hello pdf")]}], name="src.pdf")
+    pdf_bytes = pdf_path.read_bytes()
+
+    with get_connection(config) as conn:
+        item_id = upsert_item(
+            conn,
+            ItemCreate(
+                source_type="google-drive",
+                source_id="drive-1",
+                title="Item One",
+                content="raw docling content",
+                metadata={"drive_id": "drive-1", "mime_type": "application/pdf"},
+            ),
+        )
+        rel = save_media_file(item_id, pdf_bytes, "src.pdf", config=config)
+        add_item_media(
+            conn,
+            item_id,
+            media_type="source_pdf",
+            local_path=rel,
+            mime_type="application/pdf",
+        )
+    return item_id
+
+
+def _stub_extractor(enriched: EnrichedPdf):
+    return patch("lestash.core.pdf_enrich.runner.enrich_pdf", return_value=enriched)
+
+
+def test_enrich_item_happy_path(config, item_with_local_source_pdf):
+    enriched = EnrichedPdf(
+        content="enriched content with [link](http://x)",
+        pdf_sha256="a" * 64,
+        extractor_version=1,
+        images=[],
+        annotations=[
+            ExtractedAnnotation(
+                kind="underline",
+                page=0,
+                bbox=(100, 200, 300, 220),
+                anchor_text="hello pdf",
+                color="#000000",
+                strokes=[[(100, 200), (300, 200)]],
+                annotation_id="u-1",
+                created_at=None,
+                stroke_geometry_hash="h" * 64,
+            )
+        ],
+    )
+    with _stub_extractor(enriched):
+        result = enrich_item(item_with_local_source_pdf, config=config)
+    assert result.status == "enriched"
+    assert result.annotations == 1
+
+    with get_connection(config) as conn:
+        item = conn.execute(
+            "SELECT content, metadata FROM items WHERE id = ?",
+            (item_with_local_source_pdf,),
+        ).fetchone()
+    assert item["content"] == "enriched content with [link](http://x)"
+    meta = json.loads(item["metadata"])
+    assert meta["pdf_sha256"] == "a" * 64
+
+
+def test_enrich_item_skips_when_already_enriched(config, item_with_local_source_pdf):
+    enriched = EnrichedPdf(
+        content="run-1",
+        pdf_sha256="b" * 64,
+        extractor_version=1,
+    )
+    with _stub_extractor(enriched):
+        first = enrich_item(item_with_local_source_pdf, config=config)
+        second = enrich_item(item_with_local_source_pdf, config=config)
+    assert first.status == "enriched"
+    assert second.status == "skipped"
+
+
+def test_enrich_item_force_reruns_even_when_match(config, item_with_local_source_pdf):
+    enriched = EnrichedPdf(
+        content="run-1",
+        pdf_sha256="b" * 64,
+        extractor_version=1,
+    )
+    with _stub_extractor(enriched):
+        enrich_item(item_with_local_source_pdf, config=config)
+        forced = enrich_item(item_with_local_source_pdf, config=config, force=True)
+    assert forced.status == "enriched"
+
+
+def test_enrich_item_marks_source_unavailable_when_no_pdf(config):
+    """Item with neither a source_pdf media row nor a drive_id → unavailable."""
+    with get_connection(config) as conn:
+        item_id = upsert_item(
+            conn,
+            ItemCreate(
+                source_type="google-drive",
+                source_id="orphan-1",
+                title="orphan",
+                content="some content",
+                metadata={"mime_type": "application/pdf"},
+            ),
+        )
+    result = enrich_item(item_id, config=config)
+    assert result.status == "source_unavailable"
+
+    with get_connection(config) as conn:
+        meta = conn.execute("SELECT metadata FROM items WHERE id = ?", (item_id,)).fetchone()[0]
+    assert json.loads(meta)["enrichment_status"] == "source_unavailable"
+
+
+def test_enrich_item_returns_failed_for_missing_item(config):
+    result = enrich_item(999_999, config=config)
+    assert result.status == "failed"
+
+
+def test_enrich_item_returns_failed_when_extractor_raises(config, item_with_local_source_pdf):
+    with patch(
+        "lestash.core.pdf_enrich.runner.enrich_pdf",
+        side_effect=RuntimeError("boom"),
+    ):
+        result = enrich_item(item_with_local_source_pdf, config=config)
+    assert result.status == "failed"
+    assert "boom" in (result.message or "")
+
+
+def test_extracted_image_count_propagates(config, item_with_local_source_pdf):
+    enriched = EnrichedPdf(
+        content="<!-- image -->",
+        pdf_sha256="c" * 64,
+        extractor_version=1,
+        images=[
+            ExtractedImage(
+                placeholder_index=0,
+                page=0,
+                bbox=(0, 0, 10, 10),
+                bytes_=b"png-bytes",
+                mime_type="image/png",
+                xref_hash="x" * 64,
+            )
+        ],
+    )
+    with _stub_extractor(enriched):
+        result = enrich_item(item_with_local_source_pdf, config=config)
+    assert result.images == 1

--- a/packages/lestash/tests/pdf_enrich/test_runner.py
+++ b/packages/lestash/tests/pdf_enrich/test_runner.py
@@ -23,6 +23,7 @@ from lestash.core.pdf_enrich.types import (
     ExtractedAnnotation,
     ExtractedImage,
 )
+from lestash.core.pdf_enrich.version import EXTRACTOR_VERSION
 from lestash.models.item import ItemCreate
 
 
@@ -71,7 +72,7 @@ def test_enrich_item_happy_path(config, item_with_local_source_pdf):
     enriched = EnrichedPdf(
         content="enriched content with [link](http://x)",
         pdf_sha256="a" * 64,
-        extractor_version=1,
+        extractor_version=EXTRACTOR_VERSION,
         images=[],
         annotations=[
             ExtractedAnnotation(
@@ -106,7 +107,7 @@ def test_enrich_item_skips_when_already_enriched(config, item_with_local_source_
     enriched = EnrichedPdf(
         content="run-1",
         pdf_sha256="b" * 64,
-        extractor_version=1,
+        extractor_version=EXTRACTOR_VERSION,
     )
     with _stub_extractor(enriched):
         first = enrich_item(item_with_local_source_pdf, config=config)
@@ -119,7 +120,7 @@ def test_enrich_item_force_reruns_even_when_match(config, item_with_local_source
     enriched = EnrichedPdf(
         content="run-1",
         pdf_sha256="b" * 64,
-        extractor_version=1,
+        extractor_version=EXTRACTOR_VERSION,
     )
     with _stub_extractor(enriched):
         enrich_item(item_with_local_source_pdf, config=config)
@@ -167,7 +168,7 @@ def test_extracted_image_count_propagates(config, item_with_local_source_pdf):
     enriched = EnrichedPdf(
         content="<!-- image -->",
         pdf_sha256="c" * 64,
-        extractor_version=1,
+        extractor_version=EXTRACTOR_VERSION,
         images=[
             ExtractedImage(
                 placeholder_index=0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "le-stash-workspace"
 version = "1.54.0"
 description = "Le Stash monorepo workspace - personal knowledge base CLI"
 readme = "README.md"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.12"
 dependencies = [
     "lestash",

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
@@ -62,6 +65,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.97.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
 ]
 
 [[package]]
@@ -540,6 +562,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -672,6 +703,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/2a/0954f7ff6a1872c4af22408a567105c59454c63583107aca44df8b9da459/docling_parse-5.7.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2fa76923024257e22192852e169ea871beff1b25ad8e8ec81f105d400bd87997", size = 9262541, upload-time = "2026-04-01T08:46:39.205Z" },
     { url = "https://files.pythonhosted.org/packages/ec/46/cb3f037ce0886990a1ad8051e0a376dad50faa291eee584d46178e781d32/docling_parse-5.7.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3fafdac5c54d4630abfda339d60b8b7cb0ac5799a2570fbef5985244a4595a78", size = 9595698, upload-time = "2026-04-01T08:46:41.112Z" },
     { url = "https://files.pythonhosted.org/packages/c2/14/b8fca55211ee3b7e43de2b62d543d34ad97fb8e26caca76f7fb70090b493/docling_parse-5.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:499a150a7900226126a77752a0328bf768353c0058b2680b439ddf8ab33bd84b", size = 10744242, upload-time = "2026-04-01T08:46:43.169Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -1027,6 +1067,78 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1094,7 +1206,7 @@ wheels = [
 
 [[package]]
 name = "le-stash-workspace"
-version = "1.44.0"
+version = "1.54.0"
 source = { virtual = "." }
 dependencies = [
     { name = "lestash" },
@@ -1136,7 +1248,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.8.0" },
+    { name = "mypy", specifier = ">=1.20.1" },
     { name = "pre-commit", specifier = ">=3.6.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
@@ -1147,15 +1259,17 @@ dev = [
 
 [[package]]
 name = "lestash"
-version = "1.44.0"
+version = "1.54.0"
 source = { editable = "packages/lestash" }
 dependencies = [
+    { name = "anthropic" },
     { name = "docling" },
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pymupdf" },
     { name = "rich" },
     { name = "sentence-transformers" },
     { name = "sqlite-vec" },
@@ -1165,12 +1279,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.40.0" },
     { name = "docling", specifier = ">=2.84.0" },
     { name = "google-api-python-client", specifier = ">=2.0.0" },
     { name = "google-auth-httplib2", specifier = ">=0.2.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
+    { name = "pymupdf", specifier = ">=1.27.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "sentence-transformers", specifier = ">=3.0.0" },
     { name = "sqlite-vec", specifier = ">=0.1.6" },
@@ -1180,7 +1296,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-arxiv"
-version = "1.44.0"
+version = "1.54.0"
 source = { editable = "packages/lestash-arxiv" }
 dependencies = [
     { name = "arxiv" },
@@ -1195,7 +1311,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-audible"
-version = "1.44.0"
+version = "1.54.0"
 source = { editable = "packages/lestash-audible" }
 dependencies = [
     { name = "audible" },
@@ -1210,7 +1326,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-bluesky"
-version = "1.44.0"
+version = "1.54.0"
 source = { editable = "packages/lestash-bluesky" }
 dependencies = [
     { name = "atproto" },
@@ -1225,7 +1341,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-claude-code"
-version = "1.44.0"
+version = "1.54.0"
 source = { editable = "packages/lestash-claude-code" }
 dependencies = [
     { name = "lestash" },
@@ -1236,7 +1352,7 @@ requires-dist = [{ name = "lestash", editable = "packages/lestash" }]
 
 [[package]]
 name = "lestash-linkedin"
-version = "1.44.0"
+version = "1.54.0"
 source = { editable = "packages/lestash-linkedin" }
 dependencies = [
     { name = "authlib" },
@@ -1253,7 +1369,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-microblog"
-version = "1.44.0"
+version = "1.54.0"
 source = { editable = "packages/lestash-microblog" }
 dependencies = [
     { name = "httpx" },
@@ -1268,7 +1384,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-server"
-version = "1.44.0"
+version = "1.54.0"
 source = { editable = "packages/lestash-server" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1291,7 +1407,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-voice"
-version = "1.44.0"
+version = "1.54.0"
 source = { editable = "packages/lestash-voice" }
 dependencies = [
     { name = "faster-whisper" },
@@ -1306,7 +1422,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-youtube"
-version = "1.44.0"
+version = "1.54.0"
 source = { editable = "packages/lestash-youtube" }
 dependencies = [
     { name = "google-api-python-client" },
@@ -1374,54 +1490,62 @@ wheels = [
 
 [[package]]
 name = "librt"
-version = "0.7.8"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/24/5f3646ff414285e0f7708fa4e946b9bf538345a41d1c375c439467721a5e/librt-0.7.8.tar.gz", hash = "sha256:1a4ede613941d9c3470b0368be851df6bb78ab218635512d0370b27a277a0862", size = 148323, upload-time = "2026-01-14T12:56:16.876Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/04/79d8fcb43cae376c7adbab7b2b9f65e48432c9eced62ac96703bcc16e09b/librt-0.7.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b6943885b2d49c48d0cff23b16be830ba46b0152d98f62de49e735c6e655a63", size = 57472, upload-time = "2026-01-14T12:55:08.528Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/ba/60b96e93043d3d659da91752689023a73981336446ae82078cddf706249e/librt-0.7.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:46ef1f4b9b6cc364b11eea0ecc0897314447a66029ee1e55859acb3dd8757c93", size = 58986, upload-time = "2026-01-14T12:55:09.466Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/26/5215e4cdcc26e7be7eee21955a7e13cbf1f6d7d7311461a6014544596fac/librt-0.7.8-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:907ad09cfab21e3c86e8f1f87858f7049d1097f77196959c033612f532b4e592", size = 168422, upload-time = "2026-01-14T12:55:10.499Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/84/e8d1bc86fa0159bfc24f3d798d92cafd3897e84c7fea7fe61b3220915d76/librt-0.7.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2991b6c3775383752b3ca0204842743256f3ad3deeb1d0adc227d56b78a9a850", size = 177478, upload-time = "2026-01-14T12:55:11.577Z" },
-    { url = "https://files.pythonhosted.org/packages/57/11/d0268c4b94717a18aa91df1100e767b010f87b7ae444dafaa5a2d80f33a6/librt-0.7.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03679b9856932b8c8f674e87aa3c55ea11c9274301f76ae8dc4d281bda55cf62", size = 192439, upload-time = "2026-01-14T12:55:12.7Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/56/1e8e833b95fe684f80f8894ae4d8b7d36acc9203e60478fcae599120a975/librt-0.7.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3968762fec1b2ad34ce57458b6de25dbb4142713e9ca6279a0d352fa4e9f452b", size = 191483, upload-time = "2026-01-14T12:55:13.838Z" },
-    { url = "https://files.pythonhosted.org/packages/17/48/f11cf28a2cb6c31f282009e2208312aa84a5ee2732859f7856ee306176d5/librt-0.7.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:bb7a7807523a31f03061288cc4ffc065d684c39db7644c676b47d89553c0d714", size = 185376, upload-time = "2026-01-14T12:55:15.017Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/6a/d7c116c6da561b9155b184354a60a3d5cdbf08fc7f3678d09c95679d13d9/librt-0.7.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad64a14b1e56e702e19b24aae108f18ad1bf7777f3af5fcd39f87d0c5a814449", size = 206234, upload-time = "2026-01-14T12:55:16.571Z" },
-    { url = "https://files.pythonhosted.org/packages/61/de/1975200bb0285fc921c5981d9978ce6ce11ae6d797df815add94a5a848a3/librt-0.7.8-cp312-cp312-win32.whl", hash = "sha256:0241a6ed65e6666236ea78203a73d800dbed896cf12ae25d026d75dc1fcd1dac", size = 44057, upload-time = "2026-01-14T12:55:18.077Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/cd/724f2d0b3461426730d4877754b65d39f06a41ac9d0a92d5c6840f72b9ae/librt-0.7.8-cp312-cp312-win_amd64.whl", hash = "sha256:6db5faf064b5bab9675c32a873436b31e01d66ca6984c6f7f92621656033a708", size = 50293, upload-time = "2026-01-14T12:55:19.179Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/cf/7e899acd9ee5727ad8160fdcc9994954e79fab371c66535c60e13b968ffc/librt-0.7.8-cp312-cp312-win_arm64.whl", hash = "sha256:57175aa93f804d2c08d2edb7213e09276bd49097611aefc37e3fa38d1fb99ad0", size = 43574, upload-time = "2026-01-14T12:55:20.185Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/fe/b1f9de2829cf7fc7649c1dcd202cfd873837c5cc2fc9e526b0e7f716c3d2/librt-0.7.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4c3995abbbb60b3c129490fa985dfe6cac11d88fc3c36eeb4fb1449efbbb04fc", size = 57500, upload-time = "2026-01-14T12:55:21.219Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d4/4a60fbe2e53b825f5d9a77325071d61cd8af8506255067bf0c8527530745/librt-0.7.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:44e0c2cbc9bebd074cf2cdbe472ca185e824be4e74b1c63a8e934cea674bebf2", size = 59019, upload-time = "2026-01-14T12:55:22.256Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/37/61ff80341ba5159afa524445f2d984c30e2821f31f7c73cf166dcafa5564/librt-0.7.8-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d2f1e492cae964b3463a03dc77a7fe8742f7855d7258c7643f0ee32b6651dd3", size = 169015, upload-time = "2026-01-14T12:55:23.24Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/86/13d4f2d6a93f181ebf2fc953868826653ede494559da8268023fe567fca3/librt-0.7.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:451e7ffcef8f785831fdb791bd69211f47e95dc4c6ddff68e589058806f044c6", size = 178161, upload-time = "2026-01-14T12:55:24.826Z" },
-    { url = "https://files.pythonhosted.org/packages/88/26/e24ef01305954fc4d771f1f09f3dd682f9eb610e1bec188ffb719374d26e/librt-0.7.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3469e1af9f1380e093ae06bedcbdd11e407ac0b303a56bbe9afb1d6824d4982d", size = 193015, upload-time = "2026-01-14T12:55:26.04Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a0/92b6bd060e720d7a31ed474d046a69bd55334ec05e9c446d228c4b806ae3/librt-0.7.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f11b300027ce19a34f6d24ebb0a25fd0e24a9d53353225a5c1e6cadbf2916b2e", size = 192038, upload-time = "2026-01-14T12:55:27.208Z" },
-    { url = "https://files.pythonhosted.org/packages/06/bb/6f4c650253704279c3a214dad188101d1b5ea23be0606628bc6739456624/librt-0.7.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4adc73614f0d3c97874f02f2c7fd2a27854e7e24ad532ea6b965459c5b757eca", size = 186006, upload-time = "2026-01-14T12:55:28.594Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/00/1c409618248d43240cadf45f3efb866837fa77e9a12a71481912135eb481/librt-0.7.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:60c299e555f87e4c01b2eca085dfccda1dde87f5a604bb45c2906b8305819a93", size = 206888, upload-time = "2026-01-14T12:55:30.214Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/83/b2cfe8e76ff5c1c77f8a53da3d5de62d04b5ebf7cf913e37f8bca43b5d07/librt-0.7.8-cp313-cp313-win32.whl", hash = "sha256:b09c52ed43a461994716082ee7d87618096851319bf695d57ec123f2ab708951", size = 44126, upload-time = "2026-01-14T12:55:31.44Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/0b/c59d45de56a51bd2d3a401fc63449c0ac163e4ef7f523ea8b0c0dee86ec5/librt-0.7.8-cp313-cp313-win_amd64.whl", hash = "sha256:f8f4a901a3fa28969d6e4519deceab56c55a09d691ea7b12ca830e2fa3461e34", size = 50262, upload-time = "2026-01-14T12:55:33.01Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/b9/973455cec0a1ec592395250c474164c4a58ebf3e0651ee920fef1a2623f1/librt-0.7.8-cp313-cp313-win_arm64.whl", hash = "sha256:43d4e71b50763fcdcf64725ac680d8cfa1706c928b844794a7aa0fa9ac8e5f09", size = 43600, upload-time = "2026-01-14T12:55:34.054Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/73/fa8814c6ce2d49c3827829cadaa1589b0bf4391660bd4510899393a23ebc/librt-0.7.8-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:be927c3c94c74b05128089a955fba86501c3b544d1d300282cc1b4bd370cb418", size = 57049, upload-time = "2026-01-14T12:55:35.056Z" },
-    { url = "https://files.pythonhosted.org/packages/53/fe/f6c70956da23ea235fd2e3cc16f4f0b4ebdfd72252b02d1164dd58b4e6c3/librt-0.7.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7b0803e9008c62a7ef79058233db7ff6f37a9933b8f2573c05b07ddafa226611", size = 58689, upload-time = "2026-01-14T12:55:36.078Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/4d/7a2481444ac5fba63050d9abe823e6bc16896f575bfc9c1e5068d516cdce/librt-0.7.8-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:79feb4d00b2a4e0e05c9c56df707934f41fcb5fe53fd9efb7549068d0495b758", size = 166808, upload-time = "2026-01-14T12:55:37.595Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/3c/10901d9e18639f8953f57c8986796cfbf4c1c514844a41c9197cf87cb707/librt-0.7.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b9122094e3f24aa759c38f46bd8863433820654927370250f460ae75488b66ea", size = 175614, upload-time = "2026-01-14T12:55:38.756Z" },
-    { url = "https://files.pythonhosted.org/packages/db/01/5cbdde0951a5090a80e5ba44e6357d375048123c572a23eecfb9326993a7/librt-0.7.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e03bea66af33c95ce3addf87a9bf1fcad8d33e757bc479957ddbc0e4f7207ac", size = 189955, upload-time = "2026-01-14T12:55:39.939Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/b4/e80528d2f4b7eaf1d437fcbd6fc6ba4cbeb3e2a0cb9ed5a79f47c7318706/librt-0.7.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f1ade7f31675db00b514b98f9ab9a7698c7282dad4be7492589109471852d398", size = 189370, upload-time = "2026-01-14T12:55:41.057Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/ab/938368f8ce31a9787ecd4becb1e795954782e4312095daf8fd22420227c8/librt-0.7.8-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a14229ac62adcf1b90a15992f1ab9c69ae8b99ffb23cb64a90878a6e8a2f5b81", size = 183224, upload-time = "2026-01-14T12:55:42.328Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/10/559c310e7a6e4014ac44867d359ef8238465fb499e7eb31b6bfe3e3f86f5/librt-0.7.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5bcaaf624fd24e6a0cb14beac37677f90793a96864c67c064a91458611446e83", size = 203541, upload-time = "2026-01-14T12:55:43.501Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/db/a0db7acdb6290c215f343835c6efda5b491bb05c3ddc675af558f50fdba3/librt-0.7.8-cp314-cp314-win32.whl", hash = "sha256:7aa7d5457b6c542ecaed79cec4ad98534373c9757383973e638ccced0f11f46d", size = 40657, upload-time = "2026-01-14T12:55:44.668Z" },
-    { url = "https://files.pythonhosted.org/packages/72/e0/4f9bdc2a98a798511e81edcd6b54fe82767a715e05d1921115ac70717f6f/librt-0.7.8-cp314-cp314-win_amd64.whl", hash = "sha256:3d1322800771bee4a91f3b4bd4e49abc7d35e65166821086e5afd1e6c0d9be44", size = 46835, upload-time = "2026-01-14T12:55:45.655Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/3d/59c6402e3dec2719655a41ad027a7371f8e2334aa794ed11533ad5f34969/librt-0.7.8-cp314-cp314-win_arm64.whl", hash = "sha256:5363427bc6a8c3b1719f8f3845ea53553d301382928a86e8fab7984426949bce", size = 39885, upload-time = "2026-01-14T12:55:47.138Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/9c/2481d80950b83085fb14ba3c595db56330d21bbc7d88a19f20165f3538db/librt-0.7.8-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ca916919793a77e4a98d4a1701e345d337ce53be4a16620f063191f7322ac80f", size = 59161, upload-time = "2026-01-14T12:55:48.45Z" },
-    { url = "https://files.pythonhosted.org/packages/96/79/108df2cfc4e672336765d54e3ff887294c1cc36ea4335c73588875775527/librt-0.7.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:54feb7b4f2f6706bb82325e836a01be805770443e2400f706e824e91f6441dde", size = 61008, upload-time = "2026-01-14T12:55:49.527Z" },
-    { url = "https://files.pythonhosted.org/packages/46/f2/30179898f9994a5637459d6e169b6abdc982012c0a4b2d4c26f50c06f911/librt-0.7.8-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:39a4c76fee41007070f872b648cc2f711f9abf9a13d0c7162478043377b52c8e", size = 187199, upload-time = "2026-01-14T12:55:50.587Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/da/f7563db55cebdc884f518ba3791ad033becc25ff68eb70902b1747dc0d70/librt-0.7.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac9c8a458245c7de80bc1b9765b177055efff5803f08e548dd4bb9ab9a8d789b", size = 198317, upload-time = "2026-01-14T12:55:51.991Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/6c/4289acf076ad371471fa86718c30ae353e690d3de6167f7db36f429272f1/librt-0.7.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b67aa7eff150f075fda09d11f6bfb26edffd300f6ab1666759547581e8f666", size = 210334, upload-time = "2026-01-14T12:55:53.682Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/7f/377521ac25b78ac0a5ff44127a0360ee6d5ddd3ce7327949876a30533daa/librt-0.7.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:535929b6eff670c593c34ff435d5440c3096f20fa72d63444608a5aef64dd581", size = 211031, upload-time = "2026-01-14T12:55:54.827Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b1/e1e96c3e20b23d00cf90f4aad48f0deb4cdfec2f0ed8380d0d85acf98bbf/librt-0.7.8-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:63937bd0f4d1cb56653dc7ae900d6c52c41f0015e25aaf9902481ee79943b33a", size = 204581, upload-time = "2026-01-14T12:55:56.811Z" },
-    { url = "https://files.pythonhosted.org/packages/43/71/0f5d010e92ed9747e14bef35e91b6580533510f1e36a8a09eb79ee70b2f0/librt-0.7.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cf243da9e42d914036fd362ac3fa77d80a41cadcd11ad789b1b5eec4daaf67ca", size = 224731, upload-time = "2026-01-14T12:55:58.175Z" },
-    { url = "https://files.pythonhosted.org/packages/22/f0/07fb6ab5c39a4ca9af3e37554f9d42f25c464829254d72e4ebbd81da351c/librt-0.7.8-cp314-cp314t-win32.whl", hash = "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365", size = 41173, upload-time = "2026-01-14T12:55:59.315Z" },
-    { url = "https://files.pythonhosted.org/packages/24/d4/7e4be20993dc6a782639625bd2f97f3c66125c7aa80c82426956811cfccf/librt-0.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32", size = 47668, upload-time = "2026-01-14T12:56:00.261Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/85/69f92b2a7b3c0f88ffe107c86b952b397004b5b8ea5a81da3d9c04c04422/librt-0.7.8-cp314-cp314t-win_arm64.whl", hash = "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06", size = 40550, upload-time = "2026-01-14T12:56:01.542Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/90/89ddba8e1c20b0922783cd93ed8e64f34dc05ab59c38a9c7e313632e20ff/librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4", size = 68332, upload-time = "2026-04-09T16:05:00.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/7aa4da1fb08bdeeb540cb07bfc8207cb32c5c41642f2594dbd0098a0662d/librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d", size = 70581, upload-time = "2026-04-09T16:05:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/73a2187e1031041e93b7e3a25aae37aa6f13b838c550f7e0f06f66766212/librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f", size = 203984, upload-time = "2026-04-09T16:05:02.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/23460d571e9cbddb405b017681df04c142fb1b04cbfce77c54b08e28b108/librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27", size = 215762, upload-time = "2026-04-09T16:05:04.127Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/42dc7f8ab63e65b20640d058e63e97fd3e482c1edbda3570d813b4d0b927/librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2", size = 230288, upload-time = "2026-04-09T16:05:05.883Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/08/ca812b6d8259ad9ece703397f8ad5c03af5b5fedfce64279693d3ce4087c/librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b", size = 224103, upload-time = "2026-04-09T16:05:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/620490fb2fa66ffd44e7f900254bc110ebec8dac6c1b7514d64662570e6f/librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265", size = 232122, upload-time = "2026-04-09T16:05:08.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/83/12864700a1b6a8be458cf5d05db209b0d8e94ae281e7ec261dbe616597b4/librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084", size = 225045, upload-time = "2026-04-09T16:05:09.707Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1b/845d339c29dc7dbc87a2e992a1ba8d28d25d0e0372f9a0a2ecebde298186/librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8", size = 227372, upload-time = "2026-04-09T16:05:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/277985610269d926a64c606f761d58d3db67b956dbbf40024921e95e7fcb/librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f", size = 248224, upload-time = "2026-04-09T16:05:12.254Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986, upload-time = "2026-04-09T16:05:13.529Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260, upload-time = "2026-04-09T16:05:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694, upload-time = "2026-04-09T16:05:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/1b3e26fffde1452d82f5666164858a81c26ebe808e7ae8c9c88628981540/librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e", size = 68367, upload-time = "2026-04-09T16:05:17.243Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/5b/c61b043ad2e091fbe1f2d35d14795e545d0b56b03edaa390fa1dcee3d160/librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22", size = 70595, upload-time = "2026-04-09T16:05:18.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/2448471196d8a73370aa2f23445455dc42712c21404081fcd7a03b9e0749/librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a", size = 204354, upload-time = "2026-04-09T16:05:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5e/39fc4b153c78cfd2c8a2dcb32700f2d41d2312aa1050513183be4540930d/librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5", size = 216238, upload-time = "2026-04-09T16:05:20.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/42/bc2d02d0fa7badfa63aa8d6dcd8793a9f7ef5a94396801684a51ed8d8287/librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11", size = 230589, upload-time = "2026-04-09T16:05:22.305Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/e2d95cc513866373692aa5edf98080d5602dd07cabfb9e5d2f70df2f25f7/librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858", size = 224610, upload-time = "2026-04-09T16:05:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/6cec4607e998eaba57564d06a1295c21b0a0c8de76e4e74d699e627bd98c/librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e", size = 232558, upload-time = "2026-04-09T16:05:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/95/8c/27f1d8d3aaf079d3eb26439bf0b32f1482340c3552e324f7db9dca858671/librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0", size = 225521, upload-time = "2026-04-09T16:05:26.311Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d8/1e0d43b1c329b416017619469b3c3801a25a6a4ef4a1c68332aeaa6f72ca/librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2", size = 227789, upload-time = "2026-04-09T16:05:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/d3d842e88610fcd4c8eec7067b0c23ef2d7d3bff31496eded6a83b0f99be/librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d", size = 248616, upload-time = "2026-04-09T16:05:29.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/28/527df8ad0d1eb6c8bdfa82fc190f1f7c4cca5a1b6d7b36aeabf95b52d74d/librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd", size = 56039, upload-time = "2026-04-09T16:05:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a7/413652ad0d92273ee5e30c000fc494b361171177c83e57c060ecd3c21538/librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519", size = 63264, upload-time = "2026-04-09T16:05:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0a/92c244309b774e290ddb15e93363846ae7aa753d9586b8aad511c5e6145b/librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5", size = 53728, upload-time = "2026-04-09T16:05:33.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
 ]
 
 [[package]]
@@ -1644,7 +1768,7 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.19.1"
+version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
@@ -1652,27 +1776,37 @@ dependencies = [
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/8a/19bfae96f6615aa8a0604915512e0289b1fad33d5909bf7244f02935d33a/mypy-1.19.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8174a03289288c1f6c46d55cef02379b478bfbc8e358e02047487cad44c6ca1", size = 13206053, upload-time = "2025-12-15T05:03:46.622Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/34/3e63879ab041602154ba2a9f99817bb0c85c4df19a23a1443c8986e4d565/mypy-1.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffcebe56eb09ff0c0885e750036a095e23793ba6c2e894e7e63f6d89ad51f22e", size = 12219134, upload-time = "2025-12-15T05:03:24.367Z" },
-    { url = "https://files.pythonhosted.org/packages/89/cc/2db6f0e95366b630364e09845672dbee0cbf0bbe753a204b29a944967cd9/mypy-1.19.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b64d987153888790bcdb03a6473d321820597ab8dd9243b27a92153c4fa50fd2", size = 12731616, upload-time = "2025-12-15T05:02:44.725Z" },
-    { url = "https://files.pythonhosted.org/packages/00/be/dd56c1fd4807bc1eba1cf18b2a850d0de7bacb55e158755eb79f77c41f8e/mypy-1.19.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c35d298c2c4bba75feb2195655dfea8124d855dfd7343bf8b8c055421eaf0cf8", size = 13620847, upload-time = "2025-12-15T05:03:39.633Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/42/332951aae42b79329f743bf1da088cd75d8d4d9acc18fbcbd84f26c1af4e/mypy-1.19.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:34c81968774648ab5ac09c29a375fdede03ba253f8f8287847bd480782f73a6a", size = 13834976, upload-time = "2025-12-15T05:03:08.786Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/63/e7493e5f90e1e085c562bb06e2eb32cae27c5057b9653348d38b47daaecc/mypy-1.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:b10e7c2cd7870ba4ad9b2d8a6102eb5ffc1f16ca35e3de6bfa390c1113029d13", size = 10118104, upload-time = "2025-12-15T05:03:10.834Z" },
-    { url = "https://files.pythonhosted.org/packages/de/9f/a6abae693f7a0c697dbb435aac52e958dc8da44e92e08ba88d2e42326176/mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250", size = 13201927, upload-time = "2025-12-15T05:02:29.138Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/a4/45c35ccf6e1c65afc23a069f50e2c66f46bd3798cbe0d680c12d12935caa/mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b", size = 12206730, upload-time = "2025-12-15T05:03:01.325Z" },
-    { url = "https://files.pythonhosted.org/packages/05/bb/cdcf89678e26b187650512620eec8368fded4cfd99cfcb431e4cdfd19dec/mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e", size = 12724581, upload-time = "2025-12-15T05:03:20.087Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/32/dd260d52babf67bad8e6770f8e1102021877ce0edea106e72df5626bb0ec/mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef", size = 13616252, upload-time = "2025-12-15T05:02:49.036Z" },
-    { url = "https://files.pythonhosted.org/packages/71/d0/5e60a9d2e3bd48432ae2b454b7ef2b62a960ab51292b1eda2a95edd78198/mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75", size = 13840848, upload-time = "2025-12-15T05:02:55.95Z" },
-    { url = "https://files.pythonhosted.org/packages/98/76/d32051fa65ecf6cc8c6610956473abdc9b4c43301107476ac03559507843/mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd", size = 10135510, upload-time = "2025-12-15T05:02:58.438Z" },
-    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
-    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
-    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4e/7560e4528db9e9b147e4c0f22660466bf30a0a1fe3d63d1b9d3b0fd354ee/mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b", size = 14539393, upload-time = "2026-04-21T17:07:12.52Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d9/34a5efed8124f5a9234f55ac6a4ced4201e2c5b81e1109c49ad23190ec8c/mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4", size = 13361642, upload-time = "2026-04-21T17:06:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/14/eb377acf78c03c92d566a1510cda8137348215b5335085ef662ab82ecd3a/mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6", size = 13740347, upload-time = "2026-04-21T17:12:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/7e4634a32b641aa1c112422eed1bbece61ee16205f674190e8b536f884de/mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066", size = 14734042, upload-time = "2026-04-21T17:07:43.16Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f3/f7e62395cb7f434541b4491a01149a4439e28ace4c0c632bbf5431e92d1f/mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102", size = 14964958, upload-time = "2026-04-21T17:11:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0d/47e3c3a0ec2a876e35aeac365df3cac7776c36bbd4ed18cc521e1b9d255b/mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9", size = 10911340, upload-time = "2026-04-21T17:10:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b2/6c852d72e0ea8b01f49da817fb52539993cde327e7d010e0103dc12d0dac/mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58", size = 9833947, upload-time = "2026-04-21T17:09:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c4/b93812d3a192c9bcf5df405bd2f30277cd0e48106a14d1023c7f6ed6e39b/mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026", size = 14524670, upload-time = "2026-04-21T17:10:30.737Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/42c122501bff18eaf1e8f457f5c017933452d8acdc52918a9f59f6812955/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943", size = 13336218, upload-time = "2026-04-21T17:08:44.069Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/75bbc92f41725fbd585fb17b440b1119b576105df1013622983e18640a93/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517", size = 13724906, upload-time = "2026-04-21T17:08:01.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15", size = 14726046, upload-time = "2026-04-21T17:11:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/4e354a1bd70216359deb0c9c54847ee6b32ef78dfb09f5131ff99b494078/mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee", size = 14955587, upload-time = "2026-04-21T17:12:16.033Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/c0f2056e9eb8f08c62cafd9715e4584b89132bdc832fcf85d27d07b5f3e5/mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f", size = 10922681, upload-time = "2026-04-21T17:06:35.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/065e333721f05de8ef683d0aa804c23026bcc287446b61cac657b902ccac/mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330", size = 9830560, upload-time = "2026-04-21T17:07:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
 ]
 
 [[package]]
@@ -2438,6 +2572,22 @@ name = "pylatexenc"
 version = "2.10"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5d/ab/34ec41718af73c00119d0351b7a2531d2ebddb51833a36448fc7b862be60/pylatexenc-2.10.tar.gz", hash = "sha256:3dd8fd84eb46dc30bee1e23eaab8d8fb5a7f507347b23e5f38ad9675c84f40d3", size = 162597, upload-time = "2021-04-06T07:56:07.854Z" }
+
+[[package]]
+name = "pymupdf"
+version = "1.27.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/32/708bedc9dde7b328d45abbc076091769d44f2f24ad151ad92d56a6ec142b/pymupdf-1.27.2.3.tar.gz", hash = "sha256:7a92faa25129e8bbec5e50eeb9214f187665428c31b05c4ef6e36c58c0b1c6d2", size = 85759618, upload-time = "2026-04-24T14:13:14.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/09/ddbdfa7ee91fbabd6f63d7d744884cbdfe3e7ff9b8604749fb38bddf5c5d/pymupdf-1.27.2.3-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc1bc3cae6e9e150b0dbb0a9221bdfd411d65f0db2fe359eaa22467d7cc2a05f", size = 24002636, upload-time = "2026-04-24T14:09:17.459Z" },
+    { url = "https://files.pythonhosted.org/packages/01/89/3f8edd6c4f50ca370e2a2f2a3011face36f3760728ffe76dffec91c0fca0/pymupdf-1.27.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:660d93cb6da5bbddf11d3982ae27745dd3a9902d9f24cdb69adab83962294b5a", size = 23278238, upload-time = "2026-04-24T14:09:32.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/26/b7e5a70eb83bd189f8b5df87ec442746b992f2f632662839b288170d357d/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1dd460a3ae4597a755f00a3bd9771f5ebf1531dc111f6a36bf05dd00a6b84425", size = 24333923, upload-time = "2026-04-24T14:09:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/aa1ee2240f29481a04a827c313333b4ecd8a14d6ac3e15d3f41a30574781/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:857842b4888827bd6155a1131341b2822a7ebe9a8c15a975fd7d490d7a64a30c", size = 24963198, upload-time = "2026-04-24T14:10:07.408Z" },
+    { url = "https://files.pythonhosted.org/packages/69/49/4f742451f980840829fc00ba158bebb25d389c846d8f4f8c65936ee55de8/pymupdf-1.27.2.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:580983849c64a08d08344ca3d1580e87c01f046a8392421797bc850efd72a5b6", size = 25184609, upload-time = "2026-04-24T14:10:22.911Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/3f/3853d6608f394faf6eec2bd4e8ea9f6a00beea329b071abdb29f4164cc3d/pymupdf-1.27.2.3-cp310-abi3-win32.whl", hash = "sha256:a5c1088a87189891a4946ab314a14b7934ac4c5b6077f7e74ebee956f8906d0e", size = 18019286, upload-time = "2026-04-24T14:10:34.239Z" },
+    { url = "https://files.pythonhosted.org/packages/44/47/5fb10fe73f96b31253a41647c362ea9e0380920bddf16028414a051247fc/pymupdf-1.27.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:d20f68ef15195e073071dbc4ae7455257c7889af7584e39df490c0a92728526e", size = 19249102, upload-time = "2026-04-24T14:10:46.72Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/b9e91aac82293f9c954654c85581ee8212b5b05efadc534b581141241e6f/pymupdf-1.27.2.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:77691604c5d1d0233827139bbcdea61fd57879c84712b8e49b1f45520f7ab9c2", size = 25000393, upload-time = "2026-04-24T14:11:01.669Z" },
+]
 
 [[package]]
 name = "pyobjc-core"
@@ -3277,6 +3427,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a post-Docling enrichment pipeline that extracts hyperlinks, images, and ink annotations from PDFs using PyMuPDF. Re-runnable over previously imported content via version-keyed idempotency.

## Changes

- **AGPL-3.0 relicense** + `pymupdf` and `anthropic` dependencies (#138)
- **Pure extractor module** (`pdf_enrich/`) — links, images, annotation classifier, cleanup
- **Persistence layer** — stores images as media, annotations as child items, rewrites content with markdown links and inline images
- **CLI** — `lestash enrich item|all|backfill-sources|ocr`
- **Server API** — `POST /api/items/{id}/enrich`, `POST /api/enrich/all`, etc.
- **Inline enrichment** — new Drive/upload PDFs enriched automatically on import
- **Claude vision OCR** — opt-in handwriting transcription for margin notes
- **Tuning fixes** — repeated-image dedup, two-pass link matching with HTML entity decoding

## Test plan

- [x] 137 lestash + 51 server tests pass (`just check` green)
- [x] Spot check: item 25114 — 23/23 links inline, 3/3 images, 0 placeholders, 0 artifacts
- [ ] Backfill existing Drive items (`lestash enrich backfill-sources` + `lestash enrich all`)
- [ ] Classifier tuning against real Kobo pen strokes

## Pre-merge notes

- Copyright name in LICENSE shows "Matthew Thompson" — confirm this is correct (was "Mark Thompson")
- OCR model set to `claude-sonnet-4-6` — can be changed later

Closes #135, #138, #143