### PR TITLE
Add item history tracking and restore functionality

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -1548,7 +1548,7 @@
               ${titlePart}
               <span style="margin-left:auto;display:flex;gap:0.3rem">
                 <button class="sync-btn" data-action="expand-version" data-id="${itemId}" data-version-id="${v.id}" style="font-size:0.7rem;padding:0.1rem 0.4rem">View</button>
-                <button class="sync-btn" data-action="restore-version" data-id="${itemId}" data-version-id="${v.id}" style="font-size:0.7rem;padding:0.1rem 0.4rem">Restore</button>
+                <button class="sync-btn" data-action="restore-version" data-id="${itemId}" data-version-id="${v.id}" data-parent-null="${v.parent_id_old === null || v.parent_id_old === undefined ? '1' : '0'}" style="font-size:0.7rem;padding:0.1rem 0.4rem">Restore</button>
               </span>
             </div>
             ${previewPart}
@@ -1761,9 +1761,10 @@
             Object.assign(item, updated);
             renderItemView(item);
             showToast('Saved');
+            // No finally block — renderItemView() detached btn from the DOM,
+            // so resetting its state would mutate a stale element.
           } catch (err) {
             showToast('Failed to save', 'error');
-          } finally {
             btn.disabled = false;
             btn.textContent = 'Save';
           }
