### PR TITLE
fix(app): add Send+Sync impls for GoogleAuth desktop stub (Tauri 2.10)

### DIFF
--- a/app/src-tauri/tauri-plugin-google-auth/src/desktop.rs
+++ b/app/src-tauri/tauri-plugin-google-auth/src/desktop.rs
@@ -15,6 +15,12 @@ pub fn init<R: Runtime, C: DeserializeOwned>(
 
 pub struct GoogleAuth<R: Runtime>(PhantomData<R>);
 
+// Safety: GoogleAuth holds only PhantomData<R> and no actual R instance,
+// so it is safe to send/share across threads regardless of R's own bounds.
+// Required by tauri::Manager::state/manage since Tauri 2.10.
+unsafe impl<R: Runtime> Send for GoogleAuth<R> {}
+unsafe impl<R: Runtime> Sync for GoogleAuth<R> {}
+
 impl<R: Runtime> GoogleAuth<R> {
     pub async fn authorize(&self, _req: AuthorizeRequest) -> Result<AuthorizeResponse> {
         Err(Error::UnsupportedPlatform)


### PR DESCRIPTION
## Summary

- `tauri::Manager::state()` and `manage()` require `T: Send + Sync + 'static`, a constraint enforced more strictly since Tauri 2.10.3
- `GoogleAuth<R>` on desktop wraps `PhantomData<R>`, which is only `Send + Sync` if `R` is — but `R: Runtime` doesn't imply that in the trait bound
- This caused three compile errors in the desktop CI build: two `E0277` (`PluginState<R>` not satisfying `Send + Sync`) and one cascade `E0609` (`state.inner` not resolving because `State<T>` deref couldn't type-check)
- Added `unsafe impl<R: Runtime> Send/Sync for GoogleAuth<R>` — sound because the struct holds no actual `R` instance, the same pattern Tauri uses internally for `TrayIcon<R>` and menu types

## Test plan

- [ ] Desktop CI build (Linux + macOS) passes
- [ ] No change to mobile path (`mobile::GoogleAuth` wraps `PluginHandle<R>`, unaffected)
- [ ] No functional change — desktop stub still returns `Err(Error::UnsupportedPlatform)`