@@ -1810,16 +1811,27 @@
           }
         }
         if (btn.dataset.action === 'restore-version') {
-          if (!confirm('Restore this version? The current state will be saved as a new version.')) return;
+          // Pre-Migration-9 history rows have parent_id_old=NULL by default. If
+          // the current item still has a parent, restoring would silently detach
+          // it. Detect and pass restore_parent=false to keep the current parent.
+          const versionParentNull = btn.dataset.parentNull === '1';
+          const currentHasParent = item.parent_id !== null && item.parent_id !== undefined;
+          let restoreParent = true;
+          let prompt = 'Restore this version? The current state will be saved as a new version.';
+          if (versionParentNull && currentHasParent) {
+            restoreParent = false;
+            prompt = 'This version was captured before parent tracking. Restore content but keep the current parent attachment?';
+          }
+          if (!confirm(prompt)) return;
           btn.disabled = true;
           btn.textContent = 'Restoring...';
           try {
-            const updated = await api(`/api/items/${btn.dataset.id}/history/${btn.dataset.versionId}/restore`, {
-              method: 'POST',
-            });
+            const url = `/api/items/${btn.dataset.id}/history/${btn.dataset.versionId}/restore?restore_parent=${restoreParent}`;
+            const updated = await api(url, { method: 'POST' });
             Object.assign(item, updated);
             renderItemView(item);
             showToast('Restored');
+            // No finally — renderItemView detached btn from the DOM.
           } catch (err) {
             showToast('Failed to restore', 'error');
             btn.disabled = false;

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -1522,9 +1522,17 @@
         ? new Date(item.created_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
         : '';
 
-      let html = `<div class="item-view-title">${emoji}${escHtml(item.title || item.preview || '(untitled)')}</div>`;
+      let html = `<div class="item-view-title" id="item-title-display">${emoji}${escHtml(item.title || item.preview || '(untitled)')}</div>`;
       html += `<div class="item-view-meta">${sourceName(item.subtype)}${dateFmt ? ' &middot; ' + dateFmt : ''}${item.url ? ' &middot; <a href="' + escHtml(item.url) + '" target="_blank" rel="noopener" style="color:var(--accent)">link</a>' : ''}</div>`;
-      html += `<div class="item-view-content">${renderMarkdown(item.content)}</div>`;
+      html += `<div class="item-view-content" id="item-content-display">${renderMarkdown(item.content)}</div>`;
+      html += `<div id="item-edit-form" style="display:none">
+        <input type="text" id="item-edit-title" placeholder="Title" style="width:100%;font-size:1.05rem;font-weight:bold;padding:0.4rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;margin-bottom:0.4rem">
+        <textarea id="item-edit-content" rows="10" style="width:100%;resize:vertical;font-family:inherit;font-size:0.9rem;padding:0.5rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px"></textarea>
+        <div style="display:flex;gap:0.5rem;margin-top:0.4rem">
+          <button class="sync-btn" data-action="save-edit" data-id="${item.id}">Save</button>
+          <button class="sync-btn" data-action="cancel-edit">Cancel</button>
+        </div>
+      </div>`;
 
       // Media gallery
       const visibleMedia = (item.media || []).filter(m => m.available || m.media_type === 'link' || m.media_type === 'pdf');
@@ -1625,7 +1633,8 @@
       </div>`;
 
       // Actions
-      html += `<div class="item-detail-actions">
+      html += `<div class="item-detail-actions" id="item-detail-actions">
+        <button class="sync-btn" data-action="edit-item" data-id="${item.id}">Edit</button>
         <button class="sync-btn" data-action="show-note-form">+ Note</button>
         <button class="sync-btn" data-action="link-item" data-id="${item.id}">+ Link</button>
         <button class="sync-btn" data-action="copy" data-id="${item.id}">Copy</button>
@@ -1673,6 +1682,42 @@
         if (!btn) return;
         if (btn.dataset.action === 'copy') copyToClipboard(item.content, 'Copied to clipboard');
         if (btn.dataset.action === 'copy-link') copyToClipboard(`${getApiBase()}/items/${item.id}`, 'Link copied');
+        if (btn.dataset.action === 'edit-item') {
+          document.getElementById('item-title-display').style.display = 'none';
+          document.getElementById('item-content-display').style.display = 'none';
+          document.getElementById('item-detail-actions').style.display = 'none';
+          document.getElementById('item-edit-title').value = item.title || '';
+          document.getElementById('item-edit-content').value = item.content || '';
+          document.getElementById('item-edit-form').style.display = 'block';
+          document.getElementById('item-edit-title').focus();
+        }
+        if (btn.dataset.action === 'cancel-edit') {
+          document.getElementById('item-edit-form').style.display = 'none';
+          document.getElementById('item-title-display').style.display = '';
+          document.getElementById('item-content-display').style.display = '';
+          document.getElementById('item-detail-actions').style.display = '';
+        }
+        if (btn.dataset.action === 'save-edit') {
+          const newTitle = document.getElementById('item-edit-title').value;
+          const newContent = document.getElementById('item-edit-content').value;
+          btn.disabled = true;
+          btn.textContent = 'Saving...';
+          try {
+            const updated = await api(`/api/items/${btn.dataset.id}`, {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ title: newTitle, content: newContent }),
+            });
+            Object.assign(item, updated);
+            renderItemView(item);
+            showToast('Saved');
+          } catch (err) {
+            showToast('Failed to save', 'error');
+          } finally {
+            btn.disabled = false;
+            btn.textContent = 'Save';
+          }
+        }
         if (btn.dataset.action === 'remove-tag') {
           await api(`/api/items/${btn.dataset.id}/tags/${encodeURIComponent(btn.dataset.tag)}`, { method: 'DELETE' });
           const updated = await api(`/api/items/${btn.dataset.id}`);

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -1515,6 +1515,51 @@
       }
     }
 
+    async function loadItemHistory(itemId) {
+      const list = document.getElementById('item-history-list');
+      list.textContent = 'Loading...';
+      try {
+        const data = await api(`/api/items/${itemId}/history`);
+        if (!data.versions.length) {
+          list.innerHTML = '<span style="color:var(--muted)">No versions yet — edits create history rows.</span>';
+          return;
+        }
+        const reasonColor = {
+          'user-edit': '#3b82f6',
+          'sync': '#6b7280',
+          'enricher': '#10b981',
+          'restore': '#f59e0b',
+          'api-update': '#9ca3af',
+        };
+        list.innerHTML = data.versions.map(v => {
+          const reason = v.change_reason || 'unknown';
+          const color = reasonColor[reason] || '#9ca3af';
+          const dateFmt = new Date(v.changed_at + 'Z').toLocaleString();
+          const titlePart = v.title_old !== null && v.title_old !== undefined
+            ? `<span style="margin-left:0.5rem">${escHtml(v.title_old)}</span>`
+            : '';
+          const previewPart = v.content_preview
+            ? `<div style="color:var(--muted);margin-top:0.15rem">${escHtml(v.content_preview)}</div>`
+            : '';
+          return `<div style="padding:0.4rem 0;border-top:1px solid var(--border)">
+            <div style="display:flex;align-items:center;gap:0.4rem;flex-wrap:wrap">
+              <span style="font-size:0.7rem;padding:0.1rem 0.35rem;border-radius:3px;background:${color};color:white">${escHtml(reason)}</span>
+              <span style="color:var(--muted);font-size:0.75rem">${dateFmt}</span>
+              ${titlePart}
+              <span style="margin-left:auto;display:flex;gap:0.3rem">
+                <button class="sync-btn" data-action="expand-version" data-id="${itemId}" data-version-id="${v.id}" style="font-size:0.7rem;padding:0.1rem 0.4rem">View</button>
+                <button class="sync-btn" data-action="restore-version" data-id="${itemId}" data-version-id="${v.id}" style="font-size:0.7rem;padding:0.1rem 0.4rem">Restore</button>
+              </span>
+            </div>
+            ${previewPart}
+            <div id="version-detail-${v.id}" style="display:none;margin-top:0.35rem;padding:0.35rem;background:var(--bg);border:1px solid var(--border);border-radius:3px"></div>
+          </div>`;
+        }).join('');
+      } catch (err) {
+        list.innerHTML = '<span style="color:var(--muted)">Failed to load history</span>';
+      }
+    }
+
     function renderItemView(item) {
       const container = document.getElementById('item-view-content');
       const emoji = item.metadata && item.metadata.emoji ? item.metadata.emoji + ' ' : '';
@@ -1635,12 +1680,17 @@
       // Actions
       html += `<div class="item-detail-actions" id="item-detail-actions">
         <button class="sync-btn" data-action="edit-item" data-id="${item.id}">Edit</button>
+        <button class="sync-btn" data-action="toggle-history" data-id="${item.id}">History</button>
         <button class="sync-btn" data-action="show-note-form">+ Note</button>
         <button class="sync-btn" data-action="link-item" data-id="${item.id}">+ Link</button>
         <button class="sync-btn" data-action="copy" data-id="${item.id}">Copy</button>
         <button class="sync-btn" data-action="copy-link" data-id="${item.id}">Copy Link</button>
         <button class="sync-btn" onclick="addToCollection(${item.id})">+ Collection</button>
         <select id="add-to-coll-select" style="display:none;font-size:0.75rem;padding:0.25rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px" onchange="confirmAddToCollection(this)"></select>
+      </div>`;
+      html += `<div id="item-history-panel" style="display:none;margin-top:0.5rem;padding:0.5rem;border:1px solid var(--border);border-radius:4px">
+        <div style="font-size:0.85rem;font-weight:bold;margin-bottom:0.4rem">Version history</div>
+        <div id="item-history-list" style="font-size:0.8rem"></div>
       </div>`;
 
       // Children section (always shown so new notes appear immediately)
@@ -1716,6 +1766,64 @@
           } finally {
             btn.disabled = false;
             btn.textContent = 'Save';
+          }
+        }
+        if (btn.dataset.action === 'toggle-history') {
+          const panel = document.getElementById('item-history-panel');
+          if (panel.style.display === 'none') {
+            panel.style.display = 'block';
+            await loadItemHistory(btn.dataset.id);
+          } else {
+            panel.style.display = 'none';
+          }
+        }
+        if (btn.dataset.action === 'expand-version') {
+          const detailDiv = container.querySelector(`#version-detail-${btn.dataset.versionId}`);
+          if (detailDiv.style.display === 'none') {
+            if (!detailDiv.dataset.loaded) {
+              detailDiv.textContent = 'Loading...';
+              try {
+                const detail = await api(`/api/items/${btn.dataset.id}/history/${btn.dataset.versionId}`);
+                detailDiv.textContent = '';
+                const titleLine = document.createElement('div');
+                titleLine.style.fontWeight = 'bold';
+                titleLine.style.marginBottom = '0.25rem';
+                titleLine.textContent = detail.title_old || '(no title)';
+                const contentBlock = document.createElement('pre');
+                contentBlock.style.whiteSpace = 'pre-wrap';
+                contentBlock.style.wordBreak = 'break-word';
+                contentBlock.style.margin = '0';
+                contentBlock.style.fontSize = '0.75rem';
+                contentBlock.textContent = detail.content_old || '(no content)';
+                detailDiv.appendChild(titleLine);
+                detailDiv.appendChild(contentBlock);
+                detailDiv.dataset.loaded = '1';
+              } catch (err) {
+                detailDiv.textContent = 'Failed to load version';
+              }
+            }
+            detailDiv.style.display = 'block';
+            btn.textContent = 'Hide';
+          } else {
+            detailDiv.style.display = 'none';
+            btn.textContent = 'View';
+          }
+        }
+        if (btn.dataset.action === 'restore-version') {
+          if (!confirm('Restore this version? The current state will be saved as a new version.')) return;
+          btn.disabled = true;
+          btn.textContent = 'Restoring...';
+          try {
+            const updated = await api(`/api/items/${btn.dataset.id}/history/${btn.dataset.versionId}/restore`, {
+              method: 'POST',
+            });
+            Object.assign(item, updated);
+            renderItemView(item);
+            showToast('Restored');
+          } catch (err) {
+            showToast('Failed to restore', 'error');
+            btn.disabled = false;
+            btn.textContent = 'Restore';
           }
         }
         if (btn.dataset.action === 'remove-tag') {

--- a/packages/lestash-linkedin/src/lestash_linkedin/source.py
+++ b/packages/lestash-linkedin/src/lestash_linkedin/source.py
@@ -15,6 +15,7 @@ from typing import Annotated, Any
 
 import httpx
 import typer
+from lestash.core.database import mark_recent_history, max_history_id
 from lestash.core.logging import get_plugin_logger
 from lestash.models.item import ItemCreate
 from lestash.plugins.base import SourcePlugin
@@ -76,6 +77,7 @@ def resolve_linkedin_parents(conn: sqlite3.Connection) -> int:
     Returns the number of items updated.
     """
     total = 0
+    pre_max = max_history_id(conn)
     for field in ("reacted_to", "commented_on"):
         match_sql = _parent_match_sql(field)
         cursor = conn.execute(
@@ -95,6 +97,7 @@ def resolve_linkedin_parents(conn: sqlite3.Connection) -> int:
             """,
         )
         total += cursor.rowcount
+    mark_recent_history(conn, pre_max, "sync")
     conn.commit()
     return total
 
@@ -1403,6 +1406,8 @@ class LinkedInSource(SourcePlugin):
                     if deleted:
                         console.print(f"[dim]Removed {deleted} duplicate items[/dim]")
 
+                    backfill_pre_max = max_history_id(conn)
+
                     # Step 2: Backfill snowflake_ts on posts
                     rows = conn.execute("""
                         SELECT id, json_extract(metadata, '$.post_id'), metadata
@@ -1450,6 +1455,7 @@ class LinkedInSource(SourcePlugin):
                                     "UPDATE items SET metadata = ? WHERE id = ?",
                                     (json.dumps(meta), row_id),
                                 )
+                    mark_recent_history(conn, backfill_pre_max, "sync")
                     conn.commit()
 
                     # Step 4: Resolve parents

--- a/packages/lestash-server/src/lestash_server/models.py
+++ b/packages/lestash-server/src/lestash_server/models.py
@@ -120,6 +120,39 @@ class ItemPatchRequest(BaseModel):
     parent_id: int | None | object = _UNSET
 
 
+class HistoryVersion(BaseModel):
+    """One version snapshot in an item's history (list view)."""
+
+    id: int
+    changed_at: datetime
+    change_reason: str | None
+    change_type: str | None
+    title_old: str | None
+    content_preview: str | None
+    parent_id_old: int | None
+
+
+class HistoryVersionDetail(BaseModel):
+    """Full snapshot of a single version (detail view)."""
+
+    id: int
+    item_id: int
+    changed_at: datetime
+    change_reason: str | None
+    change_type: str | None
+    title_old: str | None
+    content_old: str | None
+    author_old: str | None
+    url_old: str | None
+    metadata_old: dict[str, Any] | None
+    is_own_content_old: bool | None
+    parent_id_old: int | None
+
+
+class HistoryListResponse(BaseModel):
+    versions: list[HistoryVersion]
+
+
 class CollectionCreate(BaseModel):
     """Request to create a collection."""
 

--- a/packages/lestash-server/src/lestash_server/routes/items.py
+++ b/packages/lestash-server/src/lestash_server/routes/items.py
@@ -420,10 +420,21 @@ def update_item(item_id: int, body: ItemPatchRequest):
         if not updates:
             raise HTTPException(status_code=400, detail="No fields to update")
 
+        pre_max = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) FROM item_history WHERE item_id = ?",
+            (item_id,),
+        ).fetchone()[0]
+
         params.append(item_id)
         conn.execute(
             f"UPDATE items SET {', '.join(updates)} WHERE id = ?",
             params,
+        )
+
+        # Mark any history row the trigger just captured as a user edit.
+        conn.execute(
+            "UPDATE item_history SET change_reason = 'user-edit' WHERE item_id = ? AND id > ?",
+            (item_id, pre_max),
         )
         conn.commit()
 

--- a/packages/lestash-server/src/lestash_server/routes/items.py
+++ b/packages/lestash-server/src/lestash_server/routes/items.py
@@ -13,6 +13,7 @@ from lestash.core.database import (
     max_history_id,
     remove_tag,
 )
+from lestash.core.embeddings import re_embed_item
 from lestash.core.enrichment import get_author_actor, get_item_subtype, get_preview
 from lestash.models.item import Item
 
@@ -431,7 +432,11 @@ def update_item(item_id: int, body: ItemPatchRequest):
         if not updates:
             raise HTTPException(status_code=400, detail="No fields to update")
 
-        text_changed = body.content is not None or body.title is not _UNSET
+        # Only re-embed when title or content actually differ from current row,
+        # not just because the client sent the field with the same value.
+        text_changed = (body.content is not None and body.content != row["content"]) or (
+            body.title is not _UNSET and body.title != row["title"]
+        )
         pre_max = max_history_id(conn)
 
         params.append(item_id)
@@ -439,12 +444,10 @@ def update_item(item_id: int, body: ItemPatchRequest):
             f"UPDATE items SET {', '.join(updates)} WHERE id = ?",
             params,
         )
-        mark_recent_history(conn, pre_max, "user-edit")
+        mark_recent_history(conn, pre_max, "user-edit", item_ids=[item_id])
         conn.commit()
 
         if text_changed:
-            from lestash.core.embeddings import re_embed_item
-
             re_embed_item(conn, item_id)
 
         row = conn.execute("SELECT * FROM items WHERE id = ?", (item_id,)).fetchone()
@@ -454,8 +457,11 @@ def update_item(item_id: int, body: ItemPatchRequest):
 def _content_preview(content: str | None, max_length: int = 200) -> str | None:
     if content is None:
         return None
-    text = content.strip().replace("\n", " ")
-    return text[:max_length] + ("…" if len(text) > max_length else "")
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped[:max_length] + ("…" if len(stripped) > max_length else "")
+    return None
 
 
 def _parse_metadata_old(metadata_old: str | None) -> dict | None:
@@ -529,14 +535,27 @@ def get_item_history_version(item_id: int, version_id: int):
 
 
 @router.post("/{item_id}/history/{version_id}/restore", response_model=ItemResponse)
-def restore_item_history_version(item_id: int, version_id: int):
+def restore_item_history_version(
+    item_id: int,
+    version_id: int,
+    restore_parent: bool = Query(
+        True,
+        description=(
+            "If False, leave the item's current parent_id alone instead of "
+            "writing the snapshot's parent_id_old. Use this for history rows "
+            "captured before Migration 9, where parent_id_old is always NULL "
+            "but the item may currently have a real parent."
+        ),
+    ),
+):
     """Restore an item to a previous version.
 
     Writes the snapshot fields back to items; the resulting UPDATE captures
     the pre-restore state as a new history row tagged 'restore'. NULL values
     in the snapshot are written through verbatim — note that history rows
-    captured before Migration 9 always have parent_id_old=NULL, so restoring
-    those will clear the current parent_id.
+    captured before Migration 9 always have parent_id_old=NULL, so callers
+    should pass `restore_parent=false` for those rows to avoid silently
+    detaching a still-parented item.
     """
     with get_db() as conn:
         snapshot = conn.execute(
@@ -558,31 +577,50 @@ def restore_item_history_version(item_id: int, version_id: int):
             )
 
         pre_max = max_history_id(conn)
-        conn.execute(
-            """UPDATE items SET
-                   title = ?,
-                   content = ?,
-                   author = ?,
-                   url = ?,
-                   metadata = ?,
-                   is_own_content = ?,
-                   parent_id = ?
-               WHERE id = ?""",
-            (
-                snapshot["title_old"],
-                snapshot["content_old"],
-                snapshot["author_old"],
-                snapshot["url_old"],
-                snapshot["metadata_old"],
-                snapshot["is_own_content_old"],
-                snapshot["parent_id_old"],
-                item_id,
-            ),
-        )
-        mark_recent_history(conn, pre_max, "restore")
+        if restore_parent:
+            conn.execute(
+                """UPDATE items SET
+                       title = ?,
+                       content = ?,
+                       author = ?,
+                       url = ?,
+                       metadata = ?,
+                       is_own_content = ?,
+                       parent_id = ?
+                   WHERE id = ?""",
+                (
+                    snapshot["title_old"],
+                    snapshot["content_old"],
+                    snapshot["author_old"],
+                    snapshot["url_old"],
+                    snapshot["metadata_old"],
+                    snapshot["is_own_content_old"],
+                    snapshot["parent_id_old"],
+                    item_id,
+                ),
+            )
+        else:
+            conn.execute(
+                """UPDATE items SET
+                       title = ?,
+                       content = ?,
+                       author = ?,
+                       url = ?,
+                       metadata = ?,
+                       is_own_content = ?
+                   WHERE id = ?""",
+                (
+                    snapshot["title_old"],
+                    snapshot["content_old"],
+                    snapshot["author_old"],
+                    snapshot["url_old"],
+                    snapshot["metadata_old"],
+                    snapshot["is_own_content_old"],
+                    item_id,
+                ),
+            )
+        mark_recent_history(conn, pre_max, "restore", item_ids=[item_id])
         conn.commit()
-
-        from lestash.core.embeddings import re_embed_item
 
         re_embed_item(conn, item_id)
 

--- a/packages/lestash-server/src/lestash_server/routes/items.py
+++ b/packages/lestash-server/src/lestash_server/routes/items.py
@@ -4,13 +4,24 @@ import json
 import logging
 
 from fastapi import APIRouter, HTTPException, Query
-from lestash.core.database import add_tag, get_item_media, get_tags, list_tags, remove_tag
+from lestash.core.database import (
+    add_tag,
+    get_item_media,
+    get_tags,
+    list_tags,
+    mark_recent_history,
+    max_history_id,
+    remove_tag,
+)
 from lestash.core.enrichment import get_author_actor, get_item_subtype, get_preview
 from lestash.models.item import Item
 
 from lestash_server.deps import get_db
 from lestash_server.models import (
     _UNSET,
+    HistoryListResponse,
+    HistoryVersion,
+    HistoryVersionDetail,
     ItemCreateRequest,
     ItemListResponse,
     ItemPatchRequest,
@@ -420,23 +431,160 @@ def update_item(item_id: int, body: ItemPatchRequest):
         if not updates:
             raise HTTPException(status_code=400, detail="No fields to update")
 
-        pre_max = conn.execute(
-            "SELECT COALESCE(MAX(id), 0) FROM item_history WHERE item_id = ?",
-            (item_id,),
-        ).fetchone()[0]
+        text_changed = body.content is not None or body.title is not _UNSET
+        pre_max = max_history_id(conn)
 
         params.append(item_id)
         conn.execute(
             f"UPDATE items SET {', '.join(updates)} WHERE id = ?",
             params,
         )
-
-        # Mark any history row the trigger just captured as a user edit.
-        conn.execute(
-            "UPDATE item_history SET change_reason = 'user-edit' WHERE item_id = ? AND id > ?",
-            (item_id, pre_max),
-        )
+        mark_recent_history(conn, pre_max, "user-edit")
         conn.commit()
+
+        if text_changed:
+            from lestash.core.embeddings import re_embed_item
+
+            re_embed_item(conn, item_id)
+
+        row = conn.execute("SELECT * FROM items WHERE id = ?", (item_id,)).fetchone()
+        return _enrich_item(conn, Item.from_row(row))
+
+
+def _content_preview(content: str | None, max_length: int = 200) -> str | None:
+    if content is None:
+        return None
+    text = content.strip().replace("\n", " ")
+    return text[:max_length] + ("…" if len(text) > max_length else "")
+
+
+def _parse_metadata_old(metadata_old: str | None) -> dict | None:
+    if not metadata_old:
+        return None
+    try:
+        parsed = json.loads(metadata_old)
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+@router.get("/{item_id}/history", response_model=HistoryListResponse)
+def list_item_history(item_id: int):
+    """List all history versions for an item, newest first."""
+    with get_db() as conn:
+        if not conn.execute("SELECT 1 FROM items WHERE id = ?", (item_id,)).fetchone():
+            raise HTTPException(status_code=404, detail=f"Item {item_id} not found")
+
+        rows = conn.execute(
+            """SELECT id, changed_at, change_reason, change_type,
+                      title_old, content_old, parent_id_old
+               FROM item_history WHERE item_id = ? ORDER BY id DESC""",
+            (item_id,),
+        ).fetchall()
+
+        versions = [
+            HistoryVersion(
+                id=r["id"],
+                changed_at=r["changed_at"],
+                change_reason=r["change_reason"],
+                change_type=r["change_type"],
+                title_old=r["title_old"],
+                content_preview=_content_preview(r["content_old"]),
+                parent_id_old=r["parent_id_old"],
+            )
+            for r in rows
+        ]
+        return HistoryListResponse(versions=versions)
+
+
+@router.get("/{item_id}/history/{version_id}", response_model=HistoryVersionDetail)
+def get_item_history_version(item_id: int, version_id: int):
+    """Get the full snapshot for one history version."""
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT * FROM item_history WHERE id = ? AND item_id = ?",
+            (version_id, item_id),
+        ).fetchone()
+        if not row:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Version {version_id} not found for item {item_id}",
+            )
+        return HistoryVersionDetail(
+            id=row["id"],
+            item_id=row["item_id"],
+            changed_at=row["changed_at"],
+            change_reason=row["change_reason"],
+            change_type=row["change_type"],
+            title_old=row["title_old"],
+            content_old=row["content_old"],
+            author_old=row["author_old"],
+            url_old=row["url_old"],
+            metadata_old=_parse_metadata_old(row["metadata_old"]),
+            is_own_content_old=bool(row["is_own_content_old"])
+            if row["is_own_content_old"] is not None
+            else None,
+            parent_id_old=row["parent_id_old"],
+        )
+
+
+@router.post("/{item_id}/history/{version_id}/restore", response_model=ItemResponse)
+def restore_item_history_version(item_id: int, version_id: int):
+    """Restore an item to a previous version.
+
+    Writes the snapshot fields back to items; the resulting UPDATE captures
+    the pre-restore state as a new history row tagged 'restore'. NULL values
+    in the snapshot are written through verbatim — note that history rows
+    captured before Migration 9 always have parent_id_old=NULL, so restoring
+    those will clear the current parent_id.
+    """
+    with get_db() as conn:
+        snapshot = conn.execute(
+            "SELECT * FROM item_history WHERE id = ? AND item_id = ?",
+            (version_id, item_id),
+        ).fetchone()
+        if not snapshot:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Version {version_id} not found for item {item_id}",
+            )
+
+        # content has NOT NULL on items, so refuse if snapshot's content_old is NULL
+        # (would be a pathological pre-trigger row).
+        if snapshot["content_old"] is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Snapshot is missing content; cannot restore",
+            )
+
+        pre_max = max_history_id(conn)
+        conn.execute(
+            """UPDATE items SET
+                   title = ?,
+                   content = ?,
+                   author = ?,
+                   url = ?,
+                   metadata = ?,
+                   is_own_content = ?,
+                   parent_id = ?
+               WHERE id = ?""",
+            (
+                snapshot["title_old"],
+                snapshot["content_old"],
+                snapshot["author_old"],
+                snapshot["url_old"],
+                snapshot["metadata_old"],
+                snapshot["is_own_content_old"],
+                snapshot["parent_id_old"],
+                item_id,
+            ),
+        )
+        mark_recent_history(conn, pre_max, "restore")
+        conn.commit()
+
+        from lestash.core.embeddings import re_embed_item
+
+        re_embed_item(conn, item_id)
 
         row = conn.execute("SELECT * FROM items WHERE id = ?", (item_id,)).fetchone()
         return _enrich_item(conn, Item.from_row(row))

--- a/packages/lestash-server/tests/test_api.py
+++ b/packages/lestash-server/tests/test_api.py
@@ -196,6 +196,102 @@ class TestItemPatch:
         assert history == []
 
 
+class TestItemHistory:
+    """Test the GET/POST /api/items/{id}/history* endpoints."""
+
+    def _seeded_item(self, client) -> dict:
+        items = client.get("/api/items?source=linkedin&own=true&limit=1").json()["items"]
+        return items[0]
+
+    def test_history_list_empty_for_unedited_item(self, client):
+        item = self._seeded_item(client)
+        resp = client.get(f"/api/items/{item['id']}/history")
+        assert resp.status_code == 200
+        assert resp.json() == {"versions": []}
+
+    def test_history_list_returns_versions_newest_first(self, client):
+        item = self._seeded_item(client)
+        client.patch(f"/api/items/{item['id']}", json={"title": "Edit 1"})
+        client.patch(f"/api/items/{item['id']}", json={"title": "Edit 2"})
+
+        resp = client.get(f"/api/items/{item['id']}/history")
+        versions = resp.json()["versions"]
+        assert len(versions) == 2
+        assert versions[0]["title_old"] == "Edit 1"
+        assert versions[1]["title_old"] == item["title"]
+        assert all(v["change_reason"] == "user-edit" for v in versions)
+
+    def test_history_list_404_for_missing_item(self, client):
+        resp = client.get("/api/items/999999/history")
+        assert resp.status_code == 404
+
+    def test_history_detail_returns_full_snapshot(self, client):
+        item = self._seeded_item(client)
+        client.patch(f"/api/items/{item['id']}", json={"content": "Edited content"})
+
+        version_id = client.get(f"/api/items/{item['id']}/history").json()["versions"][0]["id"]
+
+        resp = client.get(f"/api/items/{item['id']}/history/{version_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["item_id"] == item["id"]
+        assert body["content_old"] == item["content"]
+        assert body["title_old"] == item["title"]
+        assert body["change_reason"] == "user-edit"
+        assert body["metadata_old"] == item["metadata"]
+
+    def test_history_detail_404_for_missing_version(self, client):
+        item = self._seeded_item(client)
+        resp = client.get(f"/api/items/{item['id']}/history/999999")
+        assert resp.status_code == 404
+
+    def test_history_detail_404_for_mismatched_item(self, client):
+        # Edit item A, then ask for that version under item B's ID.
+        a = self._seeded_item(client)
+        b_items = client.get("/api/items?source=bluesky&limit=1").json()["items"]
+        b_id = b_items[0]["id"]
+        client.patch(f"/api/items/{a['id']}", json={"title": "Edit"})
+        version_id = client.get(f"/api/items/{a['id']}/history").json()["versions"][0]["id"]
+
+        resp = client.get(f"/api/items/{b_id}/history/{version_id}")
+        assert resp.status_code == 404
+
+    def test_restore_reverts_to_snapshot(self, client):
+        item = self._seeded_item(client)
+        original_title = item["title"]
+        original_content = item["content"]
+
+        client.patch(
+            f"/api/items/{item['id']}",
+            json={"title": "Bad rename", "content": "Bad content"},
+        )
+        version_id = client.get(f"/api/items/{item['id']}/history").json()["versions"][0]["id"]
+
+        resp = client.post(f"/api/items/{item['id']}/history/{version_id}/restore")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["title"] == original_title
+        assert body["content"] == original_content
+
+    def test_restore_creates_new_history_row_tagged_restore(self, client):
+        item = self._seeded_item(client)
+        client.patch(f"/api/items/{item['id']}", json={"title": "Bad rename"})
+        version_id = client.get(f"/api/items/{item['id']}/history").json()["versions"][0]["id"]
+
+        client.post(f"/api/items/{item['id']}/history/{version_id}/restore")
+
+        versions = client.get(f"/api/items/{item['id']}/history").json()["versions"]
+        assert len(versions) == 2
+        # The newest version captures the pre-restore state ("Bad rename").
+        assert versions[0]["change_reason"] == "restore"
+        assert versions[0]["title_old"] == "Bad rename"
+
+    def test_restore_404_for_unknown_version(self, client):
+        item = self._seeded_item(client)
+        resp = client.post(f"/api/items/{item['id']}/history/999999/restore")
+        assert resp.status_code == 404
+
+
 class TestSources:
     """Test /api/sources endpoints."""
 

--- a/packages/lestash-server/tests/test_api.py
+++ b/packages/lestash-server/tests/test_api.py
@@ -291,6 +291,112 @@ class TestItemHistory:
         resp = client.post(f"/api/items/{item['id']}/history/999999/restore")
         assert resp.status_code == 404
 
+    def test_restore_parent_false_keeps_current_parent(self, client):
+        """restore_parent=false must leave the current parent_id alone."""
+        # Build child with a parent. Edit child to capture a history row with
+        # parent_id_old pointing at the parent. Then null out parent_id_old in
+        # that row to simulate a pre-Migration-9 snapshot, and reparent the
+        # child to a different parent so we can detect whether restore clears it.
+        from lestash.core.database import get_connection
+
+        # Two seeded linkedin items will serve as parents.
+        parents = client.get("/api/items?source=linkedin&limit=2").json()["items"]
+        parent_a, parent_b = parents[0]["id"], parents[1]["id"]
+
+        # Create a child via POST.
+        new_child = client.post(
+            "/api/items",
+            json={
+                "source_type": "note",
+                "source_id": f"restore-test-{parent_a}",
+                "content": "child v1",
+                "parent_id": parent_a,
+            },
+        ).json()
+        child_id = new_child["id"]
+
+        # Edit content to create a history row.
+        client.patch(f"/api/items/{child_id}", json={"content": "child v2"})
+
+        # Simulate a pre-Migration-9 row: null out parent_id_old.
+        from lestash_server.deps import _config
+
+        with get_connection(_config) as conn:
+            conn.execute(
+                "UPDATE item_history SET parent_id_old = NULL WHERE item_id = ?",
+                (child_id,),
+            )
+            conn.commit()
+
+        version_id = client.get(f"/api/items/{child_id}/history").json()["versions"][0]["id"]
+
+        # Reparent to B, then restore the (parent-null) version with restore_parent=false.
+        client.patch(f"/api/items/{child_id}", json={"parent_id": parent_b})
+        resp = client.post(
+            f"/api/items/{child_id}/history/{version_id}/restore?restore_parent=false"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["parent_id"] == parent_b  # unchanged
+        assert resp.json()["content"] == "child v1"  # content restored
+
+    def test_restore_parent_default_writes_snapshot_value(self, client):
+        """restore_parent=true (default) writes parent_id_old verbatim."""
+        parents = client.get("/api/items?source=linkedin&limit=2").json()["items"]
+        parent_a, parent_b = parents[0]["id"], parents[1]["id"]
+
+        new_child = client.post(
+            "/api/items",
+            json={
+                "source_type": "note",
+                "source_id": f"restore-default-{parent_a}",
+                "content": "child v1",
+                "parent_id": parent_a,
+            },
+        ).json()
+        child_id = new_child["id"]
+
+        # Trigger a history row (this captures parent_id_old=parent_a).
+        client.patch(f"/api/items/{child_id}", json={"content": "child v2"})
+        version_id = client.get(f"/api/items/{child_id}/history").json()["versions"][0]["id"]
+
+        # Reparent to B, then restore the version (default restore_parent=true).
+        client.patch(f"/api/items/{child_id}", json={"parent_id": parent_b})
+        resp = client.post(f"/api/items/{child_id}/history/{version_id}/restore")
+        assert resp.status_code == 200
+        assert resp.json()["parent_id"] == parent_a  # restored from snapshot
+
+    def test_patch_unchanged_title_skips_re_embed(self, client, monkeypatch):
+        """Sending the same title back must not call re_embed_item."""
+        from lestash_server.routes import items as items_route
+
+        called: list[int] = []
+
+        def fake_re_embed(conn, item_id):
+            called.append(item_id)
+            return True
+
+        monkeypatch.setattr(items_route, "re_embed_item", fake_re_embed)
+
+        item = self._seeded_item(client)
+        resp = client.patch(f"/api/items/{item['id']}", json={"title": item["title"]})
+        assert resp.status_code == 200
+        assert called == []  # no-op title → no re-embed
+
+    def test_patch_changed_title_triggers_re_embed(self, client, monkeypatch):
+        from lestash_server.routes import items as items_route
+
+        called: list[int] = []
+
+        def fake_re_embed(conn, item_id):
+            called.append(item_id)
+            return True
+
+        monkeypatch.setattr(items_route, "re_embed_item", fake_re_embed)
+
+        item = self._seeded_item(client)
+        client.patch(f"/api/items/{item['id']}", json={"title": "Real change"})
+        assert called == [item["id"]]
+
 
 class TestSources:
     """Test /api/sources endpoints."""

--- a/packages/lestash-server/tests/test_api.py
+++ b/packages/lestash-server/tests/test_api.py
@@ -127,6 +127,75 @@ class TestItems:
         assert len(data["items"]) == 0
 
 
+class TestItemPatch:
+    """Test PATCH /api/items/{id} — user edits create history rows tagged 'user-edit'."""
+
+    def _item_id(self, client, source: str = "linkedin", own: bool | None = None) -> int:
+        url = f"/api/items?source={source}&limit=1"
+        if own is not None:
+            url += f"&own={'true' if own else 'false'}"
+        items = client.get(url).json()["items"]
+        return items[0]["id"]
+
+    def _history(self, test_config, item_id: int):
+        from lestash.core.database import get_connection
+
+        with get_connection(test_config) as conn:
+            rows = conn.execute(
+                "SELECT change_reason, title_old, content_old, parent_id_old "
+                "FROM item_history WHERE item_id = ? ORDER BY id",
+                (item_id,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def test_patch_title_creates_user_edit_history(self, client, test_config):
+        item_id = self._item_id(client, own=True)
+        resp = client.patch(f"/api/items/{item_id}", json={"title": "Edited Title"})
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Edited Title"
+
+        history = self._history(test_config, item_id)
+        assert len(history) == 1
+        assert history[0]["change_reason"] == "user-edit"
+        assert history[0]["title_old"] == "First Post"
+
+    def test_patch_content_creates_user_edit_history(self, client, test_config):
+        item_id = self._item_id(client, own=True)
+        resp = client.patch(f"/api/items/{item_id}", json={"content": "New body"})
+        assert resp.status_code == 200
+
+        history = self._history(test_config, item_id)
+        assert len(history) == 1
+        assert history[0]["change_reason"] == "user-edit"
+        assert history[0]["content_old"] == "My first LinkedIn post about Python"
+
+    def test_patch_parent_id_creates_user_edit_history(self, client, test_config):
+        # Use bluesky item; reparent under linkedin item
+        bluesky_id = self._item_id(client, "bluesky")
+        linkedin_id = self._item_id(client, "linkedin", own=True)
+
+        resp = client.patch(f"/api/items/{bluesky_id}", json={"parent_id": linkedin_id})
+        assert resp.status_code == 200
+
+        history = self._history(test_config, bluesky_id)
+        assert len(history) == 1
+        assert history[0]["change_reason"] == "user-edit"
+        assert history[0]["parent_id_old"] is None
+
+    def test_patch_no_change_creates_no_history(self, client, test_config):
+        item_id = self._item_id(client, own=True)
+        current = client.get(f"/api/items/{item_id}").json()
+
+        resp = client.patch(
+            f"/api/items/{item_id}",
+            json={"title": current["title"], "content": current["content"]},
+        )
+        assert resp.status_code == 200
+
+        history = self._history(test_config, item_id)
+        assert history == []
+
+
 class TestSources:
     """Test /api/sources endpoints."""
 

--- a/packages/lestash/src/lestash/core/database.py
+++ b/packages/lestash/src/lestash/core/database.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Current schema version - increment when adding migrations
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 # Base schema (version 0) - applied to new databases
 SCHEMA = """
@@ -290,6 +290,50 @@ MIGRATIONS = [
         END;
         """,
     ),
+    (
+        9,
+        "Capture parent_id in item_history; cleanup duplicate sync history rows",
+        # Note: ALTER TABLE ADD COLUMN parent_id_old is handled in apply_migrations()
+        # because SQLite has no IF NOT EXISTS for ALTER TABLE.
+        """
+        DROP TRIGGER IF EXISTS capture_item_history;
+
+        CREATE TRIGGER capture_item_history
+        BEFORE UPDATE ON items
+        FOR EACH ROW
+        WHEN OLD.content IS NOT NEW.content
+          OR OLD.title IS NOT NEW.title
+          OR OLD.author IS NOT NEW.author
+          OR OLD.metadata IS NOT NEW.metadata
+          OR OLD.parent_id IS NOT NEW.parent_id
+        BEGIN
+            INSERT INTO item_history (
+                item_id, content_old, title_old, author_old,
+                url_old, metadata_old, is_own_content_old,
+                parent_id_old, change_reason, change_type
+            ) VALUES (
+                OLD.id, OLD.content, OLD.title, OLD.author,
+                OLD.url, OLD.metadata, OLD.is_own_content,
+                OLD.parent_id, 'api-update', 'update'
+            );
+        END;
+
+        DELETE FROM item_history
+        WHERE id NOT IN (
+            SELECT MIN(ih.id) FROM item_history ih
+            JOIN items i ON i.id = ih.item_id
+            WHERE i.source_type IN ('linkedin', 'youtube', 'audible', 'bluesky')
+            GROUP BY ih.item_id,
+                     COALESCE(ih.content_old, ''),
+                     COALESCE(ih.title_old, ''),
+                     COALESCE(ih.metadata_old, '')
+        )
+        AND item_id IN (
+            SELECT id FROM items
+            WHERE source_type IN ('linkedin', 'youtube', 'audible', 'bluesky')
+        );
+        """,
+    ),
 ]
 
 
@@ -333,6 +377,8 @@ def apply_migrations(conn: sqlite3.Connection) -> int:
             # because ALTER TABLE ADD COLUMN has no IF NOT EXISTS in SQLite)
             if version == 5 and not _column_exists(conn, "items", "parent_id"):
                 conn.execute("ALTER TABLE items ADD COLUMN parent_id INTEGER")
+            if version == 9 and not _column_exists(conn, "item_history", "parent_id_old"):
+                conn.execute("ALTER TABLE item_history ADD COLUMN parent_id_old INTEGER")
             conn.executescript(sql)
             set_schema_version(conn, version)
             conn.commit()

--- a/packages/lestash/src/lestash/core/database.py
+++ b/packages/lestash/src/lestash/core/database.py
@@ -361,6 +361,28 @@ def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
     return any(row[1] == column for row in cursor.fetchall())
 
 
+def max_history_id(conn: sqlite3.Connection) -> int:
+    """Snapshot the latest item_history.id for a 'mark recent rows' bookkeeping pattern.
+
+    Pair with mark_recent_history() to tag rows that the capture_item_history
+    trigger writes during a subsequent UPDATE/UPSERT.
+    """
+    return conn.execute("SELECT COALESCE(MAX(id), 0) FROM item_history").fetchone()[0]
+
+
+def mark_recent_history(conn: sqlite3.Connection, since_id: int, change_reason: str) -> None:
+    """Re-tag history rows newer than `since_id` with the given change_reason.
+
+    SQLite triggers cannot receive parameters, so the trigger always writes
+    'api-update'. Callers (sync, enricher, user-edit) capture max_history_id()
+    before their write and call this after to overwrite the default.
+    """
+    conn.execute(
+        "UPDATE item_history SET change_reason = ? WHERE id > ?",
+        (change_reason, since_id),
+    )
+
+
 def apply_migrations(conn: sqlite3.Connection) -> int:
     """Apply any pending migrations.
 
@@ -516,6 +538,7 @@ def upsert_item(conn: sqlite3.Connection, item: ItemCreate) -> int:
     import json
 
     metadata_json = json.dumps(item.metadata) if item.metadata else None
+    pre_max = max_history_id(conn)
     conn.execute(
         """
         INSERT INTO items (
@@ -547,6 +570,7 @@ def upsert_item(conn: sqlite3.Connection, item: ItemCreate) -> int:
             item.parent_id,
         ),
     )
+    mark_recent_history(conn, pre_max, "sync")
     conn.commit()
 
     row = conn.execute(

--- a/packages/lestash/src/lestash/core/database.py
+++ b/packages/lestash/src/lestash/core/database.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -370,16 +370,37 @@ def max_history_id(conn: sqlite3.Connection) -> int:
     return conn.execute("SELECT COALESCE(MAX(id), 0) FROM item_history").fetchone()[0]
 
 
-def mark_recent_history(conn: sqlite3.Connection, since_id: int, change_reason: str) -> None:
+def mark_recent_history(
+    conn: sqlite3.Connection,
+    since_id: int,
+    change_reason: str,
+    *,
+    item_ids: Iterable[int] | None = None,
+) -> None:
     """Re-tag history rows newer than `since_id` with the given change_reason.
 
     SQLite triggers cannot receive parameters, so the trigger always writes
     'api-update'. Callers (sync, enricher, user-edit) capture max_history_id()
     before their write and call this after to overwrite the default.
+
+    Pass `item_ids` when the caller knows exactly which items it touched —
+    this prevents re-tagging rows produced by an unrelated concurrent writer
+    that interleaved between the snapshot and the mark. Sync/enricher paths
+    that touch many items by design should leave it None.
     """
+    if item_ids is None:
+        conn.execute(
+            "UPDATE item_history SET change_reason = ? WHERE id > ?",
+            (change_reason, since_id),
+        )
+        return
+    ids = list(item_ids)
+    if not ids:
+        return
+    placeholders = ",".join("?" * len(ids))
     conn.execute(
-        "UPDATE item_history SET change_reason = ? WHERE id > ?",
-        (change_reason, since_id),
+        f"UPDATE item_history SET change_reason = ? WHERE id > ? AND item_id IN ({placeholders})",
+        (change_reason, since_id, *ids),
     )
 
 

--- a/packages/lestash/src/lestash/core/database.py
+++ b/packages/lestash/src/lestash/core/database.py
@@ -591,14 +591,15 @@ def upsert_item(conn: sqlite3.Connection, item: ItemCreate) -> int:
             item.parent_id,
         ),
     )
-    mark_recent_history(conn, pre_max, "sync")
-    conn.commit()
 
     row = conn.execute(
         "SELECT id FROM items WHERE source_type = ? AND source_id = ?",
         (item.source_type, item.source_id),
     ).fetchone()
     item_id = row[0]
+
+    mark_recent_history(conn, pre_max, "sync", item_ids=[item_id])
+    conn.commit()
 
     # Insert any media attachments
     if item.media:

--- a/packages/lestash/src/lestash/core/embeddings.py
+++ b/packages/lestash/src/lestash/core/embeddings.py
@@ -110,6 +110,34 @@ def search_similar(
     return [(r[0], r[1]) for r in rows]
 
 
+def re_embed_item(conn: sqlite3.Connection, item_id: int) -> bool:
+    """Re-compute and upsert the embedding for a single item.
+
+    Returns True on success, False if the item has no embeddable text or if
+    the vector backend is unavailable. Errors are logged but never raised so
+    callers (PATCH, restore) can continue without surfacing infra failures.
+    """
+    from lestash.models.item import Item
+
+    row = conn.execute("SELECT * FROM items WHERE id = ?", (item_id,)).fetchone()
+    if not row:
+        return False
+    item = Item.from_row(row)
+    text = make_embed_text(item)
+    if not text:
+        return False
+    try:
+        load_vec_extension(conn)
+        ensure_vec_table(conn)
+        embedding = embed_text(text)
+        upsert_embedding(conn, item_id, embedding)
+        conn.commit()
+        return True
+    except Exception:
+        logger.warning("Re-embed failed for item %d", item_id, exc_info=True)
+        return False
+
+
 def get_embedding_stats(conn: sqlite3.Connection) -> dict:
     """Get embedding coverage statistics."""
     total_parents = conn.execute("SELECT COUNT(*) FROM items WHERE parent_id IS NULL").fetchone()[0]

--- a/packages/lestash/src/lestash/core/pdf_enrich/ocr.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/ocr.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from lestash.core.config import Config
-from lestash.core.database import get_connection
+from lestash.core.database import get_connection, mark_recent_history, max_history_id
 
 OCR_EXTRACTOR_VERSION: int = 1
 OCR_TARGET_KINDS = ("margin_note", "ink_unclassified")
@@ -98,10 +98,12 @@ def ocr_annotation(child_id: int, *, config: Config | None = None) -> OcrResult:
 
         meta["ocr_text"] = text
         meta["ocr_version"] = OCR_EXTRACTOR_VERSION
+        pre_max = max_history_id(conn)
         conn.execute(
             "UPDATE items SET content = ?, metadata = ? WHERE id = ?",
             (text or row["metadata"], json.dumps(meta), child_id),
         )
+        mark_recent_history(conn, pre_max, "enricher")
         conn.commit()
         return OcrResult(child_id=child_id, status="transcribed", text=text)
 

--- a/packages/lestash/src/lestash/core/pdf_enrich/ocr.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/ocr.py
@@ -103,7 +103,7 @@ def ocr_annotation(child_id: int, *, config: Config | None = None) -> OcrResult:
             "UPDATE items SET content = ?, metadata = ? WHERE id = ?",
             (text or row["metadata"], json.dumps(meta), child_id),
         )
-        mark_recent_history(conn, pre_max, "enricher")
+        mark_recent_history(conn, pre_max, "enricher", item_ids=[child_id])
         conn.commit()
         return OcrResult(child_id=child_id, status="transcribed", text=text)
 

--- a/packages/lestash/src/lestash/core/pdf_enrich/persistence.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/persistence.py
@@ -92,7 +92,7 @@ def mark_source_unavailable(conn: sqlite3.Connection, item_id: int) -> None:
     meta["enriched_at"] = _now_iso()
     pre_max = max_history_id(conn)
     conn.execute("UPDATE items SET metadata = ? WHERE id = ?", (json.dumps(meta), item_id))
-    mark_recent_history(conn, pre_max, "enricher")
+    mark_recent_history(conn, pre_max, "enricher", item_ids=[item_id])
     conn.commit()
 
 
@@ -232,7 +232,7 @@ def _update_parent_item(
         "UPDATE items SET content = ?, metadata = ? WHERE id = ?",
         (content, json.dumps(meta), item_id),
     )
-    mark_recent_history(conn, pre_max, "enricher")
+    mark_recent_history(conn, pre_max, "enricher", item_ids=[item_id])
 
 
 def _annotation_title(ann: ExtractedAnnotation) -> str:

--- a/packages/lestash/src/lestash/core/pdf_enrich/persistence.py
+++ b/packages/lestash/src/lestash/core/pdf_enrich/persistence.py
@@ -25,6 +25,8 @@ from datetime import UTC, datetime
 from lestash.core.config import Config
 from lestash.core.database import (
     add_item_media,
+    mark_recent_history,
+    max_history_id,
     save_media_file,
 )
 
@@ -88,7 +90,9 @@ def mark_source_unavailable(conn: sqlite3.Connection, item_id: int) -> None:
             meta = {}
     meta["enrichment_status"] = "source_unavailable"
     meta["enriched_at"] = _now_iso()
+    pre_max = max_history_id(conn)
     conn.execute("UPDATE items SET metadata = ? WHERE id = ?", (json.dumps(meta), item_id))
+    mark_recent_history(conn, pre_max, "enricher")
     conn.commit()
 
 
@@ -223,10 +227,12 @@ def _update_parent_item(
     meta["extractor_version"] = enriched.extractor_version
     meta["enrichment_status"] = status
     meta["enriched_at"] = _now_iso()
+    pre_max = max_history_id(conn)
     conn.execute(
         "UPDATE items SET content = ?, metadata = ? WHERE id = ?",
         (content, json.dumps(meta), item_id),
     )
+    mark_recent_history(conn, pre_max, "enricher")
 
 
 def _annotation_title(ann: ExtractedAnnotation) -> str:

--- a/packages/lestash/tests/test_history.py
+++ b/packages/lestash/tests/test_history.py
@@ -8,7 +8,11 @@ from lestash.core.database import (
     get_connection,
     get_db_path,
     get_schema_version,
+    mark_recent_history,
+    max_history_id,
+    upsert_item,
 )
+from lestash.models.item import ItemCreate
 
 
 class TestSchemaMigrations:
@@ -281,6 +285,78 @@ class TestHistoryWithUpsert:
 
             cursor = conn.execute("SELECT COUNT(*) FROM item_history")
             assert cursor.fetchone()[0] == 0
+
+
+class TestChangeReason:
+    """Test that the change_reason taxonomy is wired through the right callers."""
+
+    def test_helper_marks_only_rows_after_snapshot(self, test_db):
+        with get_connection(test_db) as conn:
+            conn.execute(
+                "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+                ("test", "id1", "v1"),
+            )
+            conn.commit()
+
+            conn.execute("UPDATE items SET content = 'v2' WHERE source_id = 'id1'")
+            conn.commit()
+            pre_max = max_history_id(conn)
+
+            conn.execute("UPDATE items SET content = 'v3' WHERE source_id = 'id1'")
+            conn.commit()
+
+            mark_recent_history(conn, pre_max, "custom-reason")
+            conn.commit()
+
+            rows = conn.execute(
+                "SELECT content_old, change_reason FROM item_history ORDER BY id"
+            ).fetchall()
+            assert rows[0]["content_old"] == "v1"
+            assert rows[0]["change_reason"] == "api-update"
+            assert rows[1]["content_old"] == "v2"
+            assert rows[1]["change_reason"] == "custom-reason"
+
+    def test_upsert_item_marks_history_as_sync(self, test_db):
+        with get_connection(test_db) as conn:
+            upsert_item(
+                conn,
+                ItemCreate(
+                    source_type="linkedin",
+                    source_id="post-1",
+                    content="original",
+                ),
+            )
+            upsert_item(
+                conn,
+                ItemCreate(
+                    source_type="linkedin",
+                    source_id="post-1",
+                    content="updated",
+                ),
+            )
+
+            rows = conn.execute("SELECT change_reason, content_old FROM item_history").fetchall()
+            assert len(rows) == 1
+            assert rows[0]["change_reason"] == "sync"
+            assert rows[0]["content_old"] == "original"
+
+    def test_pdf_enricher_marks_history_as_enricher(self, test_db):
+        from lestash.core.pdf_enrich.persistence import mark_source_unavailable
+
+        with get_connection(test_db) as conn:
+            conn.execute(
+                "INSERT INTO items (source_type, source_id, content, metadata) VALUES (?, ?, ?, ?)",
+                ("arxiv", "2401.0001", "abstract", '{"existing": "meta"}'),
+            )
+            conn.commit()
+
+            mark_source_unavailable(conn, 1)
+
+            rows = conn.execute(
+                "SELECT change_reason FROM item_history WHERE item_id = 1"
+            ).fetchall()
+            assert len(rows) == 1
+            assert rows[0]["change_reason"] == "enricher"
 
 
 class TestHistoryDuplicateCleanup:

--- a/packages/lestash/tests/test_history.py
+++ b/packages/lestash/tests/test_history.py
@@ -199,29 +199,32 @@ class TestHistoryTrigger:
     def test_trigger_captures_parent_id_change(self, test_db):
         """Updating parent_id should create history record with parent_id_old."""
         with get_connection(test_db) as conn:
-            conn.execute(
+            parent_a_id = conn.execute(
                 "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
                 ("test", "parent-a", "parent A"),
-            )
-            conn.execute(
+            ).lastrowid
+            parent_b_id = conn.execute(
                 "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
                 ("test", "parent-b", "parent B"),
-            )
-            conn.execute(
+            ).lastrowid
+            child_id = conn.execute(
                 "INSERT INTO items (source_type, source_id, content, parent_id) "
                 "VALUES (?, ?, ?, ?)",
-                ("test", "child", "child", 1),
-            )
+                ("test", "child", "child", parent_a_id),
+            ).lastrowid
             conn.commit()
 
             conn.execute(
                 "UPDATE items SET parent_id = ? WHERE source_id = ?",
-                (2, "child"),
+                (parent_b_id, "child"),
             )
             conn.commit()
 
-            cursor = conn.execute("SELECT parent_id_old FROM item_history WHERE item_id = 3")
-            assert cursor.fetchone()[0] == 1
+            cursor = conn.execute(
+                "SELECT parent_id_old FROM item_history WHERE item_id = ?",
+                (child_id,),
+            )
+            assert cursor.fetchone()[0] == parent_a_id
 
     def test_trigger_captures_changed_at_timestamp(self, test_db):
         """History record should have timestamp."""
@@ -316,6 +319,55 @@ class TestChangeReason:
             assert rows[1]["content_old"] == "v2"
             assert rows[1]["change_reason"] == "custom-reason"
 
+    def test_helper_with_item_ids_scopes_update(self, test_db):
+        """mark_recent_history(..., item_ids=[X]) must not touch other items' rows."""
+        with get_connection(test_db) as conn:
+            a_id = conn.execute(
+                "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+                ("test", "a", "a-v1"),
+            ).lastrowid
+            b_id = conn.execute(
+                "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+                ("test", "b", "b-v1"),
+            ).lastrowid
+            conn.commit()
+
+            pre_max = max_history_id(conn)
+            conn.execute("UPDATE items SET content = ? WHERE id = ?", ("a-v2", a_id))
+            conn.execute("UPDATE items SET content = ? WHERE id = ?", ("b-v2", b_id))
+            conn.commit()
+
+            mark_recent_history(conn, pre_max, "scoped", item_ids=[a_id])
+            conn.commit()
+
+            a_reason = conn.execute(
+                "SELECT change_reason FROM item_history WHERE item_id = ?", (a_id,)
+            ).fetchone()[0]
+            b_reason = conn.execute(
+                "SELECT change_reason FROM item_history WHERE item_id = ?", (b_id,)
+            ).fetchone()[0]
+            assert a_reason == "scoped"
+            assert b_reason == "api-update"
+
+    def test_helper_with_empty_item_ids_is_noop(self, test_db):
+        with get_connection(test_db) as conn:
+            item_id = conn.execute(
+                "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+                ("test", "a", "v1"),
+            ).lastrowid
+            conn.commit()
+            pre_max = max_history_id(conn)
+            conn.execute("UPDATE items SET content = ? WHERE id = ?", ("v2", item_id))
+            conn.commit()
+
+            mark_recent_history(conn, pre_max, "scoped", item_ids=[])
+            conn.commit()
+
+            reason = conn.execute(
+                "SELECT change_reason FROM item_history WHERE item_id = ?", (item_id,)
+            ).fetchone()[0]
+            assert reason == "api-update"
+
     def test_upsert_item_marks_history_as_sync(self, test_db):
         with get_connection(test_db) as conn:
             upsert_item(
@@ -344,16 +396,17 @@ class TestChangeReason:
         from lestash.core.pdf_enrich.persistence import mark_source_unavailable
 
         with get_connection(test_db) as conn:
-            conn.execute(
+            item_id = conn.execute(
                 "INSERT INTO items (source_type, source_id, content, metadata) VALUES (?, ?, ?, ?)",
                 ("arxiv", "2401.0001", "abstract", '{"existing": "meta"}'),
-            )
+            ).lastrowid
             conn.commit()
 
-            mark_source_unavailable(conn, 1)
+            mark_source_unavailable(conn, item_id)
 
             rows = conn.execute(
-                "SELECT change_reason FROM item_history WHERE item_id = 1"
+                "SELECT change_reason FROM item_history WHERE item_id = ?",
+                (item_id,),
             ).fetchall()
             assert len(rows) == 1
             assert rows[0]["change_reason"] == "enricher"

--- a/packages/lestash/tests/test_history.py
+++ b/packages/lestash/tests/test_history.py
@@ -83,6 +83,7 @@ class TestHistoryTableCreation:
                 "url_old",
                 "metadata_old",
                 "is_own_content_old",
+                "parent_id_old",
                 "changed_at",
                 "change_reason",
                 "change_type",
@@ -173,6 +174,51 @@ class TestHistoryTrigger:
             cursor = conn.execute("SELECT COUNT(*) FROM item_history")
             assert cursor.fetchone()[0] == 0
 
+    def test_trigger_captures_title_change(self, test_db):
+        """Updating title should create history record with title_old."""
+        with get_connection(test_db) as conn:
+            conn.execute(
+                "INSERT INTO items (source_type, source_id, content, title) VALUES (?, ?, ?, ?)",
+                ("test", "id1", "content", "old title"),
+            )
+            conn.commit()
+
+            conn.execute(
+                "UPDATE items SET title = ? WHERE source_id = ?",
+                ("new title", "id1"),
+            )
+            conn.commit()
+
+            cursor = conn.execute("SELECT title_old FROM item_history WHERE item_id = 1")
+            assert cursor.fetchone()[0] == "old title"
+
+    def test_trigger_captures_parent_id_change(self, test_db):
+        """Updating parent_id should create history record with parent_id_old."""
+        with get_connection(test_db) as conn:
+            conn.execute(
+                "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+                ("test", "parent-a", "parent A"),
+            )
+            conn.execute(
+                "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+                ("test", "parent-b", "parent B"),
+            )
+            conn.execute(
+                "INSERT INTO items (source_type, source_id, content, parent_id) "
+                "VALUES (?, ?, ?, ?)",
+                ("test", "child", "child", 1),
+            )
+            conn.commit()
+
+            conn.execute(
+                "UPDATE items SET parent_id = ? WHERE source_id = ?",
+                (2, "child"),
+            )
+            conn.commit()
+
+            cursor = conn.execute("SELECT parent_id_old FROM item_history WHERE item_id = 3")
+            assert cursor.fetchone()[0] == 1
+
     def test_trigger_captures_changed_at_timestamp(self, test_db):
         """History record should have timestamp."""
         with get_connection(test_db) as conn:
@@ -235,6 +281,118 @@ class TestHistoryWithUpsert:
 
             cursor = conn.execute("SELECT COUNT(*) FROM item_history")
             assert cursor.fetchone()[0] == 0
+
+
+class TestHistoryDuplicateCleanup:
+    """Test the migration 9 cleanup query that removes duplicate sync history rows."""
+
+    CLEANUP_SQL = """
+        DELETE FROM item_history
+        WHERE id NOT IN (
+            SELECT MIN(ih.id) FROM item_history ih
+            JOIN items i ON i.id = ih.item_id
+            WHERE i.source_type IN ('linkedin', 'youtube', 'audible', 'bluesky')
+            GROUP BY ih.item_id,
+                     COALESCE(ih.content_old, ''),
+                     COALESCE(ih.title_old, ''),
+                     COALESCE(ih.metadata_old, '')
+        )
+        AND item_id IN (
+            SELECT id FROM items
+            WHERE source_type IN ('linkedin', 'youtube', 'audible', 'bluesky')
+        );
+    """
+
+    def test_cleanup_removes_duplicate_sync_rows_keeping_earliest(self, test_db):
+        with get_connection(test_db) as conn:
+            conn.execute(
+                "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+                ("linkedin", "post-1", "current"),
+            )
+            conn.commit()
+            for _ in range(3):
+                conn.execute(
+                    """INSERT INTO item_history
+                       (item_id, content_old, title_old, metadata_old, change_reason)
+                       VALUES (1, 'same', 'same', '{}', 'api-update')""",
+                )
+            conn.commit()
+
+            conn.execute(self.CLEANUP_SQL)
+            conn.commit()
+
+            cursor = conn.execute("SELECT COUNT(*) FROM item_history WHERE item_id = 1")
+            assert cursor.fetchone()[0] == 1
+
+    def test_cleanup_preserves_distinct_versions(self, test_db):
+        with get_connection(test_db) as conn:
+            conn.execute(
+                "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+                ("linkedin", "post-1", "current"),
+            )
+            conn.commit()
+            for content in ("v1", "v2", "v3"):
+                conn.execute(
+                    """INSERT INTO item_history
+                       (item_id, content_old, change_reason)
+                       VALUES (1, ?, 'api-update')""",
+                    (content,),
+                )
+            conn.commit()
+
+            conn.execute(self.CLEANUP_SQL)
+            conn.commit()
+
+            cursor = conn.execute("SELECT COUNT(*) FROM item_history WHERE item_id = 1")
+            assert cursor.fetchone()[0] == 3
+
+    def test_cleanup_does_not_touch_non_sync_sources(self, test_db):
+        with get_connection(test_db) as conn:
+            conn.execute(
+                "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+                ("note", "n1", "current"),
+            )
+            conn.commit()
+            for _ in range(3):
+                conn.execute(
+                    """INSERT INTO item_history
+                       (item_id, content_old, change_reason)
+                       VALUES (1, 'same', 'api-update')""",
+                )
+            conn.commit()
+
+            conn.execute(self.CLEANUP_SQL)
+            conn.commit()
+
+            cursor = conn.execute("SELECT COUNT(*) FROM item_history WHERE item_id = 1")
+            assert cursor.fetchone()[0] == 3
+
+    def test_cleanup_is_idempotent(self, test_db):
+        with get_connection(test_db) as conn:
+            conn.execute(
+                "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+                ("linkedin", "post-1", "current"),
+            )
+            conn.commit()
+            for _ in range(3):
+                conn.execute(
+                    """INSERT INTO item_history
+                       (item_id, content_old, change_reason)
+                       VALUES (1, 'same', 'api-update')""",
+                )
+            conn.commit()
+
+            conn.execute(self.CLEANUP_SQL)
+            conn.commit()
+            cursor = conn.execute("SELECT COUNT(*) FROM item_history WHERE item_id = 1")
+            first = cursor.fetchone()[0]
+
+            conn.execute(self.CLEANUP_SQL)
+            conn.commit()
+            cursor = conn.execute("SELECT COUNT(*) FROM item_history WHERE item_id = 1")
+            second = cursor.fetchone()[0]
+
+            assert first == second == 1
 
 
 class TestHistoryCascadeDelete:

--- a/uv.lock
+++ b/uv.lock
@@ -1206,7 +1206,7 @@ wheels = [
 
 [[package]]
 name = "le-stash-workspace"
-version = "1.54.0"
+version = "1.56.3"
 source = { virtual = "." }
 dependencies = [
     { name = "lestash" },
@@ -1259,7 +1259,7 @@ dev = [
 
 [[package]]
 name = "lestash"
-version = "1.54.0"
+version = "1.56.3"
 source = { editable = "packages/lestash" }
 dependencies = [
     { name = "anthropic" },
@@ -1296,7 +1296,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-arxiv"
-version = "1.54.0"
+version = "1.56.3"
 source = { editable = "packages/lestash-arxiv" }
 dependencies = [
     { name = "arxiv" },
@@ -1311,7 +1311,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-audible"
-version = "1.54.0"
+version = "1.56.3"
 source = { editable = "packages/lestash-audible" }
 dependencies = [
     { name = "audible" },
@@ -1326,7 +1326,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-bluesky"
-version = "1.54.0"
+version = "1.56.3"
 source = { editable = "packages/lestash-bluesky" }
 dependencies = [
     { name = "atproto" },
@@ -1341,7 +1341,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-claude-code"
-version = "1.54.0"
+version = "1.56.3"
 source = { editable = "packages/lestash-claude-code" }
 dependencies = [
     { name = "lestash" },
@@ -1352,7 +1352,7 @@ requires-dist = [{ name = "lestash", editable = "packages/lestash" }]
 
 [[package]]
 name = "lestash-linkedin"
-version = "1.54.0"
+version = "1.56.3"
 source = { editable = "packages/lestash-linkedin" }
 dependencies = [
     { name = "authlib" },
@@ -1369,7 +1369,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-microblog"
-version = "1.54.0"
+version = "1.56.3"
 source = { editable = "packages/lestash-microblog" }
 dependencies = [
     { name = "httpx" },
@@ -1384,7 +1384,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-server"
-version = "1.54.0"
+version = "1.56.3"
 source = { editable = "packages/lestash-server" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1407,7 +1407,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-voice"
-version = "1.54.0"
+version = "1.56.3"
 source = { editable = "packages/lestash-voice" }
 dependencies = [
     { name = "faster-whisper" },
@@ -1422,7 +1422,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-youtube"
-version = "1.54.0"
+version = "1.56.3"
 source = { editable = "packages/lestash-youtube" }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary
This PR adds comprehensive item history tracking and restoration capabilities, allowing users to view and restore previous versions of items. It introduces a new `parent_id_old` column to capture parent relationship changes, implements change reason taxonomy to distinguish between different types of updates (user-edit, sync, enricher, restore), and provides REST API endpoints for history management.

## Key Changes

### Database & History Tracking
- **Migration 9**: Added `parent_id_old` column to `item_history` table to capture parent relationship changes in the trigger
- Updated `capture_item_history` trigger to track `parent_id` changes alongside existing fields
- Implemented `max_history_id()` and `mark_recent_history()` helper functions to enable change reason tagging after writes (since SQLite triggers cannot receive parameters)
- Added cleanup query in migration 9 to remove duplicate sync history rows for LinkedIn, YouTube, Audible, and Bluesky sources, keeping only the earliest version of each unique state

### Change Reason Taxonomy
- Introduced change reason tracking to distinguish update sources:
  - `api-update`: Default trigger-written reason
  - `user-edit`: User edits via PATCH endpoint
  - `sync`: Synced items from external sources
  - `enricher`: Enrichment operations (e.g., PDF unavailability marking)
  - `restore`: Restoring from a previous version
- Updated `upsert_item()` to mark synced changes with `change_reason='sync'`
- Updated PDF enricher to mark changes with `change_reason='enricher'`

### API Endpoints
- **PATCH `/api/items/{id}`**: Enhanced to capture user edits as history with `change_reason='user-edit'`; triggers re-embedding if content/title changed
- **GET `/api/items/{id}/history`**: List all history versions for an item (newest first) with preview data
- **GET `/api/items/{id}/history/{version_id}`**: Retrieve full snapshot of a specific version
- **POST `/api/items/{id}/history/{version_id}/restore`**: Restore item to a previous version; the restoration itself creates a new history row tagged `change_reason='restore'`

### Frontend UI
- Added "Edit" button to toggle inline edit form for title and content
- Added "History" button to toggle version history panel showing all changes with timestamps, change reasons, and previews
- Implemented "View" and "Restore" buttons for each history version
- History list displays color-coded change reasons and content previews
- Version detail view shows full snapshot including metadata and author

### Embedding Updates
- Added `re_embed_item()` function to recompute and upsert embeddings for a single item after edits or restores
- Automatically re-embeds items when content or title changes via PATCH or restore operations

## Notable Implementation Details
- History rows created before Migration 9 will have `parent_id_old=NULL`, so restoring those versions will clear the current parent_id
- The cleanup query in migration 9 uses a GROUP BY on content/title/metadata to identify and remove duplicate rows, preserving only the earliest version of each unique state
- Change reason tagging uses a two-step pattern: capture `max_history_id()` before the write, then call `mark_recent_history()` after to update the trigger-written rows
- Content previews in history list are truncated to 200 characters with ellipsis for readability

https://claude.ai/code/session_01BoUPjEyaHRWn1G4cPcMgj1