### PR TITLE
docs: UX architecture for micro.blog compose, embeds, fast categories

### DIFF
--- a/docs/blog-categories-consolidation.md
+++ b/docs/blog-categories-consolidation.md
@@ -1,0 +1,170 @@
+# Blog categories — consolidation proposal
+
+> Status: proposal · 2026-05-30 · for [`ux-compose-and-categories-design.md`](ux-compose-and-categories-design.md) §3.1 `categories` field
+> Source: scraped `matt.thompson.gr/categories/*` on 2026-05-30
+> Method: enumerated every category listed in the archive nav; pulled post counts and titles from each `/categories/<slug>/` page; spot-checked a handful of post pages for category tags.
+
+The blog has accumulated 18 categories over ~15 years, half of which overlap, two of which are stale, and several of which are sub-series of a larger theme. This file proposes a tighter set the composer can offer as autocomplete candidates.
+
+---
+
+## 1. Current categories (verbatim)
+
+Slug — label — approx. post count (from listing pages; capped where the page stopped scrolling):
+
+- `being-human` — Being Human — ~21
+- `agenticai` — Agentic AI — ~24
+- `intelligent-agents` — Intelligent Agents — ~23
+- `vibe-engineering` — Vibe Engineering — ~10
+- `ia-series` — IA Series — 11
+- `learning` — Learning — 30+
+- `deep-learning` — Deep Learning — 8
+- `research` — Research — 5
+- `agi` — AGI — 10
+- `reinforcement-learning` — Reinforcement Learning — 12
+- `ml` — ML — 3
+- `responsibleai` — Responsible AI — 6
+- `being-human-series` — Being Human Series — 6
+- `python-series` — Python Series — 1
+- `nn-series` — NN Series — 5
+- `rl-series` — RL Series — 2
+- `powershell` — Powershell — 7
+- `projecteuler` — ProjectEuler — 7 (same 7 posts as `powershell`)
+
+---
+
+## 2. Problems with the current set
+
+1. **Slug inconsistency.** `agenticai` and `responsibleai` are squashed; everything else is kebab-case. `projecteuler` is also squashed. Search, autocomplete and URL hygiene all suffer.
+2. **Series-vs-theme duplication.** `being-human` (21) and `being-human-series` (6) are the same topic — the series posts are tagged with both. Same shape for `intelligent-agents` (23) vs `ia-series` (11), and `reinforcement-learning` (12) vs `rl-series` (2). The series acts as a sub-filter, not a separate theme — three categories doing the work of one.
+3. **Total overlap, no successor.** `powershell` and `projecteuler` contain the **same** 7 posts from 2011. A 15-year-old throwaway sub-project gets two categories; neither has had a new post since 2011.
+4. **One-off categories.** `python-series` has 1 post (April 2025). `nn-series` has 5 (Feb-Mar 2025). `rl-series` has 2 (Jan-Feb 2025). These are abandoned mini-courses, not categories — they fit under broader learning/ML buckets.
+5. **`ml` is a stub.** 3 posts, all of which are already in `learning` or `deep-learning`. Adds no signal.
+6. **No category for personal / family content.** "Sophie's work" is the named use case in the design doc; there is currently no public category that fits a child's school work or other family posts. The author would either need to invent one or leave it uncategorised.
+7. **No category for "tools / craft / dev workflow."** Posts like *Building Handy on an Intel Mac*, *Domain Driven Design*, *Modern Python Package Management* sit under `learning` or `vibe-engineering` by default — neither captures "this is a how-to / tool note."
+
+---
+
+## 3. Proposed consolidated set
+
+Target: 11 top-level categories. Every existing category either maps to one of these or retires (§4).
+
+- **`being-human` — Being Human**
+  - Reflective / philosophical posts on agency, learning, parenting, society.
+  - Absorbs: `being-human`, `being-human-series`
+  - Example saved item: a Bluesky thread the author quote-replies with a personal take.
+
+- **`intelligent-agents` — Intelligent Agents**
+  - Long-running theory thread on agents, rationality, PEAS, planning. The "course" the author is working through.
+  - Absorbs: `intelligent-agents`, `ia-series`
+  - Example saved item: arXiv paper on agent design read for the IA series.
+
+- **`agentic-ai` — Agentic AI**
+  - Applied / industry-side of agents: coding agents, tools-use, agent products, MCP, deployments.
+  - Absorbs: `agenticai`
+  - Example saved item: YouTube of a Claude Code demo; LinkedIn post about a new agent framework.
+
+- **`learning` — Learning**
+  - The author's own learning notes (Masters, deep-dives, term sheets). The "study journal" bucket.
+  - Absorbs: `learning`, `nn-series`, `rl-series`, `python-series` (each series becomes a *tag*, not a category — see §6.1)
+  - Example saved item: a textbook chapter summary or a video lecture review.
+
+- **`ml-research` — ML Research**
+  - Paper notes, technique deep-dives, model behaviour analysis. The "I read a paper" bucket.
+  - Absorbs: `research`, `deep-learning`, `reinforcement-learning`, `ml`, `agi`
+  - Example saved item: arXiv paper notes; a Bluesky thread linking to a paper.
+
+- **`responsible-ai` — Responsible AI**
+  - Ethics, regulation, safety, alignment commentary. Mostly opinion / commentary.
+  - Absorbs: `responsibleai`
+  - Example saved item: LinkedIn post about the EU AI Act; news article on AI policy.
+
+- **`vibe-engineering` — Vibe Engineering**
+  - The author's named practice: building with LLM agents in the loop. Distinct from `agentic-ai` because it's first-person craft, not third-person commentary.
+  - Absorbs: `vibe-engineering`
+  - Example saved item: own LeStash PR retrospective; a Cursor / Claude Code workflow note.
+
+- **`software-craft` — Software Craft** *(see §6)*
+  - Tool notes, build guides, design patterns, language ergonomics. Not LLM-flavoured.
+  - Absorbs: parts of `learning` and `vibe-engineering` that are really "this is how I set up X" or "DDD revisited"
+  - Example saved item: a "Building Handy on Intel Mac" how-to; a uv / pipx note.
+
+- **`reading` — Reading** *(see §6)*
+  - Book notes, citations, reading-list updates. Today these scatter across `learning` and `being-human`.
+  - Absorbs: nothing existing (new)
+  - Example saved item: an Audible highlight; a quote from *The Alignment Problem*.
+
+- **`life` — Life** *(see §6)*
+  - Family, kids' work, travel, "la rentrée" posts, year-end reviews. The not-work bucket.
+  - Absorbs: nothing existing (new) — currently lives uneasily inside `being-human`
+  - Example saved item: a photo of Sophie's school project; a Micro.blog post about a trip.
+
+- **`commentary` — Commentary** *(see §6)*
+  - Opinion / hot-take posts on politics, tech industry, society. Currently mixed into `being-human` and `responsible-ai`.
+  - Absorbs: nothing existing (new) — splits commentary out of `being-human`
+  - Example saved item: a quote-share of a political LinkedIn post with the author's framing.
+
+---
+
+## 4. Retire (do not migrate)
+
+- **`powershell`** — last post 2011, sub-project of a sub-project. If the author ever returns to PowerShell, a fresh `software-craft` post with a `#powershell` tag handles it.
+- **`projecteuler`** — same 7 posts as `powershell`, same retirement logic.
+- **`python-series`** — 1 post, series never continued. Move the one post to `learning` with a `#python` tag and drop the category.
+
+Total retired: 3 categories.
+
+The 2011 PowerShell + ProjectEuler posts are not deleted, just uncategorised at the new schema level. They keep existing under their current URLs.
+
+---
+
+## 5. Migration map
+
+| Old category | → | New category |
+| --- | --- | --- |
+| `being-human` | → | `being-human` (split: commentary-ish posts → `commentary`; family posts → `life`; rest stays) |
+| `being-human-series` | → | `being-human` (series becomes `#bh-series` tag) |
+| `agenticai` | → | `agentic-ai` (slug fix) |
+| `intelligent-agents` | → | `intelligent-agents` |
+| `ia-series` | → | `intelligent-agents` (series becomes `#ia-series` tag) |
+| `vibe-engineering` | → | `vibe-engineering` (tool-heavy posts → `software-craft`) |
+| `learning` | → | `learning` (paper-notes posts → `ml-research`; tool posts → `software-craft`) |
+| `deep-learning` | → | `ml-research` |
+| `research` | → | `ml-research` |
+| `agi` | → | `ml-research` |
+| `reinforcement-learning` | → | `ml-research` |
+| `ml` | → | `ml-research` |
+| `responsibleai` | → | `responsible-ai` (slug fix) |
+| `python-series` | → | `learning` (+ `#python` tag) |
+| `nn-series` | → | `learning` (+ `#nn-series` tag) |
+| `rl-series` | → | `learning` (+ `#rl-series` tag) |
+| `powershell` | → | *retire* |
+| `projecteuler` | → | *retire* |
+
+Net: 18 → 11. Series-as-category becomes series-as-tag (4 such moves).
+
+---
+
+## 6. New categories the saved-item patterns suggest
+
+Justified from the LeStash saved-item shapes the design doc mentions and from gaps in the current set:
+
+1. **`life`** — The "Sophie's work" use case explicitly named in the compose design has no current home. Posts like *Summer review, la rentrée est proche* or year-end reflections drift into `being-human` and dilute its philosophical character. A `life` category lets `being-human` stay reflective-philosophical and gives family/travel/personal content a clean place.
+
+2. **`reading`** — The author has an Audible integration design (`docs/audible-integration-design.md`) and routinely cites books. Book-shaped content (highlights, citations, capsule reviews) is its own pattern — a saved highlight from Audible composes very differently from a paper note or a hot take. A dedicated category makes the compose template "book quote + framing" obvious.
+
+3. **`software-craft`** — Posts like *Building Handy on Intel Mac*, *Domain Driven Design*, *Modern Python Package Management* are how-tos / tool-notes / design pattern revisits. They aren't LLM-flavoured so don't fit `vibe-engineering`, and they aren't paper notes so don't fit `ml-research`. Pulling them into one bucket sharpens both neighbours.
+
+4. **`commentary`** — Political/industry hot takes (e.g. *How did America break itself?*, *Meta is now the pervy old man*) are currently in `being-human` or `responsible-ai`. They have a distinct rhythm: short, opinionated, often quoting another post. Worth its own bucket — and worth being explicit because the author can then decide to *not* surface this category in some shared contexts.
+
+---
+
+## 7. Open questions for the author
+
+1. **Personal vs professional split — keep or merge?** This proposal keeps `life` separate from `being-human`. Alternative: one `personal` bucket that absorbs both. Lean on author taste — how openly do you want family content to mix with the AI / agency reflections that built `being-human`'s audience?
+2. **`commentary` — keep or drop?** Cleanly splitting hot takes from `being-human` reads good on paper, but it risks sterilising `being-human` into "philosophy only." Is the bleed actually a feature?
+3. **Granularity on AI sub-topics.** `ml-research` absorbs 5 existing categories (deep-learning, research, agi, RL, ML). Is that too coarse? Alternative: keep `reinforcement-learning` as its own top-level if it stays a recurring thread.
+4. **`agentic-ai` vs `vibe-engineering` boundary.** Proposed split is third-person commentary (agentic-ai) vs first-person craft (vibe-engineering). Author may prefer the inverse framing or a merge.
+5. **Series-as-tag — confirm.** This proposal demotes `*-series` categories to tags (`#bh-series`, `#ia-series`, etc.). That assumes tag autocomplete from the LeStash UX-compose design ships. If tags stay second-class on the blog, keeping series as categories is the lesser evil.
+6. **Slugs — `agentic-ai` or `agentic`?** Two-word kebab is clearer in URLs and matches the human label; one word is shorter to type. Author taste.
+7. **Migration cost.** Recategorising ~150+ posts manually is real work. Alternative: leave existing posts on existing categories, only enforce the new set for *future* posts via the LeStash composer. Old categories silently stop being suggested. The duplication tolerated as historical artefact.

--- a/docs/ux-compose-and-categories-design.md
+++ b/docs/ux-compose-and-categories-design.md
@@ -648,7 +648,7 @@ Each slice is independently mergeable + demo-able. PR titles in the suggested co
 | 2 | `feat(microblog): implement MicropubClient.create_entry()` | Backend can post; tested via CLI | `lestash-microblog` |
 | 3 | `feat(microblog): expose POST /api/microblog/publish` | API-first publish | `lestash-server` |
 | 4 | `feat(app): micro.blog compose modal (YouTube prefill)` | First end-to-end user flow | `app/` |
-| 5 | `feat(lestash): compose.lint with YT_RAW_URL + IMG_NOT_MARKDOWN` | Embed warnings | `packages/lestash` |
+| 5 | `feat(lestash): compose.lint with YT_RAW_URL + IMG_NOT_MARKDOWN` | Embed warnings | `lestash/plugins/lint_rules.py` (shared helpers, next to `publisher.py`) + `lestash-microblog/.../source.py` (`lint()` method). No new submodule — defer a `compose/` namespace until something beyond lint earns it. |
 | 6 | `feat(app): EmbedRenderer (extract + render) + iframe in detail view` | YouTube embeds inline in LeStash | `app/` |
 | 7 | `feat(server): GET /api/items/tags?prefix=` | Autocomplete backend | `lestash-server` |
 | 8 | `feat(app): TagTypeahead + "t" shortcut` | Path B faster tag | `app/` |

--- a/docs/ux-compose-and-categories-design.md
+++ b/docs/ux-compose-and-categories-design.md
@@ -1,0 +1,610 @@
+# UX Architecture — Compose, Embed, Categorize
+
+> Status: design draft · 2026-05-30 · author: Matt + Claude
+> Scope: micro.blog compose flow, YouTube/LinkedIn embed handling, fast category creation
+> Test discipline: Canon TDD — see [§7](#7-interfaces-canon-tdd)
+
+---
+
+## 1. Goals
+
+Three concrete user jobs, each currently friction-heavy or unsupported:
+
+1. **Re-publish a saved item to my micro.blog.** Take a LinkedIn post or YouTube video I've already liked + saved into LeStash, add my own framing, publish it. Today: no publish path exists — micro.blog plugin is read-only.
+2. **Render the YouTube link the way micro.blog wants it.** The `spacex-ipo-imminent` post shows a `[youtu.be/-X6YzlY…](…)` markdown link. micro.blog will auto-embed a bare YouTube URL on its own line, but won't embed a wrapped markdown link. The compose flow should produce the embed-friendly form.
+3. **Create a category fast and put items in it.** "Sophie's work" should take seconds, not a tag-input-per-item ritual. Today: no autocomplete, no bulk-tag, no save-this-filter-as-category.
+
+A non-goal here: replacing collections with tags or vice versa. They earn their separate keep (see [§5.2](#52-tags-vs-collections)).
+
+---
+
+## 2. Today — what we have
+
+### 2.1 Surface map (verified by reading)
+
+| Concern | Where | State |
+| --- | --- | --- |
+| Item list | `app/src/index.html:2207-2248` · `/api/items` | Paginated 20, "Load more" |
+| Item detail | `app/src/index.html:1563-2176` | Markdown + media gallery + tags |
+| Tags on item | `app/src/index.html:1655-1666` · `POST /api/items/{id}/tags` | Add by typing; remove `×`; **no autocomplete** |
+| Tags global | `routes/items.py:375` `GET /api/items/tags` | Lists tags w/ counts (used in filter dropdown) |
+| Collections | `app/src/index.html:3852-3939` · `/api/collections` | Modal create, manual add |
+| LinkedIn publish | `app/src/index.html:3943-4063` · `/api/linkedin/post` | Works — proves the publish pattern |
+| micro.blog publish | — | **Missing** |
+| Share/capture | `app/src/index.html:3070-3168` | URL ingest + YouTube transcript fetch |
+| Bear-style notes | `Notes` tab | Voice + text |
+
+### 2.2 The example, decoded
+
+`https://matt.thompson.gr/2026/05/30/spacex-ipo-imminent.html` rendered as:
+
+```markdown
+![](https://matt.thompson.gr/uploads/2026/screenshot-20260530-090356.png)
+
+…body prose…
+
+[youtu.be/-X6YzlY…](https://youtu.be/-X6YzlY_8tM?is=…)
+```
+
+What micro.blog *would* have embedded: a bare URL on its own line:
+
+```markdown
+https://youtu.be/-X6YzlY_8tM
+```
+
+micro.blog's posting endpoint runs the body through its own auto-embed logic that recognises YouTube / Vimeo URLs **only when they stand alone on a line** — wrapped in `[]()` they stay as anchor text. So the bug is in the compose path: whatever generated that post wrapped the URL in a markdown link instead of emitting a bare line. We need a compose pipeline that knows the embed rules.
+
+### 2.3 Capability gaps (the short list)
+
+- `MicropubClient` has no `create_entry()` — read-only.
+- `SourcePlugin` base class has no `publish()` contract — every publisher (LinkedIn, future micro.blog) reinvents it.
+- No "compose from existing item" flow. The share modal goes inbound only.
+- No tag autocomplete; no bulk-tag selection.
+- No "save current filter as a category."
+- No CLI tag commands (precludes batch grooming).
+
+---
+
+## 3. Proposed UX
+
+Three flows, each kept narrow on purpose.
+
+### 3.1 Compose-from-item
+
+**Entry points (all open the same composer with the item pre-loaded):**
+
+- Item detail → `Share to micro.blog` button next to existing `Share to LinkedIn`.
+- Keyboard: `m` on a focused item card or in detail view.
+- Right-click / long-press on an item card → `Publish… → micro.blog`.
+
+**Composer modal** (mirrors LinkedIn composer for muscle memory):
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Publish to micro.blog                              [✕]  │
+├──────────────────────────────────────────────────────────┤
+│  Title  ┌─────────────────────────────────────────────┐  │
+│         │ SpaceX IPO imminent                         │  │
+│         └─────────────────────────────────────────────┘  │
+│  Body   ┌─────────────────────────────────────────────┐  │
+│         │ Reusable rockets, satellite comms, and the  │  │
+│         │ AI-hype refrain.                            │  │
+│         │                                             │  │
+│         │ https://youtu.be/-X6YzlY_8tM    ⟵ bare URL  │  │
+│         │                                  auto-embeds│  │
+│         └─────────────────────────────────────────────┘  │
+│  Image  [thumb] screenshot-20260530.png   [Remove]       │
+│  Tags   ⊞ spacex   ⊞ ipo                                 │
+│  Cats   ⊞ tech-watch   [+ add]                           │
+│  Visibility: ● Public  ○ Draft                           │
+│                                                          │
+│  ☑ Save syndication link back to source item             │
+│  ☑ Tag source item as "published-to-microblog"           │
+│                                                          │
+│  Preview ─────────────────────────────────────  [Open ⤴] │
+│                                                          │
+│             [Cancel]              [Publish to micro.blog]│
+└──────────────────────────────────────────────────────────┘
+```
+
+**Pre-fill rules**, ordered by source kind:
+
+| Source | Title | Body seed | Embed | Image |
+| --- | --- | --- | --- | --- |
+| YouTube | video title | empty (cursor here) + blank line + bare URL | bare URL | thumbnail (optional) |
+| LinkedIn | first 80 chars of post or empty | `> …quote…` blockquote + blank line + source link | source URL on own line | first attached image |
+| Bluesky | empty | `> …quote…` + source link | bare URL | attached image |
+| arXiv | paper title | `> abstract…` + bare URL | bare URL | (none) |
+| micro.blog (reshare) | original title | `> …quote…` + bare URL | bare URL | first photo |
+| Note (own) | first line | rest of body | (none) | (none) |
+
+The composer never silently strips formatting — what you see is what gets POSTed.
+
+**Embed-rule guard.** A lint pass on the body, surfaced inline:
+
+- `⚠ Line 4: YouTube URL wrapped in [](). Click to convert to bare URL for auto-embed.`
+- `✓ Line 6: bare YouTube URL — will auto-embed.`
+- `⚠ Image referenced as <img>; micro.blog prefers ![]() markdown.`
+
+One-click "fix" for each warning. No silent rewrites.
+
+### 3.2 Quick-category
+
+The "Sophie's work" path should be one of:
+
+**Path A — from filtered list ("save this filter"):**
+
+1. Apply `source = note` + `tag = sophie` filter on Recent.
+2. Click `★ Save as collection` (new button next to Load more).
+3. Name it "Sophie's work" → all matching items auto-added; future items matching saved filter auto-added too (smart collection).
+
+**Path B — from item detail:**
+
+1. On any item, press `t` → tag input with **typeahead** opens (existing tags first, "Create new tag '…'" at bottom).
+2. Type "sop" → see `sophie`, `sophies-work`, or "Create new tag 'sophies-work'" — picking creates and assigns in one action.
+
+**Path C — bulk-tag from list:**
+
+1. Hold `Shift` and click items to multi-select (selection chip count appears at bottom).
+2. Press `t` → tag input with typeahead applies to all selected.
+
+**Why three:** A is for "this filter is meaningful, persist it"; B is for "this one item belongs here"; C is for "I just realised five items belong here." Each is one of the three real moves.
+
+### 3.3 Embed-aware rendering everywhere
+
+Wherever LeStash currently shows a YouTube link as plain text, render the actual embed:
+
+- Item detail body: detect bare YouTube URLs → render iframe (lazy-loaded, no-cookie domain).
+- Compose preview: same renderer, so WYSIWYG matches what micro.blog will produce.
+- One renderer module shared between detail view, compose preview, and (future) feed cards. See [§7.4](#74-embedrenderer).
+
+---
+
+## 4. Architecture
+
+### 4.1 Component diagram
+
+```mermaid
+graph TB
+  subgraph UI["app/src/index.html (single-file frontend)"]
+    Compose["ComposeModal\n(micro.blog & LinkedIn)"]
+    TagInput["TagTypeahead"]
+    EmbedR["EmbedRenderer"]
+    BulkSel["BulkSelectionBar"]
+  end
+
+  subgraph Server["packages/lestash-server"]
+    Pub["POST /api/microblog/publish"]
+    Lint["POST /api/compose/lint"]
+    TagsAPI["GET /api/items/tags?prefix="]
+    SmartC["POST /api/collections/smart"]
+    BulkTag["POST /api/items/tags/bulk"]
+  end
+
+  subgraph Core["packages/lestash"]
+    PublishHook["Publisher ABC\nplugins/base.py"]
+    LintSvc["compose.lint\nembed rules"]
+  end
+
+  subgraph MB["packages/lestash-microblog"]
+    MBPub["MicropubClient.create_entry()"]
+    MBSrc["MicroblogSource\n(implements Publisher)"]
+  end
+
+  Compose --> Pub
+  Compose --> Lint
+  Compose --> EmbedR
+  TagInput --> TagsAPI
+  BulkSel --> BulkTag
+  Pub --> MBSrc
+  MBSrc --> PublishHook
+  MBSrc --> MBPub
+  Lint --> LintSvc
+  MBPub -->|HTTPS Micropub| MicroBlog[(micro.blog\nMicropub endpoint)]
+```
+
+### 4.2 Plugin contract — Publisher
+
+New abstract base, opt-in per plugin. LinkedIn migrates to it; micro.blog implements it from day one.
+
+```python
+class Publisher(Protocol):
+    """Optional companion to SourcePlugin — plugin can post outbound."""
+
+    async def publish(
+        self,
+        item: Item,                       # the source item
+        compose: ComposeRequest,          # user-edited title/body/etc.
+    ) -> PublishResult: ...
+
+    def lint(
+        self,
+        compose: ComposeRequest,
+    ) -> list[LintFinding]: ...           # called pre-publish + for live preview
+```
+
+A plugin can be `SourcePlugin & Publisher`, `SourcePlugin` only, or `Publisher` only.
+
+### 4.3 What sits in core vs. plugin
+
+- **Core**: `Publisher` Protocol, `ComposeRequest` / `PublishResult` / `LintFinding` schemas, the dispatcher that maps `target=microblog|linkedin` to a registered Publisher, server routes.
+- **Plugin (microblog)**: Micropub call, h-entry property mapping, micro.blog-specific lint rules (bare-URL embed rule, image preference rule, character soft-limit).
+- **Plugin (linkedin)**: stays where it is, gains `Publisher` conformance.
+
+---
+
+## 5. Data schema
+
+### 5.1 Existing (verified)
+
+```mermaid
+erDiagram
+  items ||--o{ item_tags : has
+  tags  ||--o{ item_tags : applies-to
+  items ||--o{ media : has
+  collections ||--o{ collection_items : contains
+  items ||--o{ collection_items : in
+
+  items {
+    INTEGER id PK
+    TEXT source
+    TEXT source_id
+    TEXT title
+    TEXT content
+    TEXT url
+    INTEGER parent_id FK
+    TEXT metadata "JSON"
+    TIMESTAMP created_at
+  }
+  tags { INTEGER id PK; TEXT name UK }
+  item_tags { INTEGER item_id FK; INTEGER tag_id FK }
+  collections { INTEGER id PK; TEXT name; TEXT description }
+  collection_items { INTEGER collection_id FK; INTEGER item_id FK }
+```
+
+### 5.2 Tags vs. collections — keep both
+
+- **Tags**: lightweight, many-per-item, faceted filter. "spacex", "ipo", "watched".
+- **Collections**: named, curated, ordered set. "Sophie's work", "Q2-review reading list". Can be public-named, exported, shared.
+- A **smart collection** (new) is a collection whose membership is computed from a filter spec, and recomputed on item insert.
+
+### 5.3 New tables
+
+```sql
+-- §3.1 round-trip: where did this item get republished to?
+CREATE TABLE syndications (
+  id              INTEGER PRIMARY KEY,
+  item_id         INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  target          TEXT    NOT NULL,        -- 'microblog' | 'linkedin' | …
+  target_url      TEXT    NOT NULL,        -- the published URL
+  published_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  request_body    TEXT,                    -- JSON ComposeRequest (audit trail)
+  response_body   TEXT,                    -- raw provider response
+  UNIQUE(item_id, target, target_url)
+);
+CREATE INDEX idx_syndications_item ON syndications(item_id);
+
+-- §3.2 path A: smart collections (filter-driven)
+ALTER TABLE collections ADD COLUMN kind TEXT NOT NULL DEFAULT 'manual';  -- 'manual' | 'smart'
+ALTER TABLE collections ADD COLUMN filter_spec TEXT;                      -- JSON when kind='smart'
+-- filter_spec example: {"source":"note","tag":"sophie","q":null,"own":true}
+```
+
+`syndications` lets the item detail show "Published to micro.blog ⤴" and prevents accidental double-posting. Storing `request_body` makes "re-publish with edits" trivially safe — we have the prior text.
+
+### 5.4 Tag input — no schema change
+
+Tag normalization is already lowercase; autocomplete just needs a `prefix=` query (small server change, see [§7.5](#75-tag-autocomplete-api)).
+
+---
+
+## 6. Sequence flows
+
+### 6.1 Compose & publish a YouTube item to micro.blog
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor U as User
+  participant UI as ComposeModal
+  participant ER as EmbedRenderer
+  participant LI as Lint /api/compose/lint
+  participant API as /api/microblog/publish
+  participant MB as MicropubClient
+  participant MBlog as micro.blog
+  participant DB as SQLite
+
+  U->>UI: Item detail → "Share to micro.blog"
+  UI->>DB: GET /api/items/{id} (already in memory)
+  UI->>UI: prefill(title, body seed, bare URL, image)
+  loop on every body edit (debounced 250ms)
+    UI->>LI: lint(compose)
+    LI-->>UI: [{line:4, code:"YT_NOT_BARE", fix:"unwrap"}]
+    UI->>ER: render preview
+  end
+  U->>UI: click "Publish to micro.blog"
+  UI->>API: POST {item_id, title, body, image_url, categories}
+  API->>LI: lint(compose)  // belt+braces, server-side
+  LI-->>API: [] (clean) or 422 with findings
+  API->>MB: create_entry(h-entry properties)
+  MB->>MBlog: POST Micropub
+  MBlog-->>MB: 201 Created · Location: https://matt.thompson.gr/…
+  MB-->>API: PublishResult(url=…)
+  API->>DB: INSERT syndications(item_id, target='microblog', url, request_body, response_body)
+  API->>DB: add_tag(item_id, 'published-to-microblog')  // if opt-in checked
+  API-->>UI: 200 {url}
+  UI-->>U: toast "Published ⤴ open"; modal closes
+```
+
+Notes on step 4 (lint findings): findings render inline (yellow underline + tooltip) rather than blocking submit. Submit is blocked only on `severity=error` — currently none of the embed rules are errors, all warnings.
+
+### 6.2 Quick-tag with typeahead (Path B)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor U as User
+  participant UI as TagTypeahead
+  participant API as /api/items/tags?prefix=
+  participant DB as SQLite
+
+  U->>UI: press "t" on focused item
+  UI->>API: prefix=""  (initial)
+  API->>DB: SELECT name, COUNT FROM tags … LIMIT 8
+  API-->>UI: [{name:"work", count:14}, …]
+  U->>UI: types "sop"
+  UI->>API: prefix="sop"
+  API->>DB: SELECT … WHERE name LIKE 'sop%' LIMIT 8
+  API-->>UI: [{name:"sophie", count:3}]
+  UI->>UI: render list + bottom row: "Create 'sop'"
+  U->>UI: ↓ to "sophie", Enter
+  UI->>API: POST /api/items/{id}/tags {tag:"sophie"}
+  API->>DB: INSERT OR IGNORE tags; INSERT item_tags
+  API-->>UI: 200
+  UI-->>U: chip appears
+```
+
+### 6.3 Bulk-tag (Path C)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor U as User
+  participant List as ItemList
+  participant Bar as BulkSelectionBar
+  participant API as /api/items/tags/bulk
+  participant DB as SQLite
+
+  U->>List: Shift-click items 3, 7, 12
+  List->>Bar: selection = {3,7,12}
+  Bar-->>U: "3 selected · [t]ag · [c]ollection · [esc] clear"
+  U->>Bar: press "t" → typeahead opens
+  U->>Bar: pick "sophie"
+  Bar->>API: POST {item_ids:[3,7,12], tag:"sophie"}
+  API->>DB: BEGIN; INSERT OR IGNORE tag; bulk INSERT item_tags; COMMIT
+  API-->>Bar: {applied:3, skipped:0}
+  Bar-->>U: toast "Tagged 3 items"; selection cleared
+```
+
+### 6.4 Smart collection (Path A)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor U as User
+  participant List as ItemList
+  participant API as /api/collections/smart
+  participant Hook as item-insert hook
+  participant DB as SQLite
+
+  U->>List: filter = {source:'note', tag:'sophie'}
+  U->>List: click "★ Save as collection"
+  List->>API: POST {name:"Sophie's work", filter_spec:{…}}
+  API->>DB: INSERT collections(name, kind='smart', filter_spec)
+  API->>DB: INSERT collection_items SELECT id FROM items WHERE filter matches
+  API-->>List: {collection_id}
+  Note over Hook: later, on every new item insert
+  Hook->>DB: SELECT smart collections WHERE filter matches new item
+  Hook->>DB: INSERT collection_items
+```
+
+---
+
+## 7. Interfaces (Canon TDD)
+
+> Canon TDD's claim: "It's in the writing of this test that you'll begin making design decisions, but they are primarily interface decisions." Below: the test list first, then the interface that falls out of it.
+
+### 7.1 Test list — `Publisher` Protocol
+
+1. `publish()` on a fresh item returns a `PublishResult` with a non-empty URL.
+2. `publish()` records a `syndications` row keyed by `(item_id, target, target_url)`.
+3. `publish()` twice with same body is **not** automatically idempotent — caller must opt-in via `if_not_already_published=True`; default raises `AlreadyPublished` to surface the choice.
+4. `publish()` failure (5xx from provider) leaves no `syndications` row, raises `PublishFailed` with the provider response attached.
+5. `publish()` failure (4xx with body) raises `PublishRejected` with provider message — caller shows it to user verbatim.
+6. `lint()` on a body with `[text](https://youtu.be/X)` returns one `YT_NOT_BARE` finding pointing at that line.
+7. `lint()` on a body with a bare YouTube URL on its own line returns no findings.
+8. `lint()` on a body with a bare URL followed by trailing punctuation (`https://youtu.be/X.`) returns a `YT_TRAILING_PUNCT` finding.
+9. `lint()` on a body with an `<img src="…">` returns `IMG_NOT_MARKDOWN`.
+10. `lint()` is pure — no IO, no network.
+
+### 7.2 Interface that falls out
+
+```python
+# packages/lestash/src/lestash/plugins/publisher.py
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Protocol, Literal
+
+LintCode = Literal[
+    "YT_NOT_BARE",
+    "YT_TRAILING_PUNCT",
+    "IMG_NOT_MARKDOWN",
+    "SOFT_CHAR_LIMIT",
+]
+Severity = Literal["info", "warn", "error"]
+
+@dataclass(frozen=True)
+class ComposeRequest:
+    item_id: int
+    title: str | None
+    body: str
+    image_url: str | None
+    categories: tuple[str, ...]
+    visibility: Literal["public", "draft"] = "public"
+
+@dataclass(frozen=True)
+class LintFinding:
+    line: int                 # 1-indexed
+    col: int                  # 1-indexed; 0 = whole line
+    code: LintCode
+    severity: Severity
+    message: str
+    fix_hint: str | None      # e.g. "unwrap markdown link to bare URL"
+
+@dataclass(frozen=True)
+class PublishResult:
+    url: str
+    target: str               # 'microblog' | 'linkedin' | …
+    raw_response: dict
+
+class AlreadyPublished(Exception): ...
+class PublishRejected(Exception):  # 4xx
+    def __init__(self, message: str, raw: dict) -> None: ...
+class PublishFailed(Exception):    # 5xx / network
+    def __init__(self, message: str, raw: dict | None) -> None: ...
+
+class Publisher(Protocol):
+    target: str
+
+    def lint(self, compose: ComposeRequest) -> list[LintFinding]: ...
+
+    async def publish(
+        self,
+        compose: ComposeRequest,
+        *,
+        if_not_already_published: bool = False,
+    ) -> PublishResult: ...
+```
+
+Notice what the test list forced into the interface:
+
+- **`lint` is sync + pure** (tests 6–10) — no `async`, no IO. Pure function, trivial to unit-test, can run on every keystroke.
+- **Three distinct exception classes** (tests 3–5) — collapsing them to one `PublishError` would lose the calling-code distinctions the tests already require (re-publish flag, show-to-user, retry).
+- **`if_not_already_published` is an explicit boolean** (test 3) — not a global config, not implicit-by-default. The default surfaces the decision.
+- **`raw_response` returned** (test 1+2) — so the route can store it in `syndications.response_body` without the Publisher having to know about the DB.
+
+### 7.3 Test list — `TagTypeahead` (server side)
+
+1. `GET /api/items/tags?prefix=` (empty) returns top 8 tags by count, descending.
+2. `GET /api/items/tags?prefix=sop` returns tags starting with `sop`, case-insensitive, by count desc.
+3. Tag names are normalized to lowercase before comparison — `prefix=SOP` matches `sophie`.
+4. `prefix` with SQL wildcards (`%`, `_`) is treated as literal — no injection.
+5. Response includes a `total` field so the UI can show "+12 more".
+6. Empty result returns `[]` with HTTP 200, not 404.
+7. `limit` query param caps results, max 50, default 8.
+
+### 7.4 `EmbedRenderer`
+
+Test list:
+
+1. `render("https://youtu.be/X\n")` returns an `<iframe>` with `youtube-nocookie.com` host.
+2. `render("[label](https://youtu.be/X)")` returns an `<a>` — does **not** embed (matches micro.blog behaviour).
+3. `render("https://www.youtube.com/watch?v=X\n")` and `render("https://youtu.be/X\n")` produce the same embed.
+4. `render` is sync, pure, no fetch.
+5. `render` escapes user content in surrounding text — no XSS.
+6. Unknown video host falls back to plain `<a>`.
+
+Interface:
+
+```ts
+// app/src/embed.ts (extracted from index.html)
+export type EmbedRenderResult = { html: string; embedsUsed: string[] };
+export function renderBodyToHtml(body: string): EmbedRenderResult;
+export function detectEmbeds(body: string): Array<{ line: number; url: string; provider: 'youtube' | 'vimeo' | null }>;
+```
+
+`embedsUsed` lets the composer preview show "1 YouTube embed" and the lint pass cross-check intent vs reality.
+
+### 7.5 Tag autocomplete API
+
+```
+GET /api/items/tags?prefix=<str>&limit=<int>
+→ 200 { results: [{name, count}], total: int }
+```
+
+### 7.6 Bulk-tag API
+
+Test list:
+
+1. POST with `item_ids=[]` returns 400.
+2. POST with valid ids creates one tag row (if new), and N `item_tags` rows.
+3. Items already tagged are counted in `skipped`, not `applied`.
+4. Non-existent item ids are reported in `not_found`, transaction still commits for the rest.
+5. Operation is atomic per request — partial DB writes never persist on exception.
+
+Interface:
+
+```
+POST /api/items/tags/bulk
+  body: { item_ids: int[], tag: string }
+  → 200 { applied: int, skipped: int, not_found: int[] }
+```
+
+### 7.7 Smart collection — minimal first pass
+
+Test list:
+
+1. Creating a smart collection with `filter_spec={source:'note', tag:'sophie'}` snapshots matching items into `collection_items`.
+2. Inserting a new item that matches the filter appends it to the smart collection (via hook).
+3. Inserting a new item that does not match is ignored.
+4. Editing a tag off an item does **not** remove it from a smart collection (snapshot semantics — explicit). Document this clearly; revisit if it bites.
+5. Deleting a smart collection drops its rows but does not delete items.
+
+Why snapshot semantics in test 4: live "view" semantics would require running the filter on every read and would couple smart collections to filter-spec versioning. Snapshot keeps the schema flat and the behaviour predictable; the user can always re-save the filter.
+
+---
+
+## 8. Open questions / decisions to make
+
+1. **Where do credentials for "post to *which* micro.blog blog" live?** Today `mp-destination` is settable in sync (multi-blog). Composer should expose a destination picker if >1 blog detected at auth time. → Default: detect; show picker only when ambiguous.
+2. **Draft vs publish.** Micropub supports `post-status=draft`. UI exposes this as visibility radio. → Yes, ship from day one (low cost, lets user proof).
+3. **Image upload path.** micro.blog config advertises a `media-endpoint`. For initial slice: only support items whose `media[0]` is already a URL we can pass through; defer multipart upload to v2. → Documented limit in composer ("Local images coming soon").
+4. **Tag normalization on autocomplete.** Show `sophies-work` and `sophie work` as separate? They *are* separate today. → Add a "suggest merge?" hint when prefix matches multiple near-duplicates (`Levenshtein ≤ 2`). Defer the actual merge UI; surface the smell.
+5. **`lint` rule extensibility.** Per-target rule sets or one shared set? → One shared set lives in core; targets opt in by listing codes. micro.blog opts into `YT_*`, `IMG_NOT_MARKDOWN`, `SOFT_CHAR_LIMIT(300)`. LinkedIn opts into `SOFT_CHAR_LIMIT(3000)` only.
+6. **Two-app pattern (project memory: LinkedIn dual-app, see [[project_linkedin_posting]]):** does micro.blog need anything similar? → No. Single app token, single endpoint. Simpler.
+
+---
+
+## 9. Roadmap — small, shippable slices
+
+Each slice is independently mergeable + demo-able. PR titles in the suggested commit style.
+
+| # | Slice | Slice value | Touches |
+| - | --- | --- | --- |
+| 1 | `feat(lestash): add Publisher protocol + ComposeRequest/PublishResult/LintFinding schemas` | Foundation; no user-visible change | `packages/lestash` |
+| 2 | `feat(microblog): implement MicropubClient.create_entry()` | Backend can post; tested via CLI | `lestash-microblog` |
+| 3 | `feat(microblog): expose POST /api/microblog/publish` | API-first publish | `lestash-server` |
+| 4 | `feat(app): micro.blog compose modal (YouTube prefill)` | First end-to-end user flow | `app/` |
+| 5 | `feat(lestash): compose.lint with YT_NOT_BARE + IMG_NOT_MARKDOWN` | Embed warnings | `packages/lestash` |
+| 6 | `feat(app): EmbedRenderer extraction + iframe rendering in detail view` | YouTube embeds everywhere | `app/` |
+| 7 | `feat(server): GET /api/items/tags?prefix=` | Autocomplete backend | `lestash-server` |
+| 8 | `feat(app): TagTypeahead + "t" shortcut` | Path B faster tag | `app/` |
+| 9 | `feat(server): POST /api/items/tags/bulk` | Bulk endpoint | `lestash-server` |
+| 10 | `feat(app): bulk selection bar (Shift-click)` | Path C bulk | `app/` |
+| 11 | `feat(server): smart collections (kind=smart, filter_spec)` | Path A persistence | `lestash-server` |
+| 12 | `feat(app): "Save filter as collection" button` | Path A surface | `app/` |
+| 13 | `feat(microblog): LinkedIn migrates to Publisher protocol` | Consolidation; deletes dup code | `lestash-linkedin` |
+| 14 | `feat(microblog): draft visibility + destination picker` | Polish | `lestash-microblog`, `app/` |
+
+Slices 1–4 unlock the SpaceX-IPO use case. Slices 7–10 unlock the Sophie's-work use case. Slice 5–6 fix the YouTube-link bug. Each is its own PR, each has its own test list before code.
+
+---
+
+## 10. What this design deliberately leaves out
+
+- Local image upload to micro.blog media-endpoint (v2).
+- Cross-target compose ("publish to both micro.blog AND LinkedIn in one click") — additive later.
+- Reading own micro.blog posts from `syndications` table to build a back-link feed.
+- A WYSIWYG editor — markdown stays the substrate, preview is the live render.
+- Categories *as a third concept* on top of tags + collections — keeps the model small.
+- AI-assisted body drafting from item content — separate design.

--- a/docs/ux-compose-and-categories-design.md
+++ b/docs/ux-compose-and-categories-design.md
@@ -43,16 +43,45 @@ A non-goal here: replacing collections with tags or vice versa. They earn their 
 
 …body prose…
 
-[youtu.be/-X6YzlY…](https://youtu.be/-X6YzlY_8tM?is=…)
+[youtu.be/-X6YzlY…](https://youtu.be/-X6YzlY_8tM?is=i1Qr7bQuRiXhd9-G)
 ```
 
-What micro.blog *would* have embedded: a bare URL on its own line:
+The blog has the [`micro-blog-lite-youtube`](https://github.com/rknightuk/micro-blog-lite-youtube) plugin installed — see §2.4. That plugin scans every rendered `<a href>` for a YouTube URL and appends a `<lite-youtube videoid="…">` at the end of the post. Wrapping in `[]()` is *not* the problem.
 
-```markdown
-https://youtu.be/-X6YzlY_8tM
+The problem is the **trailing `?is=…` tracking parameter**. The plugin's video-ID regex captures everything after the slash as non-whitespace, so `videoid` gets set to `-X6YzlY_8tM?is=i1Qr7bQuRiXhd9-G`. The lite-youtube web component then builds an embed URL like `…/embed/-X6YzlY_8tM?is=…?autoplay=…` — two `?` characters, malformed, YouTube returns nothing.
+
+Fix in the compose pipeline: **strip YouTube query params and normalise to `https://youtu.be/<id>`** before publish. The lint rule isn't `YT_NOT_BARE`, it's `YT_TRACKING_PARAM`.
+
+### 2.4 The rknightuk plugin (installed)
+
+[`micro-blog-lite-youtube`](https://github.com/rknightuk/micro-blog-lite-youtube) is a Hugo partial that ships JS + CSS to every page. On `DOMContentLoaded`:
+
+```js
+const links = [...p.getElementsByTagName('a')]
+links.forEach(l => {
+  const m = l.href.match(/…(youtube.com|youtu.be)\/(watch|embed)?(\?v=|\/)?(\S+)?/)
+  const ytId = m ? m[7] : null
+  if (ytId && article) {
+    const video = document.createElement('lite-youtube')
+    video.setAttribute('videoid', ytId)
+    article.appendChild(video)
+  }
+})
 ```
 
-micro.blog's posting endpoint runs the body through its own auto-embed logic that recognises YouTube / Vimeo URLs **only when they stand alone on a line** — wrapped in `[]()` they stay as anchor text. So the bug is in the compose path: whatever generated that post wrapped the URL in a markdown link instead of emitting a bare line. We need a compose pipeline that knows the embed rules.
+Three behaviours that shape our design:
+
+| Behaviour | Implication for compose |
+| --- | --- |
+| Matches **any** `<a href>` with youtube.com / youtu.be | Wrapped `[label](url)` markdown links are fine — no need to force bare URLs |
+| Appends embeds **at the end of `.post-content`**, not inline | The link's text position is purely visual; the player will always be at the bottom |
+| Regex captures rest-of-URL into video ID | Tracking params (`?si=`, `?is=`, `&t=`, etc.) break the embed silently |
+
+What this means for the architecture:
+
+- **No `YT_NOT_BARE` lint.** Replaced by `YT_TRACKING_PARAM` (warn + offer normalise).
+- **Compose doesn't need to render YouTube embeds for "WYSIWYG parity with micro.blog"** — the rknightuk plugin owns that. LeStash's own EmbedRenderer (§3.3, §7.4) is still useful inside the LeStash detail view, but its output doesn't need to match micro.blog's rendered HTML, only its *intent*.
+- **One open question** — see §8.7 — should we also send a fix upstream to rknightuk so the regex strips query strings? Independent of our compose-side fix, it would help others.
 
 ### 2.3 Capability gaps (the short list)
 
@@ -107,26 +136,26 @@ Three flows, each kept narrow on purpose.
 └──────────────────────────────────────────────────────────┘
 ```
 
-**Pre-fill rules**, ordered by source kind:
+**Pre-fill rules**, ordered by source kind. "Canonical YT URL" = `https://youtu.be/<id>` with no query string (see §2.4):
 
-| Source | Title | Body seed | Embed | Image |
+| Source | Title | Body seed | Link form | Image |
 | --- | --- | --- | --- | --- |
-| YouTube | video title | empty (cursor here) + blank line + bare URL | bare URL | thumbnail (optional) |
-| LinkedIn | first 80 chars of post or empty | `> …quote…` blockquote + blank line + source link | source URL on own line | first attached image |
-| Bluesky | empty | `> …quote…` + source link | bare URL | attached image |
-| arXiv | paper title | `> abstract…` + bare URL | bare URL | (none) |
-| micro.blog (reshare) | original title | `> …quote…` + bare URL | bare URL | first photo |
+| YouTube | video title | empty (cursor here) + blank line + `[<title>](<canonical YT URL>)` | canonical YT URL | thumbnail (optional) |
+| LinkedIn | first 80 chars of post or empty | `> …quote…` blockquote + blank line + source link | source URL | first attached image |
+| Bluesky | empty | `> …quote…` + source link | source URL | attached image |
+| arXiv | paper title | `> abstract…` + source link | source URL | (none) |
+| micro.blog (reshare) | original title | `> …quote…` + source link | source URL | first photo |
 | Note (own) | first line | rest of body | (none) | (none) |
 
-The composer never silently strips formatting — what you see is what gets POSTed.
+The composer never silently strips formatting — what you see is what gets POSTed. The one exception: tracking params on known-fragile URLs (YouTube) are stripped at prefill time, and shown in the lint panel as `info` so the user sees what happened.
 
 **Embed-rule guard.** A lint pass on the body, surfaced inline:
 
-- `⚠ Line 4: YouTube URL wrapped in [](). Click to convert to bare URL for auto-embed.`
-- `✓ Line 6: bare YouTube URL — will auto-embed.`
+- `ℹ Line 4: stripped tracking param ?is=…G from YouTube URL (rknightuk plugin needs a clean ID).`
+- `⚠ Line 6: YouTube URL with query string — embed will break. [Normalise]`
 - `⚠ Image referenced as <img>; micro.blog prefers ![]() markdown.`
 
-One-click "fix" for each warning. No silent rewrites.
+One-click "fix" for each warning. No silent rewrites — even the prefill-time strip is surfaced as `info` so the user can revert it (e.g. if the param matters for an unlisted/private link).
 
 ### 3.2 Quick-category
 
@@ -150,13 +179,15 @@ The "Sophie's work" path should be one of:
 
 **Why three:** A is for "this filter is meaningful, persist it"; B is for "this one item belongs here"; C is for "I just realised five items belong here." Each is one of the three real moves.
 
-### 3.3 Embed-aware rendering everywhere
+### 3.3 Embed-aware rendering in LeStash
 
-Wherever LeStash currently shows a YouTube link as plain text, render the actual embed:
+micro.blog handles its own rendering via the rknightuk plugin (§2.4). LeStash still benefits from showing the same intent inside its own UI:
 
-- Item detail body: detect bare YouTube URLs → render iframe (lazy-loaded, no-cookie domain).
-- Compose preview: same renderer, so WYSIWYG matches what micro.blog will produce.
-- One renderer module shared between detail view, compose preview, and (future) feed cards. See [§7.4](#74-embedrenderer).
+- **Item detail body**: detect YouTube URLs in any form → render lazy iframe (no-cookie domain). Saves a click vs. opening youtube.com.
+- **Compose preview**: render the *cleaned* body — what micro.blog will receive — so the user can verify the URL normalisation took effect.
+- One renderer module shared between detail view + compose preview + (future) feed cards. See [§7.4](#74-embedrenderer).
+
+Crucially, LeStash's renderer doesn't need to *match* micro.blog's rendered HTML byte-for-byte — that's the rknightuk plugin's job downstream. It just needs to show the user what they're publishing without surprises.
 
 ---
 
@@ -434,11 +465,12 @@ sequenceDiagram
 3. `publish()` twice with same body is **not** automatically idempotent — caller must opt-in via `if_not_already_published=True`; default raises `AlreadyPublished` to surface the choice.
 4. `publish()` failure (5xx from provider) leaves no `syndications` row, raises `PublishFailed` with the provider response attached.
 5. `publish()` failure (4xx with body) raises `PublishRejected` with provider message — caller shows it to user verbatim.
-6. `lint()` on a body with `[text](https://youtu.be/X)` returns one `YT_NOT_BARE` finding pointing at that line.
-7. `lint()` on a body with a bare YouTube URL on its own line returns no findings.
-8. `lint()` on a body with a bare URL followed by trailing punctuation (`https://youtu.be/X.`) returns a `YT_TRAILING_PUNCT` finding.
-9. `lint()` on a body with an `<img src="…">` returns `IMG_NOT_MARKDOWN`.
-10. `lint()` is pure — no IO, no network.
+6. `lint()` on a body with `https://youtu.be/X` (clean) returns no YouTube findings.
+7. `lint()` on a body with `https://youtu.be/X?si=abc` returns one `YT_TRACKING_PARAM` finding, with `fix_hint` containing the normalised URL `https://youtu.be/X`.
+8. `lint()` on a body with `https://www.youtube.com/watch?v=X&t=30` returns `YT_TRACKING_PARAM` (the `&t=30` breaks the rknightuk regex), `fix_hint` proposes `https://youtu.be/X`.
+9. `lint()` on a body with `[label](https://youtu.be/X?si=abc)` returns `YT_TRACKING_PARAM` — the lint walks anchor hrefs too, since that's what the rknightuk plugin inspects.
+10. `lint()` on a body with an `<img src="…">` returns `IMG_NOT_MARKDOWN`.
+11. `lint()` is pure — no IO, no network.
 
 ### 7.2 Interface that falls out
 
@@ -449,8 +481,7 @@ from dataclasses import dataclass
 from typing import Protocol, Literal
 
 LintCode = Literal[
-    "YT_NOT_BARE",
-    "YT_TRAILING_PUNCT",
+    "YT_TRACKING_PARAM",   # query string on YouTube URL breaks rknightuk plugin
     "IMG_NOT_MARKDOWN",
     "SOFT_CHAR_LIMIT",
 ]
@@ -501,7 +532,9 @@ class Publisher(Protocol):
 
 Notice what the test list forced into the interface:
 
-- **`lint` is sync + pure** (tests 6–10) — no `async`, no IO. Pure function, trivial to unit-test, can run on every keystroke.
+- **`lint` is sync + pure** (tests 6–11) — no `async`, no IO. Pure function, trivial to unit-test, can run on every keystroke.
+- **`fix_hint` carries a concrete replacement** (tests 7–9) — not just "fix this", but "replace with `<this>`". The UI's one-click fix is then a string replace, no extra logic in the frontend.
+- **`lint` walks anchor hrefs, not just bare URLs** (test 9) — mirrors what the rknightuk plugin inspects. The test forces this.
 - **Three distinct exception classes** (tests 3–5) — collapsing them to one `PublishError` would lose the calling-code distinctions the tests already require (re-publish flag, show-to-user, retry).
 - **`if_not_already_published` is an explicit boolean** (test 3) — not a global config, not implicit-by-default. The default surfaces the decision.
 - **`raw_response` returned** (test 1+2) — so the route can store it in `syndications.response_body` without the Publisher having to know about the DB.
@@ -518,14 +551,18 @@ Notice what the test list forced into the interface:
 
 ### 7.4 `EmbedRenderer`
 
+Scope: LeStash detail view + compose preview only. The rknightuk plugin owns rendering on micro.blog. We're showing the user what they *intend* to publish.
+
 Test list:
 
-1. `render("https://youtu.be/X\n")` returns an `<iframe>` with `youtube-nocookie.com` host.
-2. `render("[label](https://youtu.be/X)")` returns an `<a>` — does **not** embed (matches micro.blog behaviour).
-3. `render("https://www.youtube.com/watch?v=X\n")` and `render("https://youtu.be/X\n")` produce the same embed.
-4. `render` is sync, pure, no fetch.
-5. `render` escapes user content in surrounding text — no XSS.
-6. Unknown video host falls back to plain `<a>`.
+1. `render("https://youtu.be/X")` returns an `<iframe>` with `youtube-nocookie.com` host.
+2. `render("[label](https://youtu.be/X)")` *also* renders the embed (matches rknightuk plugin behaviour — anchor hrefs are detected).
+3. `render("https://www.youtube.com/watch?v=X")` and `render("https://youtu.be/X")` produce the same embed.
+4. `render("https://youtu.be/X?si=abc")` produces an embed for ID `X` — query strings ignored at render time (defensive). The lint pass still flags it so the user is aware.
+5. Multiple YouTube URLs in one body → multiple embeds, appended at end of body (matches rknightuk's append-at-end semantics).
+6. `render` is sync, pure, no fetch.
+7. `render` escapes user content in surrounding text — no XSS.
+8. Unknown video host falls back to plain `<a>`.
 
 Interface:
 
@@ -583,8 +620,9 @@ Why snapshot semantics in test 4: live "view" semantics would require running th
 2. **Draft vs publish.** Micropub supports `post-status=draft`. UI exposes this as visibility radio. → Yes, ship from day one (low cost, lets user proof).
 3. **Image upload path.** micro.blog config advertises a `media-endpoint`. For initial slice: only support items whose `media[0]` is already a URL we can pass through; defer multipart upload to v2. → Documented limit in composer ("Local images coming soon").
 4. **Tag normalization on autocomplete.** Show `sophies-work` and `sophie work` as separate? They *are* separate today. → Add a "suggest merge?" hint when prefix matches multiple near-duplicates (`Levenshtein ≤ 2`). Defer the actual merge UI; surface the smell.
-5. **`lint` rule extensibility.** Per-target rule sets or one shared set? → One shared set lives in core; targets opt in by listing codes. micro.blog opts into `YT_*`, `IMG_NOT_MARKDOWN`, `SOFT_CHAR_LIMIT(300)`. LinkedIn opts into `SOFT_CHAR_LIMIT(3000)` only.
+5. **`lint` rule extensibility.** Per-target rule sets or one shared set? → One shared set lives in core; targets opt in by listing codes. micro.blog opts into `YT_TRACKING_PARAM`, `IMG_NOT_MARKDOWN`, `SOFT_CHAR_LIMIT(300)`. LinkedIn opts into `SOFT_CHAR_LIMIT(3000)` only.
 6. **Two-app pattern (project memory: LinkedIn dual-app, see [[project_linkedin_posting]]):** does micro.blog need anything similar? → No. Single app token, single endpoint. Simpler.
+7. **Upstream fix to rknightuk plugin?** The video-ID regex (§2.4) captures query strings into the ID. We work around it by stripping client-side; a one-line regex fix upstream would help anyone using the plugin. → Open a PR to `rknightuk/micro-blog-lite-youtube` proposing `match(/…\/(?:watch\?v=|embed\/)?([^?&\s]+)/)`. Independent of our compose-side fix; both belt and braces.
 
 ---
 

--- a/docs/ux-compose-and-categories-design.md
+++ b/docs/ux-compose-and-categories-design.md
@@ -46,42 +46,31 @@ A non-goal here: replacing collections with tags or vice versa. They earn their 
 [youtu.be/-X6YzlY…](https://youtu.be/-X6YzlY_8tM?is=i1Qr7bQuRiXhd9-G)
 ```
 
-The blog has the [`micro-blog-lite-youtube`](https://github.com/rknightuk/micro-blog-lite-youtube) plugin installed — see §2.4. That plugin scans every rendered `<a href>` for a YouTube URL and appends a `<lite-youtube videoid="…">` at the end of the post. Wrapping in `[]()` is *not* the problem.
+The link was emitted as a markdown anchor with a `?is=…` tracking parameter. On the SpaceX post that rendered to anchor-only — no embed. After comparing the available micro.blog YouTube plugins (see §2.4), this design targets [`flschr/mbplugin-youtube-nocookie`](https://github.com/flschr/mbplugin-youtube-nocookie). That plugin doesn't take URLs at all — it takes a Hugo shortcode `{{< yt "VIDEOID" >}}` and emits a build-time, no-cookie, lazy-loaded embed inline.
 
-The problem is the **trailing `?is=…` tracking parameter**. The plugin's video-ID regex captures everything after the slash as non-whitespace, so `videoid` gets set to `-X6YzlY_8tM?is=i1Qr7bQuRiXhd9-G`. The lite-youtube web component then builds an embed URL like `…/embed/-X6YzlY_8tM?is=…?autoplay=…` — two `?` characters, malformed, YouTube returns nothing.
+Fix in the compose pipeline: **extract the 11-char video ID and emit `{{< yt "ID" >}}`** rather than a raw URL or a markdown link. The whole "did the URL keep a tracking param" class of failure disappears because the shortcode only accepts IDs.
 
-Fix in the compose pipeline: **strip YouTube query params and normalise to `https://youtu.be/<id>`** before publish. The lint rule isn't `YT_NOT_BARE`, it's `YT_TRACKING_PARAM`.
+### 2.4 Plugin choice — flschr over rknightuk
 
-### 2.4 The rknightuk plugin (installed)
+The blog currently runs [`rknightuk/micro-blog-lite-youtube`](https://github.com/rknightuk/micro-blog-lite-youtube). This design targets [`flschr/mbplugin-youtube-nocookie`](https://github.com/flschr/mbplugin-youtube-nocookie) instead — install swap recommended.
 
-[`micro-blog-lite-youtube`](https://github.com/rknightuk/micro-blog-lite-youtube) is a Hugo partial that ships JS + CSS to every page. On `DOMContentLoaded`:
-
-```js
-const links = [...p.getElementsByTagName('a')]
-links.forEach(l => {
-  const m = l.href.match(/…(youtube.com|youtu.be)\/(watch|embed)?(\?v=|\/)?(\S+)?/)
-  const ytId = m ? m[7] : null
-  if (ytId && article) {
-    const video = document.createElement('lite-youtube')
-    video.setAttribute('videoid', ytId)
-    article.appendChild(video)
-  }
-})
-```
-
-Three behaviours that shape our design:
-
-| Behaviour | Implication for compose |
-| --- | --- |
-| Matches **any** `<a href>` with youtube.com / youtu.be | Wrapped `[label](url)` markdown links are fine — no need to force bare URLs |
-| Appends embeds **at the end of `.post-content`**, not inline | The link's text position is purely visual; the player will always be at the bottom |
-| Regex captures rest-of-URL into video ID | Tracking params (`?si=`, `?is=`, `&t=`, etc.) break the embed silently |
+| Dimension | rknightuk (today) | flschr (target) |
+| --- | --- | --- |
+| Trigger | runtime JS body scan for `<a href>` | Hugo shortcode `{{< yt "ID" >}}` |
+| Render moment | browser runtime | **build-time** (HTML + small inline JS) |
+| Input form | URL (regex-parsed, fragile) | **11-char ID only** (v1.3.5 dropped URL parsing for "instability") |
+| Position | appended to end of `.post-content` | **inline** at shortcode site |
+| Privacy | `youtube.com` | `youtube-nocookie.com` |
+| RSS / Mastodon | empty — JS doesn't run in feed readers | iframe + `.yt-text-link` text fallback |
+| Tracking-param failure | `?si=` / `?is=` silently breaks the embed | structurally impossible (input is ID, not URL) |
+| Lazy load | yes (lite-yt-embed via CDN) | yes (thumbnail + click-to-play, no CDN) |
 
 What this means for the architecture:
 
-- **No `YT_NOT_BARE` lint.** Replaced by `YT_TRACKING_PARAM` (warn + offer normalise).
-- **Compose doesn't need to render YouTube embeds for "WYSIWYG parity with micro.blog"** — the rknightuk plugin owns that. LeStash's own EmbedRenderer (§3.3, §7.4) is still useful inside the LeStash detail view, but its output doesn't need to match micro.blog's rendered HTML, only its *intent*.
-- **One open question** — see §8.7 — should we also send a fix upstream to rknightuk so the regex strips query strings? Independent of our compose-side fix, it would help others.
+- **`YT_TRACKING_PARAM` lint — deleted.** The class of failure doesn't exist when input is an ID.
+- **EmbedRenderer's compose-side job becomes URL→ID extraction** — parse any of `youtu.be/<id>`, `youtube.com/watch?v=<id>`, `youtube.com/embed/<id>`, `m.youtube.com/…`, `youtube-nocookie.com/embed/<id>`, plus `?list=<id>` playlists — and emit `{{< yt "<id>" >}}` (optionally `{{< yt "<id>" "" "<title>" >}}` for the 3rd-arg title used in aria-label, iframe title, and the feed fallback link).
+- **EmbedRenderer's LeStash-side job (preview / detail-view rendering) unchanged in intent** — render an inline embed so the user sees what they're publishing. It can render an `<iframe>` directly; doesn't need to mimic flschr's button-thumbnail-then-iframe UX.
+- **Action required**: install flschr plugin on the blog, uninstall rknightuk. See §9 slice 0.
 
 ### 2.3 Capability gaps (the short list)
 
@@ -119,8 +108,8 @@ Three flows, each kept narrow on purpose.
 │         │ Reusable rockets, satellite comms, and the  │  │
 │         │ AI-hype refrain.                            │  │
 │         │                                             │  │
-│         │ https://youtu.be/-X6YzlY_8tM    ⟵ bare URL  │  │
-│         │                                  auto-embeds│  │
+│         │ {{< yt "-X6YzlY_8tM" "" "SpaceX IPO" >}}    │  │
+│         │            ⟵ flschr shortcode (build-time)  │  │
 │         └─────────────────────────────────────────────┘  │
 │  Image  [thumb] screenshot-20260530.png   [Remove]       │
 │  Tags   ⊞ spacex   ⊞ ipo                                 │
@@ -136,26 +125,26 @@ Three flows, each kept narrow on purpose.
 └──────────────────────────────────────────────────────────┘
 ```
 
-**Pre-fill rules**, ordered by source kind. "Canonical YT URL" = `https://youtu.be/<id>` with no query string (see §2.4):
+**Pre-fill rules**, ordered by source kind:
 
-| Source | Title | Body seed | Link form | Image |
+| Source | Title | Body seed | Embed form | Image |
 | --- | --- | --- | --- | --- |
-| YouTube | video title | empty (cursor here) + blank line + `[<title>](<canonical YT URL>)` | canonical YT URL | thumbnail (optional) |
-| LinkedIn | first 80 chars of post or empty | `> …quote…` blockquote + blank line + source link | source URL | first attached image |
-| Bluesky | empty | `> …quote…` + source link | source URL | attached image |
-| arXiv | paper title | `> abstract…` + source link | source URL | (none) |
-| micro.blog (reshare) | original title | `> …quote…` + source link | source URL | first photo |
+| YouTube | video title | empty (cursor here) + blank line + `{{< yt "<id>" "" "<title>" >}}` | flschr shortcode | thumbnail (optional, the shortcode renders one) |
+| LinkedIn | first 80 chars of post or empty | `> …quote…` blockquote + blank line + source link | bare link | first attached image |
+| Bluesky | empty | `> …quote…` + source link | bare link | attached image |
+| arXiv | paper title | `> abstract…` + source link | bare link | (none) |
+| micro.blog (reshare) | original title | `> …quote…` + source link | bare link | first photo |
 | Note (own) | first line | rest of body | (none) | (none) |
 
-The composer never silently strips formatting — what you see is what gets POSTed. The one exception: tracking params on known-fragile URLs (YouTube) are stripped at prefill time, and shown in the lint panel as `info` so the user sees what happened.
+The composer never silently strips formatting — what you see is what gets POSTed. YouTube prefill resolves the source URL to its video ID at prefill time, and the lint panel shows what was extracted (`ℹ extracted videoid "-X6YzlY_8tM" from saved URL`).
 
 **Embed-rule guard.** A lint pass on the body, surfaced inline:
 
-- `ℹ Line 4: stripped tracking param ?is=…G from YouTube URL (rknightuk plugin needs a clean ID).`
-- `⚠ Line 6: YouTube URL with query string — embed will break. [Normalise]`
+- `ℹ Line 4: extracted videoid "-X6YzlY_8tM" from saved URL — shortcode {{< yt "…" >}} will embed at build time.`
+- `⚠ Line 6: raw YouTube URL detected — the flschr plugin only embeds via shortcode. [Convert to {{< yt "…" >}}]`
 - `⚠ Image referenced as <img>; micro.blog prefers ![]() markdown.`
 
-One-click "fix" for each warning. No silent rewrites — even the prefill-time strip is surfaced as `info` so the user can revert it (e.g. if the param matters for an unlisted/private link).
+One-click "fix" for each warning. No silent rewrites.
 
 ### 3.2 Quick-category
 
@@ -465,12 +454,13 @@ sequenceDiagram
 3. `publish()` twice with same body is **not** automatically idempotent — caller must opt-in via `if_not_already_published=True`; default raises `AlreadyPublished` to surface the choice.
 4. `publish()` failure (5xx from provider) leaves no `syndications` row, raises `PublishFailed` with the provider response attached.
 5. `publish()` failure (4xx with body) raises `PublishRejected` with provider message — caller shows it to user verbatim.
-6. `lint()` on a body with `https://youtu.be/X` (clean) returns no YouTube findings.
-7. `lint()` on a body with `https://youtu.be/X?si=abc` returns one `YT_TRACKING_PARAM` finding, with `fix_hint` containing the normalised URL `https://youtu.be/X`.
-8. `lint()` on a body with `https://www.youtube.com/watch?v=X&t=30` returns `YT_TRACKING_PARAM` (the `&t=30` breaks the rknightuk regex), `fix_hint` proposes `https://youtu.be/X`.
-9. `lint()` on a body with `[label](https://youtu.be/X?si=abc)` returns `YT_TRACKING_PARAM` — the lint walks anchor hrefs too, since that's what the rknightuk plugin inspects.
-10. `lint()` on a body with an `<img src="…">` returns `IMG_NOT_MARKDOWN`.
-11. `lint()` is pure — no IO, no network.
+6. `lint()` on a body with `{{< yt "X" >}}` (clean shortcode) returns no YouTube findings.
+7. `lint()` on a body with `https://youtu.be/X` returns one `YT_RAW_URL` finding, `fix_hint = '{{< yt "X" >}}'`.
+8. `lint()` on a body with `https://www.youtube.com/watch?v=X&t=30` returns `YT_RAW_URL`, `fix_hint = '{{< yt "X" >}}'` — tracking params dropped during extraction.
+9. `lint()` on a body with `[label](https://youtu.be/X?si=abc)` returns `YT_RAW_URL` with `fix_hint = '{{< yt "X" "" "label" >}}'` — anchor text is preserved as the title arg.
+10. `lint()` on a body with `https://www.youtube.com/playlist?list=PLabc` returns `YT_RAW_URL`, `fix_hint = '{{< yt "PLabc" >}}'` — playlists ride the same shortcode.
+11. `lint()` on a body with an `<img src="…">` returns `IMG_NOT_MARKDOWN`.
+12. `lint()` is pure — no IO, no network.
 
 ### 7.2 Interface that falls out
 
@@ -481,7 +471,7 @@ from dataclasses import dataclass
 from typing import Protocol, Literal
 
 LintCode = Literal[
-    "YT_TRACKING_PARAM",   # query string on YouTube URL breaks rknightuk plugin
+    "YT_RAW_URL",          # raw URL where {{< yt "ID" >}} shortcode is expected
     "IMG_NOT_MARKDOWN",
     "SOFT_CHAR_LIMIT",
 ]
@@ -532,9 +522,10 @@ class Publisher(Protocol):
 
 Notice what the test list forced into the interface:
 
-- **`lint` is sync + pure** (tests 6–11) — no `async`, no IO. Pure function, trivial to unit-test, can run on every keystroke.
-- **`fix_hint` carries a concrete replacement** (tests 7–9) — not just "fix this", but "replace with `<this>`". The UI's one-click fix is then a string replace, no extra logic in the frontend.
-- **`lint` walks anchor hrefs, not just bare URLs** (test 9) — mirrors what the rknightuk plugin inspects. The test forces this.
+- **`lint` is sync + pure** (tests 6–12) — no `async`, no IO. Pure function, trivial to unit-test, can run on every keystroke.
+- **`fix_hint` carries a concrete replacement** (tests 7–10) — not just "fix this", but "replace with `<this>`". The UI's one-click fix is then a string replace, no extra logic in the frontend.
+- **`lint` walks anchor hrefs and preserves anchor text** (test 9) — the anchor's label becomes the shortcode's title arg, so the click-to-play button and feed fallback link carry it through.
+- **Playlists share the shortcode** (test 10) — same lint code, same fix shape, no separate playlist machinery.
 - **Three distinct exception classes** (tests 3–5) — collapsing them to one `PublishError` would lose the calling-code distinctions the tests already require (re-publish flag, show-to-user, retry).
 - **`if_not_already_published` is an explicit boolean** (test 3) — not a global config, not implicit-by-default. The default surfaces the decision.
 - **`raw_response` returned** (test 1+2) — so the route can store it in `syndications.response_body` without the Publisher having to know about the DB.
@@ -551,18 +542,27 @@ Notice what the test list forced into the interface:
 
 ### 7.4 `EmbedRenderer`
 
-Scope: LeStash detail view + compose preview only. The rknightuk plugin owns rendering on micro.blog. We're showing the user what they *intend* to publish.
+Scope: LeStash detail view + compose preview only. The flschr plugin owns rendering on micro.blog. We're showing the user what they *intend* to publish.
+
+The renderer has two halves:
+
+- **Extract** — `extract_video_id(url) -> str | None`, accepts any of `youtu.be/<id>`, `youtube.com/watch?v=<id>`, `youtube.com/embed/<id>`, `m.youtube.com/…`, `youtube-nocookie.com/embed/<id>`, `?list=<id>` (playlists). Tracking params discarded.
+- **Render** — `render_body(body) -> EmbedRenderResult`, walks the body, replaces YouTube URLs / anchors / `{{< yt … >}}` shortcodes with inline `<iframe>`s on `youtube-nocookie.com`.
 
 Test list:
 
-1. `render("https://youtu.be/X")` returns an `<iframe>` with `youtube-nocookie.com` host.
-2. `render("[label](https://youtu.be/X)")` *also* renders the embed (matches rknightuk plugin behaviour — anchor hrefs are detected).
-3. `render("https://www.youtube.com/watch?v=X")` and `render("https://youtu.be/X")` produce the same embed.
-4. `render("https://youtu.be/X?si=abc")` produces an embed for ID `X` — query strings ignored at render time (defensive). The lint pass still flags it so the user is aware.
-5. Multiple YouTube URLs in one body → multiple embeds, appended at end of body (matches rknightuk's append-at-end semantics).
-6. `render` is sync, pure, no fetch.
-7. `render` escapes user content in surrounding text — no XSS.
-8. Unknown video host falls back to plain `<a>`.
+1. `extract_video_id("https://youtu.be/X")` returns `"X"`.
+2. `extract_video_id("https://youtu.be/X?si=abc")` returns `"X"`.
+3. `extract_video_id("https://www.youtube.com/watch?v=X&t=30")` returns `"X"`.
+4. `extract_video_id("https://www.youtube.com/playlist?list=PLabc")` returns `"PLabc"`.
+5. `extract_video_id("https://example.com/x")` returns `None`.
+6. `render_body("{{< yt \"X\" >}}")` returns an `<iframe>` with `youtube-nocookie.com` host.
+7. `render_body("https://youtu.be/X")` *also* renders the embed inline (LeStash is more permissive than flschr — we render intent).
+8. `render_body("[label](https://youtu.be/X)")` *also* renders the embed inline.
+9. Multiple YouTube refs → multiple inline embeds at each ref's position (LeStash chooses inline; flschr already does the same).
+10. `render_body` is sync, pure, no fetch.
+11. `render_body` escapes user content in surrounding text — no XSS.
+12. Unknown video host falls back to plain `<a>`.
 
 Interface:
 
@@ -620,9 +620,9 @@ Why snapshot semantics in test 4: live "view" semantics would require running th
 2. **Draft vs publish.** Micropub supports `post-status=draft`. UI exposes this as visibility radio. → Yes, ship from day one (low cost, lets user proof).
 3. **Image upload path.** micro.blog config advertises a `media-endpoint`. For initial slice: only support items whose `media[0]` is already a URL we can pass through; defer multipart upload to v2. → Documented limit in composer ("Local images coming soon").
 4. **Tag normalization on autocomplete.** Show `sophies-work` and `sophie work` as separate? They *are* separate today. → Add a "suggest merge?" hint when prefix matches multiple near-duplicates (`Levenshtein ≤ 2`). Defer the actual merge UI; surface the smell.
-5. **`lint` rule extensibility.** Per-target rule sets or one shared set? → One shared set lives in core; targets opt in by listing codes. micro.blog opts into `YT_TRACKING_PARAM`, `IMG_NOT_MARKDOWN`, `SOFT_CHAR_LIMIT(300)`. LinkedIn opts into `SOFT_CHAR_LIMIT(3000)` only.
+5. **`lint` rule extensibility.** Per-target rule sets or one shared set? → One shared set lives in core; targets opt in by listing codes. micro.blog opts into `YT_RAW_URL`, `IMG_NOT_MARKDOWN`, `SOFT_CHAR_LIMIT(300)`. LinkedIn opts into `SOFT_CHAR_LIMIT(3000)` only.
 6. **Two-app pattern (project memory: LinkedIn dual-app, see [[project_linkedin_posting]]):** does micro.blog need anything similar? → No. Single app token, single endpoint. Simpler.
-7. **Upstream fix to rknightuk plugin?** The video-ID regex (§2.4) captures query strings into the ID. We work around it by stripping client-side; a one-line regex fix upstream would help anyone using the plugin. → Open a PR to `rknightuk/micro-blog-lite-youtube` proposing `match(/…\/(?:watch\?v=|embed\/)?([^?&\s]+)/)`. Independent of our compose-side fix; both belt and braces.
+7. **Blog plugin swap timing.** flschr (target) vs rknightuk (today). When the swap happens, any old posts that contain raw YouTube URLs will lose their embeds (flschr won't pick them up — only shortcodes embed). Two options: (a) one-off migration pass over old posts (rewrite URLs into shortcodes via Micropub update); (b) leave history as plain links. → Prefer (a) for last 12 months only; cost low, payoff is consistent feed/Mastodon rendering on recent reshared posts. Older posts: leave alone.
 
 ---
 
@@ -632,12 +632,13 @@ Each slice is independently mergeable + demo-able. PR titles in the suggested co
 
 | # | Slice | Slice value | Touches |
 | - | --- | --- | --- |
+| 0 | Install `flschr/mbplugin-youtube-nocookie` on the blog; uninstall `rknightuk/micro-blog-lite-youtube` | Unblocks the rest; standalone blog change | blog plugins (no code) |
 | 1 | `feat(lestash): add Publisher protocol + ComposeRequest/PublishResult/LintFinding schemas` | Foundation; no user-visible change | `packages/lestash` |
 | 2 | `feat(microblog): implement MicropubClient.create_entry()` | Backend can post; tested via CLI | `lestash-microblog` |
 | 3 | `feat(microblog): expose POST /api/microblog/publish` | API-first publish | `lestash-server` |
 | 4 | `feat(app): micro.blog compose modal (YouTube prefill)` | First end-to-end user flow | `app/` |
-| 5 | `feat(lestash): compose.lint with YT_NOT_BARE + IMG_NOT_MARKDOWN` | Embed warnings | `packages/lestash` |
-| 6 | `feat(app): EmbedRenderer extraction + iframe rendering in detail view` | YouTube embeds everywhere | `app/` |
+| 5 | `feat(lestash): compose.lint with YT_RAW_URL + IMG_NOT_MARKDOWN` | Embed warnings | `packages/lestash` |
+| 6 | `feat(app): EmbedRenderer (extract + render) + iframe in detail view` | YouTube embeds inline in LeStash | `app/` |
 | 7 | `feat(server): GET /api/items/tags?prefix=` | Autocomplete backend | `lestash-server` |
 | 8 | `feat(app): TagTypeahead + "t" shortcut` | Path B faster tag | `app/` |
 | 9 | `feat(server): POST /api/items/tags/bulk` | Bulk endpoint | `lestash-server` |

--- a/docs/ux-compose-and-categories-design.md
+++ b/docs/ux-compose-and-categories-design.md
@@ -663,7 +663,96 @@ Slices 1–4 unlock the SpaceX-IPO use case. Slices 7–10 unlock the Sophie's-w
 
 ---
 
-## 10. What this design deliberately leaves out
+## 10. Shipping cadence — staggered waves
+
+§9 is the granular slice list. This section answers "what do I merge first, what waits, what can run in parallel, and where do I stop to reassess." Waves are mergeable on their own — each leaves the app in a coherent state and ships value even if no later wave ever lands.
+
+### Dependency graph
+
+```mermaid
+graph LR
+  W0["Wave 0 done<br/>docs + tags.kind"]
+  W1["Wave 1<br/>blog plugin swap"]
+  W2a["Wave 2a<br/>Publisher + Micropub<br/>+ publish API"]
+  W2b["Wave 2b<br/>compose modal UI"]
+  W3["Wave 3<br/>lint + EmbedRenderer"]
+  W4["Wave 4<br/>tag autocomplete + typeahead"]
+  W5a["Wave 5a<br/>bulk-tag API + UI"]
+  W5b["Wave 5b<br/>smart collections"]
+  W6a["Wave 6a<br/>LinkedIn → Publisher refactor"]
+  W6b["Wave 6b<br/>draft visibility + destination picker"]
+
+  W0 --> W1
+  W0 --> W2a
+  W0 --> W4
+  W1 -.-> W2b
+  W2a --> W2b
+  W2b --> W3
+  W2a --> W6a
+  W2b --> W6b
+  W4 --> W5a
+  W4 --> W5b
+```
+
+Dashed line = soft dependency (Wave 2b is more useful once Wave 1 is done, but doesn't strictly require it).
+
+### Wave-by-wave
+
+| Wave | Contains | Ships independently? | Risk | Stop-point value |
+| --- | --- | --- | --- | --- |
+| **0 ✓** | docs, `tags.kind` migration, 11 categories seeded | yes | none — column is additive, no caller yet | DB now has a structured place for categories |
+| **1** | slice 0 — install flschr, uninstall rknightuk | yes | cosmetic regression on old posts with raw YouTube URLs (lose embed until backfilled) | new posts get inline nocookie embeds; RSS/Mastodon syndication finally carries them |
+| **2a** | slices 1, 2, 3 — Publisher protocol + `MicropubClient.create_entry()` + `POST /api/microblog/publish` | yes — CLI / curl callable | live blog gets test posts during dev — use `visibility=draft` | publishing works end-to-end from a script, no UI needed |
+| **2b** | slice 4 — compose modal | depends on 2a | UI gate it behind a `settings.compose_microblog_enabled` flag while shaking it down | the SpaceX-IPO use case works |
+| **3** | slices 5, 6 — `compose.lint` + `EmbedRenderer` extract+render | yes — purely additive UI | low | inline YouTube in LeStash; raw-URL warnings in composer |
+| **4** | slices 7, 8 — tag autocomplete API + TagTypeahead + `t` shortcut | yes — useful for any tag, not just categories | low | the "Sophie's work" tagging case is fast |
+| **5a** | slices 9, 10 — bulk-tag API + BulkSelectionBar | yes | low — operation is atomic per request | shift-click → `t` → tag many items at once |
+| **5b** | slices 11, 12 — smart collections backend + "Save filter as collection" UI | yes | medium — the item-insert hook adds work to every sync write; gate behind feature flag initially, default new collections to `kind='manual'` | filters become persistent |
+| **6a** | slice 13 — LinkedIn migrates to Publisher protocol | yes — refactor only, behaviour unchanged | medium — touches working production code; need parity tests before/after | one Publisher abstraction; deletes duplicate plumbing |
+| **6b** | slice 14 — draft visibility + destination picker polish | yes | low | nicer composer UX |
+
+### Recommended order
+
+1. **Wave 1 next** — zero-code, immediate visible win on the blog. Decouples everything that follows from blog plugin choice.
+2. **Then Wave 2a + Wave 4 in parallel** — independent tracks, no shared files. 2a is the publish backend (no UI), 4 is the tag UX (small backend + small UI).
+3. **Then Wave 2b** — UI to drive 2a. Stop here, use it for a week, decide if Wave 3 lint matters before building it.
+4. **Wave 3 only if Wave 2b shows raw-URL or `<img>` slip-ups happening in real use** — otherwise defer; the lint is insurance, not foundation.
+5. **Wave 5a** — bulk-tag once Wave 4 is in muscle memory. Wave 5b (smart collections) only if a saved filter survives in the user's head for more than a week — otherwise YAGNI.
+6. **Wave 6a + 6b** — last, both small. Refactor 6a only after Wave 2 has shaken the Publisher contract enough to know it's right.
+
+### Parallel tracks
+
+These pairs touch no shared code and can land in either order from the same starting point:
+
+- **Wave 2a ‖ Wave 4** — Publisher/publish backend vs tag autocomplete backend. Different files.
+- **Wave 5a ‖ Wave 5b** — bulk-tag vs smart collections, after Wave 4. Share the BulkSelectionBar component but on different code paths.
+- **Wave 6a ‖ Wave 6b** — independent polish.
+
+### Feature gating
+
+Add one boolean per in-progress wave to `~/.config/lestash/config.toml` (or `settings.toml`) under `[features]`. Default `false`; the user flips it when ready to dogfood. Surfaces:
+
+- `compose_microblog_enabled` — gates Wave 2b composer UI + the `Share to micro.blog` button.
+- `tag_typeahead_enabled` — gates Wave 4 typeahead (falls back to current type-and-add).
+- `bulk_select_enabled` — gates Wave 5a shift-click selection.
+- `smart_collections_enabled` — gates Wave 5b hook registration *and* the UI button. Critical for 5b because the insert hook touches every sync write.
+
+The gate lives in the frontend for UI waves and in the backend for backend waves (refuse the call if disabled). This lets you merge to `main` long before you're ready to use the feature, and roll forward without reverting.
+
+### Rollback story
+
+- Wave 0: `ALTER TABLE tags DROP COLUMN kind` — schema-only revert. Categories stay (as `ad-hoc`).
+- Wave 1: reinstall rknightuk plugin on the blog.
+- Wave 2: disable `compose_microblog_enabled`, then revert PR. `syndications` rows are harmless if left.
+- Wave 3: revert PR; no schema, no state.
+- Wave 4: disable `tag_typeahead_enabled`, revert PR.
+- Wave 5a: revert PR.
+- Wave 5b: disable `smart_collections_enabled` (stops the hook from firing), then revert. `collections.kind/filter_spec` columns can stay or be dropped.
+- Wave 6: revert; LinkedIn behaviour is unchanged by 6a, 6b is additive.
+
+---
+
+## 11. What this design deliberately leaves out
 
 - Local image upload to micro.blog media-endpoint (v2).
 - Cross-target compose ("publish to both micro.blog AND LinkedIn in one click") — additive later.

--- a/docs/ux-compose-and-categories-design.md
+++ b/docs/ux-compose-and-categories-design.md
@@ -253,13 +253,26 @@ erDiagram
     TEXT content
     TEXT url
     INTEGER parent_id FK
-    TEXT metadata "JSON"
+    TEXT metadata
     TIMESTAMP created_at
   }
-  tags { INTEGER id PK; TEXT name UK }
-  item_tags { INTEGER item_id FK; INTEGER tag_id FK }
-  collections { INTEGER id PK; TEXT name; TEXT description }
-  collection_items { INTEGER collection_id FK; INTEGER item_id FK }
+  tags {
+    INTEGER id PK
+    TEXT name UK
+  }
+  item_tags {
+    INTEGER item_id FK
+    INTEGER tag_id FK
+  }
+  collections {
+    INTEGER id PK
+    TEXT name
+    TEXT description
+  }
+  collection_items {
+    INTEGER collection_id FK
+    INTEGER item_id FK
+  }
 ```
 
 ### 5.2 Tags vs. collections — keep both
@@ -333,7 +346,7 @@ sequenceDiagram
   API->>DB: INSERT syndications(item_id, target='microblog', url, request_body, response_body)
   API->>DB: add_tag(item_id, 'published-to-microblog')  // if opt-in checked
   API-->>UI: 200 {url}
-  UI-->>U: toast "Published ⤴ open"; modal closes
+  UI-->>U: toast "Published ⤴ open" — modal closes
 ```
 
 Notes on step 4 (lint findings): findings render inline (yellow underline + tooltip) rather than blocking submit. Submit is blocked only on `severity=error` — currently none of the embed rules are errors, all warnings.
@@ -359,7 +372,7 @@ sequenceDiagram
   UI->>UI: render list + bottom row: "Create 'sop'"
   U->>UI: ↓ to "sophie", Enter
   UI->>API: POST /api/items/{id}/tags {tag:"sophie"}
-  API->>DB: INSERT OR IGNORE tags; INSERT item_tags
+  API->>DB: INSERT OR IGNORE tags · INSERT item_tags
   API-->>UI: 200
   UI-->>U: chip appears
 ```
@@ -381,9 +394,9 @@ sequenceDiagram
   U->>Bar: press "t" → typeahead opens
   U->>Bar: pick "sophie"
   Bar->>API: POST {item_ids:[3,7,12], tag:"sophie"}
-  API->>DB: BEGIN; INSERT OR IGNORE tag; bulk INSERT item_tags; COMMIT
+  API->>DB: BEGIN · INSERT OR IGNORE tag · bulk INSERT item_tags · COMMIT
   API-->>Bar: {applied:3, skipped:0}
-  Bar-->>U: toast "Tagged 3 items"; selection cleared
+  Bar-->>U: toast "Tagged 3 items" — selection cleared
 ```
 
 ### 6.4 Smart collection (Path A)

--- a/docs/ux-compose-and-categories-design.md
+++ b/docs/ux-compose-and-categories-design.md
@@ -325,9 +325,18 @@ ALTER TABLE collections ADD COLUMN filter_spec TEXT;                      -- JSO
 
 `syndications` lets the item detail show "Published to micro.blog ⤴" and prevents accidental double-posting. Storing `request_body` makes "re-publish with edits" trivially safe — we have the prior text.
 
-### 5.4 Tag input — no schema change
+### 5.4 Tag input — minimal schema change
 
-Tag normalization is already lowercase; autocomplete just needs a `prefix=` query (small server change, see [§7.5](#75-tag-autocomplete-api)).
+```sql
+-- migration 10: distinguish curated category tags from ad-hoc free tags
+ALTER TABLE tags ADD COLUMN kind TEXT NOT NULL DEFAULT 'ad-hoc';
+-- values: 'category' (curated, shown in composer Cats autocomplete)
+--        | 'ad-hoc'   (free tags, shown in composer Tags autocomplete)
+```
+
+Tag normalization is already lowercase. Autocomplete uses a `prefix=` query + a `kind=` filter so the composer can ask for category candidates and tag candidates separately from the same endpoint (see [§7.5](#75-tag-autocomplete-api)).
+
+The 11 categories from [`blog-categories-consolidation.md`](blog-categories-consolidation.md) are seeded into the live DB with `kind='category'`. Future renames / additions happen via the same UI affordance as any tag — there's no separate "categories admin" surface.
 
 ---
 
@@ -578,9 +587,11 @@ export function detectEmbeds(body: string): Array<{ line: number; url: string; p
 ### 7.5 Tag autocomplete API
 
 ```
-GET /api/items/tags?prefix=<str>&limit=<int>
-→ 200 { results: [{name, count}], total: int }
+GET /api/items/tags?prefix=<str>&kind=<category|ad-hoc>&limit=<int>
+→ 200 { results: [{name, kind, count}], total: int }
 ```
+
+`kind` is optional — omitted returns both, useful for legacy callers and the filter dropdown. Composer's `Cats` field passes `kind=category`; `Tags` field passes `kind=ad-hoc`. Curated categories always rank ahead of ad-hoc tags within a prefix match when `kind` is omitted.
 
 ### 7.6 Bulk-tag API
 

--- a/packages/lestash/src/lestash/core/database.py
+++ b/packages/lestash/src/lestash/core/database.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Current schema version - increment when adding migrations
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 # Base schema (version 0) - applied to new databases
 SCHEMA = """
@@ -69,10 +69,12 @@ CREATE TRIGGER IF NOT EXISTS items_au AFTER UPDATE ON items BEGIN
     VALUES (new.id, new.title, new.content, new.author);
 END;
 
--- Tags for organization
+-- Tags for organization. `kind` distinguishes curated 'category' tags
+-- (the composer's autocomplete list) from free-form 'ad-hoc' tags.
 CREATE TABLE IF NOT EXISTS tags (
     id INTEGER PRIMARY KEY,
-    name TEXT UNIQUE NOT NULL
+    name TEXT UNIQUE NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'ad-hoc'
 );
 
 CREATE TABLE IF NOT EXISTS item_tags (
@@ -334,6 +336,16 @@ MIGRATIONS = [
         );
         """,
     ),
+    (
+        10,
+        "Add tags.kind column (category vs ad-hoc)",
+        # Note: ALTER TABLE ADD COLUMN tags.kind is handled in apply_migrations()
+        # because SQLite has no IF NOT EXISTS for ALTER TABLE.
+        # The column is purely additive — existing rows get the DEFAULT 'ad-hoc'.
+        # No data backfill in the migration: which tags are categories is a
+        # user-curation decision, not a schema concern.
+        "",
+    ),
 ]
 
 
@@ -422,6 +434,8 @@ def apply_migrations(conn: sqlite3.Connection) -> int:
                 conn.execute("ALTER TABLE items ADD COLUMN parent_id INTEGER")
             if version == 9 and not _column_exists(conn, "item_history", "parent_id_old"):
                 conn.execute("ALTER TABLE item_history ADD COLUMN parent_id_old INTEGER")
+            if version == 10 and not _column_exists(conn, "tags", "kind"):
+                conn.execute("ALTER TABLE tags ADD COLUMN kind TEXT NOT NULL DEFAULT 'ad-hoc'")
             conn.executescript(sql)
             set_schema_version(conn, version)
             conn.commit()

--- a/packages/lestash/tests/test_history.py
+++ b/packages/lestash/tests/test_history.py
@@ -37,6 +37,18 @@ class TestSchemaMigrations:
             # Version should still be current
             assert get_schema_version(conn) == SCHEMA_VERSION
 
+    def test_tags_kind_column_exists_with_default(self, test_db):
+        """Migration 10: tags.kind column exists and defaults to 'ad-hoc'."""
+        with get_connection(test_db) as conn:
+            cols = {row[1]: row for row in conn.execute("PRAGMA table_info(tags)")}
+            assert "kind" in cols
+            conn.execute("INSERT INTO tags (name) VALUES ('foo')")
+            row = conn.execute("SELECT kind FROM tags WHERE name='foo'").fetchone()
+            assert row[0] == "ad-hoc"
+            conn.execute("INSERT INTO tags (name, kind) VALUES ('bar', 'category')")
+            row = conn.execute("SELECT kind FROM tags WHERE name='bar'").fetchone()
+            assert row[0] == "category"
+
     def test_migrations_applied_on_connection(self, test_db):
         """get_connection should automatically apply pending migrations."""
         # Manually reset version to 0 (simulating old database)

--- a/scripts/linkedin_cache_engaged_posts.py
+++ b/scripts/linkedin_cache_engaged_posts.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Backfill `post_cache` for every post Matt has engaged with (liked, commented
+on, reposted), so the UI can render his engagement feed with author + preview
+instead of opaque URN stubs.
+
+Walks three sources of engagement-target URNs:
+  - metadata.reacted_to                                  (likes)
+  - metadata.commented_on                                (comments)
+  - metadata.raw.activity.repostedContent.ugcPost        (reposts)
+
+For each distinct, not-yet-cached URN, fetches the unauthenticated
+/feed/update preview, extracts og:url (canonical URL + author handle),
+og:title (author display name + post title), and og:description (preview text),
+and upserts a `post_cache` row with source='feed_preview'.
+
+Read-only without --write. With --write, upserts via `upsert_post_cache`,
+which COALESCEs against existing values — your 10 manually-curated rows are
+preserved.
+
+ToS caveat: this scrapes the public preview. No auth bypass. Rate-limited at
+1s/URL; stops on 429.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Reuse the parser from the per-URL lookup script
+from linkedin_url_lookup import fetch_preview  # type: ignore
+
+DB_PATH = Path.home() / ".config/lestash/lestash.db"
+
+# Extract the underlying activity ID from a urn:li:comment:(activity:X,Y) compound URN
+COMMENT_ACTIVITY_RE = re.compile(r"urn:li:comment:\(activity:(\d+),\d+\)")
+
+
+def collect_target_urns(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    """Return distinct engagement-target URNs grouped by engagement kind."""
+    queries = {
+        "reacted_to": """
+            SELECT DISTINCT json_extract(metadata, '$.reacted_to')
+            FROM items
+            WHERE source_type='linkedin' AND is_own_content=1
+              AND json_extract(metadata, '$.resource_name')='socialActions/likes'
+              AND json_extract(metadata, '$.reacted_to') IS NOT NULL
+        """,
+        "commented_on": """
+            SELECT DISTINCT json_extract(metadata, '$.commented_on')
+            FROM items
+            WHERE source_type='linkedin' AND is_own_content=1
+              AND json_extract(metadata, '$.resource_name')='socialActions/comments'
+              AND json_extract(metadata, '$.commented_on') IS NOT NULL
+        """,
+        "reposted_ugc": """
+            SELECT DISTINCT json_extract(metadata, '$.raw.activity.repostedContent.ugcPost')
+            FROM items
+            WHERE source_type='linkedin' AND is_own_content=1
+              AND json_extract(metadata, '$.resource_name')='instantReposts'
+              AND json_extract(metadata, '$.raw.activity.repostedContent.ugcPost') IS NOT NULL
+        """,
+    }
+    return {
+        kind: [r[0] for r in conn.execute(sql).fetchall()]
+        for kind, sql in queries.items()
+    }
+
+
+def urn_to_fetchable_id(urn: str) -> tuple[str, str] | None:
+    """Map an engagement-target URN to (kind, id) suitable for /feed/update/<kind>:<id>/.
+
+    Returns None for URN shapes /feed/update can't open (groupPost is private to
+    members of the group; rare in this corpus).
+    """
+    if urn.startswith("urn:li:activity:"):
+        return ("activity", urn.split(":")[-1])
+    if urn.startswith("urn:li:ugcPost:"):
+        return ("ugcPost", urn.split(":")[-1])
+    m = COMMENT_ACTIVITY_RE.match(urn)
+    if m:
+        # Comment URNs: fetch the parent activity, but we'll still upsert under the
+        # original (compound) URN so joins against metadata.commented_on work.
+        return ("activity", m.group(1))
+    # groupPost and other shapes — skip
+    return None
+
+
+def already_cached_urns(conn: sqlite3.Connection) -> set[str]:
+    return {row[0] for row in conn.execute("SELECT urn FROM post_cache").fetchall()}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument(
+        "--write",
+        action="store_true",
+        help="Actually upsert post_cache rows. Without this, the script just "
+        "reports the scope and exits.",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Max URNs to fetch this run (0 = all).",
+    )
+    ap.add_argument(
+        "--kinds",
+        nargs="+",
+        choices=["reacted_to", "commented_on", "reposted_ugc"],
+        default=["reacted_to", "commented_on", "reposted_ugc"],
+        help="Which engagement kinds to process.",
+    )
+    ap.add_argument(
+        "--sleep",
+        type=float,
+        default=1.0,
+        help="Seconds between fetches.",
+    )
+    args = ap.parse_args()
+
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    try:
+        targets = collect_target_urns(conn)
+        cached = already_cached_urns(conn)
+
+        # Build a single deduplicated worklist preserving kind annotations
+        seen: set[str] = set()
+        worklist: list[tuple[str, str]] = []  # (urn, kind)
+        skipped_unfetchable = 0
+        for kind in args.kinds:
+            for urn in targets[kind]:
+                if urn in seen or urn in cached:
+                    continue
+                if urn_to_fetchable_id(urn) is None:
+                    skipped_unfetchable += 1
+                    continue
+                seen.add(urn)
+                worklist.append((urn, kind))
+
+        # Summary before work starts
+        print("# scope")
+        for kind in args.kinds:
+            print(f"  {kind:14s} distinct in DB: {len(targets[kind])}")
+        print(f"  already in post_cache       : {len(cached)}")
+        print(f"  skipped (unfetchable URN)   : {skipped_unfetchable}")
+        print(f"  to fetch this run           : {len(worklist)}"
+              + (f"  (--limit {args.limit})" if args.limit else ""))
+        if args.limit:
+            worklist = worklist[: args.limit]
+
+        if not args.write:
+            print(f"\n# Dry run. Re-run with --write to fetch + cache "
+                  f"{len(worklist)} URN(s). Estimated wall-time: "
+                  f"~{int(len(worklist) * args.sleep)}s.")
+            return 0
+
+        from lestash.core.database import upsert_post_cache
+
+        ok = miss = err = 0
+        for i, (urn, kind) in enumerate(worklist, 1):
+            kind_id = urn_to_fetchable_id(urn)
+            assert kind_id is not None  # filtered above
+            _, fid = kind_id
+            preview = fetch_preview(fid)
+            status = preview.get("status")
+            if status == "ERR":
+                err += 1
+                print(f"[{i}/{len(worklist)}] ERR {preview.get('error','?')} {urn}")
+            elif status != "200":
+                miss += 1
+                print(f"[{i}/{len(worklist)}] {status} {urn}")
+            else:
+                og_url = preview.get("og_url") or ""
+                # When the underlying post is deleted/private/inaccessible, LinkedIn
+                # serves the generic home page meta. og:url won't contain /posts/.
+                # Skip these — better to leave the URN uncached than to fill it with
+                # "500 million+ members | Manage your professional identity…".
+                if "/posts/" not in og_url:
+                    miss += 1
+                    print(f"[{i}/{len(worklist)}] generic-fallback {urn}")
+                    time.sleep(args.sleep)
+                    continue
+                upsert_post_cache(
+                    conn,
+                    urn=urn,
+                    author_name=preview.get("author"),
+                    content_preview=preview.get("description"),
+                    url=og_url,
+                    source="feed_preview",
+                )
+                ok += 1
+                if i % 20 == 0 or i == len(worklist):
+                    print(f"[{i}/{len(worklist)}] ok={ok} miss={miss} err={err}")
+            time.sleep(args.sleep)
+
+        conn.commit()
+        print(f"\n# done. ok={ok}  miss={miss}  err={err}")
+        print(f"# post_cache rows after: "
+              f"{conn.execute('SELECT COUNT(*) FROM post_cache').fetchone()[0]}")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/linkedin_link_postcache_authors.py
+++ b/scripts/linkedin_link_postcache_authors.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Cross-link post_cache.author rows with person_profiles, and apply a curated
+handle → human-name map.
+
+Three passes over each post_cache row where author_urn IS NULL:
+
+  1. If author_name looks like a known LinkedIn handle from CURATED_HANDLES,
+     upgrade it to the human name.
+  2. Exact case-insensitive match: author_name == person_profiles.display_name
+     → set author_urn from that row.
+  3. Normalised handle match: when author_name is still a handle shape
+     ("mike-schoonover"), compare against normalise(display_name) for every
+     person_profile, and on a hit upgrade BOTH author_name → display_name
+     AND author_urn.
+
+Read-only without --write. With --write, runs the UPDATEs in one transaction.
+
+Idempotent — re-running only touches rows where author_urn is still NULL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sqlite3
+import unicodedata
+from pathlib import Path
+
+DB_PATH = Path.home() / ".config/lestash/lestash.db"
+
+# Curated LinkedIn handle → human display name. Extend over time; the script
+# does nothing destructive if a handle here is wrong — it only upgrades rows
+# whose current author_name exactly equals the handle.
+CURATED_HANDLES: dict[str, str] = {
+    "gradybooch": "Grady Booch",
+    "gary-marcus-b6384b4": "Gary Marcus",
+    "hillel-wayne": "Hillel Wayne",
+    "jasongorman": "Jason Gorman",
+    "patrickdebois": "Patrick Debois",
+    "johncrickett": "John Crickett",
+    "yann-lecun": "Yann LeCun",
+    "danielhanchen": "Daniel Hanchen",
+    "nicholasbs": "Nicholas Bergson-Shilcock",
+    "veit-heller": "Veit Heller",
+    "cadrlife": "Ray Myers",
+    "robnewby": "Rob Newby",
+}
+
+HANDLE_SHAPE_RE = re.compile(r"^[a-z0-9][a-z0-9\-]*$")  # lowercase, hyphens, no spaces
+
+
+def normalise(s: str) -> str:
+    """Diacritic-stripped, lowercase, spaces→hyphens. Used for handle ↔ name match."""
+    no_accents = "".join(
+        c for c in unicodedata.normalize("NFKD", s) if not unicodedata.combining(c)
+    )
+    return re.sub(r"\s+", "-", no_accents.lower().strip())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--write", action="store_true", help="Apply UPDATEs to post_cache.")
+    args = ap.parse_args()
+
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        people = conn.execute(
+            "SELECT urn, display_name FROM person_profiles WHERE display_name IS NOT NULL"
+        ).fetchall()
+        by_name_ci = {name.lower(): (urn, name) for urn, name in people}
+        by_normalised = {normalise(name): (urn, name) for urn, name in people}
+
+        rows = conn.execute(
+            """
+            SELECT urn, author_name FROM post_cache
+            WHERE author_urn IS NULL AND author_name IS NOT NULL AND author_name != ''
+            """
+        ).fetchall()
+
+        updates: list[tuple[str, str | None, str]] = []  # (new_name, new_urn, post_urn)
+        handle_lifts = exact_hits = normalised_hits = 0
+
+        for post_urn, author_name in rows:
+            new_name = author_name
+            new_urn: str | None = None
+            reason = None
+
+            if author_name in CURATED_HANDLES:
+                new_name = CURATED_HANDLES[author_name]
+                handle_lifts += 1
+                reason = "curated"
+
+            hit = by_name_ci.get(new_name.lower())
+            if hit:
+                new_urn, new_name = hit
+                exact_hits += 1
+                reason = (reason + "+exact") if reason else "exact"
+            elif HANDLE_SHAPE_RE.match(new_name):
+                hit = by_normalised.get(new_name)
+                if hit:
+                    new_urn, new_name = hit
+                    normalised_hits += 1
+                    reason = (reason + "+normalised") if reason else "normalised"
+
+            if new_name != author_name or new_urn is not None:
+                updates.append((new_name, new_urn, post_urn))
+                print(f"  {reason:24s}  {author_name!r:38s} → {new_name!r}"
+                      + (f"  [{new_urn}]" if new_urn else ""))
+
+        print()
+        print(f"# rows considered            : {len(rows)}")
+        print(f"#   curated handle lifts     : {handle_lifts}")
+        print(f"#   exact name matches       : {exact_hits}")
+        print(f"#   normalised handle matches: {normalised_hits}")
+        print(f"# rows to update             : {len(updates)}")
+
+        if not args.write:
+            print("\n# Dry run. Re-run with --write to apply.")
+            return 0
+
+        with conn:
+            for new_name, new_urn, post_urn in updates:
+                conn.execute(
+                    "UPDATE post_cache SET author_name = ?, author_urn = COALESCE(?, author_urn) WHERE urn = ?",
+                    (new_name, new_urn, post_urn),
+                )
+        print(f"\n# applied {len(updates)} UPDATE(s).")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/linkedin_resolve_authors.py
+++ b/scripts/linkedin_resolve_authors.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Resolve LinkedIn person URNs → human names from data already in the DB.
+
+LinkedIn comments use a `MemberAttributedEntity` annotation: when a commenter
+@-mentions someone, the message text contains the rendered name and an
+attribute records the mention range + the URN. That means every @-mention
+across the DB is a URN→name pair we can harvest without any fetch.
+
+This script walks every linkedin item, collects MemberAttributedEntity
+annotations, and prints:
+  1. A URN→name map
+  2. The top N person URNs by activity count in `items.author`, resolved to
+     names where possible
+  3. Unresolved URNs (no name found anywhere) so you can decide if they're
+     worth fetching one-by-one with linkedin_url_lookup.py
+
+Read-only on the DB.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections import Counter, defaultdict
+from pathlib import Path
+
+DB_PATH = Path.home() / ".config/lestash/lestash.db"
+
+
+def walk_attributes(meta_raw: str) -> list[tuple[str, str]]:
+    """Yield (urn, name) pairs from a metadata JSON blob.
+
+    Looks at metadata.raw.activity.message: an `attributes` list of
+    {start, length, value: {"com.linkedin.common.MemberAttributedEntity":
+    {"member": URN}}}, and slices the name out of `text` using start+length.
+    """
+    out: list[tuple[str, str]] = []
+    try:
+        meta = json.loads(meta_raw)
+    except (TypeError, json.JSONDecodeError):
+        return out
+    msg = (
+        meta.get("raw", {})
+        .get("activity", {})
+        .get("message")
+    )
+    if not isinstance(msg, dict):  # ugcPosts have message as a plain string
+        return out
+    text = msg.get("text") or ""
+    attrs = msg.get("attributes") or []
+    if not text or not attrs:
+        return out
+    for a in attrs:
+        try:
+            start = int(a["start"])
+            length = int(a["length"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        val = a.get("value") or {}
+        entity = val.get("com.linkedin.common.MemberAttributedEntity") or {}
+        urn = entity.get("member")
+        if not urn or not isinstance(urn, str):
+            continue
+        if start < 0 or length <= 0 or start + length > len(text):
+            continue
+        name = text[start : start + length].strip()
+        if name:
+            out.append((urn, name))
+    return out
+
+
+def harvest_names(conn: sqlite3.Connection) -> dict[str, str]:
+    """Collect URN→name across the whole DB. Picks the most common name per URN."""
+    name_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    cursor = conn.execute(
+        "SELECT metadata FROM items WHERE source_type='linkedin' AND metadata IS NOT NULL"
+    )
+    for (meta_raw,) in cursor:
+        for urn, name in walk_attributes(meta_raw):
+            name_counts[urn][name] += 1
+    return {urn: counts.most_common(1)[0][0] for urn, counts in name_counts.items()}
+
+
+def top_authors_with_names(
+    conn: sqlite3.Connection, urn_to_name: dict[str, str], top_n: int = 25
+) -> list[tuple[str, int, str | None]]:
+    rows = conn.execute(
+        """
+        SELECT author, COUNT(*) AS n
+        FROM items
+        WHERE source_type='linkedin' AND author IS NOT NULL AND author != ''
+        GROUP BY author
+        ORDER BY n DESC
+        """
+    ).fetchall()
+    return [(urn, n, urn_to_name.get(urn)) for urn, n in rows[:top_n]]
+
+
+def main() -> int:
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        urn_to_name = harvest_names(conn)
+        print(f"# URN→name pairs harvested from @-mentions: {len(urn_to_name)}\n")
+
+        top = top_authors_with_names(conn, urn_to_name, top_n=30)
+        print("## Top 30 person URNs by activity count in items.author")
+        print(f"{'rank':>4}  {'count':>5}  urn                            name")
+        for i, (urn, n, name) in enumerate(top, 1):
+            print(f"{i:>4}  {n:>5}  {urn:<30} {name or '— unresolved —'}")
+
+        unresolved = [(urn, n) for urn, n, name in top if not name]
+        if unresolved:
+            print(f"\n## Unresolved in the top 30: {len(unresolved)}")
+            print("Run linkedin_url_lookup.py against any post URLs you know they wrote.")
+
+        print(f"\n## Sample of 20 URN→name pairs harvested:")
+        for urn, name in list(urn_to_name.items())[:20]:
+            print(f"  {urn:<30} {name}")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/linkedin_resolve_authors.py
+++ b/scripts/linkedin_resolve_authors.py
@@ -150,6 +150,12 @@ def main() -> int:
         "with source='mention'. Existing rows are preserved.",
     )
     ap.add_argument("--top", type=int, default=30, help="Top-N person URNs to display")
+    ap.add_argument(
+        "--dms",
+        action="store_true",
+        help="Print unresolved person URNs that sent DMs, with body snippets, "
+        "so you can recognise them and add via /api/profiles.",
+    )
     args = ap.parse_args()
 
     conn = sqlite3.connect(DB_PATH)
@@ -179,6 +185,40 @@ def main() -> int:
         if unresolved:
             print(f"\n## Unresolved in the top {args.top}: {len(unresolved)}")
             print("Run linkedin_url_lookup.py against any post URLs you know they wrote.")
+
+        if args.dms:
+            print("\n## Unresolved DM senders (most recent body snippets)\n")
+            dm_rows = conn.execute(
+                """
+                SELECT author, COUNT(*) AS n
+                FROM items
+                WHERE source_type='linkedin'
+                  AND json_extract(metadata, '$.resource_name')='messages'
+                  AND author LIKE 'urn:li:person:%'
+                GROUP BY author ORDER BY n DESC
+                """
+            ).fetchall()
+            shown = 0
+            for urn, n in dm_rows:
+                if urn in urn_to_name:
+                    continue
+                shown += 1
+                print(f"### {urn}  ({n} DMs)")
+                snippets = conn.execute(
+                    """
+                    SELECT substr(replace(content, char(10), ' '), 1, 180)
+                    FROM items
+                    WHERE source_type='linkedin' AND author = ?
+                      AND json_extract(metadata, '$.resource_name')='messages'
+                    ORDER BY created_at DESC LIMIT 2
+                    """,
+                    (urn,),
+                ).fetchall()
+                for (snip,) in snippets:
+                    print(f"  - {snip}")
+                print()
+            if not shown:
+                print("  (none — all DM senders are already resolved)")
 
         if args.write:
             from lestash.core.database import upsert_person_profile

--- a/scripts/linkedin_resolve_authors.py
+++ b/scripts/linkedin_resolve_authors.py
@@ -87,8 +87,35 @@ def load_person_profiles(conn: sqlite3.Connection) -> dict[str, str]:
     return {urn: name for urn, name in rows}
 
 
+def harvest_impersonator_bridges(conn: sqlite3.Connection) -> dict[str, set[str]]:
+    """For company-URN actors, map company URN → set of impersonator (admin) person URNs.
+
+    LinkedIn likes/reactions done "as the company" carry the human URN in
+    `raw.activity.created.impersonator`. This lets us label a company-URN
+    actor with the human(s) who admin it without inventing a person/company
+    relationship in person_profiles.
+    """
+    rows = conn.execute(
+        """
+        SELECT DISTINCT author,
+               json_extract(metadata, '$.raw.activity.created.impersonator')
+        FROM items
+        WHERE source_type='linkedin'
+          AND author LIKE 'urn:li:company:%'
+          AND json_extract(metadata, '$.raw.activity.created.impersonator') IS NOT NULL
+        """
+    ).fetchall()
+    bridges: dict[str, set[str]] = defaultdict(set)
+    for company_urn, impersonator_urn in rows:
+        bridges[company_urn].add(impersonator_urn)
+    return bridges
+
+
 def top_authors_with_names(
-    conn: sqlite3.Connection, urn_to_name: dict[str, str], top_n: int = 25
+    conn: sqlite3.Connection,
+    urn_to_name: dict[str, str],
+    impersonator_bridges: dict[str, set[str]],
+    top_n: int = 25,
 ) -> list[tuple[str, int, str | None]]:
     rows = conn.execute(
         """
@@ -99,7 +126,19 @@ def top_authors_with_names(
         ORDER BY n DESC
         """
     ).fetchall()
-    return [(urn, n, urn_to_name.get(urn)) for urn, n in rows[:top_n]]
+
+    def resolve(urn: str) -> str | None:
+        direct = urn_to_name.get(urn)
+        if direct:
+            return direct
+        if urn in impersonator_bridges:
+            admin_names = sorted(
+                {urn_to_name.get(p) or p for p in impersonator_bridges[urn]}
+            )
+            return f"(company · admin: {', '.join(admin_names)})"
+        return None
+
+    return [(urn, n, resolve(urn)) for urn, n in rows[:top_n]]
 
 
 def main() -> int:
@@ -117,6 +156,7 @@ def main() -> int:
     try:
         from_profiles = load_person_profiles(conn)
         from_mentions = harvest_names_from_mentions(conn)
+        impersonator_bridges = harvest_impersonator_bridges(conn)
         # person_profiles wins over @-mention disagreements (manual review > heuristic)
         urn_to_name: dict[str, str] = {**from_mentions, **from_profiles}
 
@@ -126,9 +166,10 @@ def main() -> int:
         print(f"# person_profiles rows loaded     : {len(from_profiles)}")
         print(f"# @-mention pairs harvested       : {len(from_mentions)}")
         print(f"# new pairs from mentions (no row): {len(new_from_mentions)}")
-        print(f"# merged URN→name map size        : {len(urn_to_name)}\n")
+        print(f"# merged URN→name map size        : {len(urn_to_name)}")
+        print(f"# company-URN → admin bridges     : {len(impersonator_bridges)}\n")
 
-        top = top_authors_with_names(conn, urn_to_name, top_n=args.top)
+        top = top_authors_with_names(conn, urn_to_name, impersonator_bridges, top_n=args.top)
         print(f"## Top {args.top} person URNs by activity count in items.author")
         print(f"{'rank':>4}  {'count':>5}  urn                            name")
         for i, (urn, n, name) in enumerate(top, 1):

--- a/scripts/linkedin_resolve_authors.py
+++ b/scripts/linkedin_resolve_authors.py
@@ -1,24 +1,22 @@
 #!/usr/bin/env python3
 """Resolve LinkedIn person URNs → human names from data already in the DB.
 
-LinkedIn comments use a `MemberAttributedEntity` annotation: when a commenter
-@-mentions someone, the message text contains the rendered name and an
-attribute records the mention range + the URN. That means every @-mention
-across the DB is a URN→name pair we can harvest without any fetch.
+Two name sources are merged:
+  1. `person_profiles` table — existing URN → display_name rows (sources:
+     'manual', 'web', 'api', ...). Authoritative when present.
+  2. `MemberAttributedEntity` annotations on comments — when someone
+     @-mentions a person, the rendered name and URN are both in the
+     metadata. Harvest gives URN → name pairs for free, no fetch.
 
-This script walks every linkedin item, collects MemberAttributedEntity
-annotations, and prints:
-  1. A URN→name map
-  2. The top N person URNs by activity count in `items.author`, resolved to
-     names where possible
-  3. Unresolved URNs (no name found anywhere) so you can decide if they're
-     worth fetching one-by-one with linkedin_url_lookup.py
-
-Read-only on the DB.
+Without --write: prints a report. The on-disk DB is not modified.
+With    --write: upserts any newly-discovered pairs into `person_profiles`
+                 with source='mention'. Existing rows are preserved
+                 (COALESCE in upsert_person_profile).
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import sqlite3
 from collections import Counter, defaultdict
@@ -69,8 +67,8 @@ def walk_attributes(meta_raw: str) -> list[tuple[str, str]]:
     return out
 
 
-def harvest_names(conn: sqlite3.Connection) -> dict[str, str]:
-    """Collect URN→name across the whole DB. Picks the most common name per URN."""
+def harvest_names_from_mentions(conn: sqlite3.Connection) -> dict[str, str]:
+    """Collect URN→name across the whole DB from @-mentions. Most common name per URN."""
     name_counts: dict[str, Counter[str]] = defaultdict(Counter)
     cursor = conn.execute(
         "SELECT metadata FROM items WHERE source_type='linkedin' AND metadata IS NOT NULL"
@@ -79,6 +77,14 @@ def harvest_names(conn: sqlite3.Connection) -> dict[str, str]:
         for urn, name in walk_attributes(meta_raw):
             name_counts[urn][name] += 1
     return {urn: counts.most_common(1)[0][0] for urn, counts in name_counts.items()}
+
+
+def load_person_profiles(conn: sqlite3.Connection) -> dict[str, str]:
+    """Read the existing URN → display_name map from person_profiles."""
+    rows = conn.execute(
+        "SELECT urn, display_name FROM person_profiles WHERE display_name IS NOT NULL"
+    ).fetchall()
+    return {urn: name for urn, name in rows}
 
 
 def top_authors_with_names(
@@ -97,25 +103,52 @@ def top_authors_with_names(
 
 
 def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument(
+        "--write",
+        action="store_true",
+        help="Upsert newly-discovered (URN, name) pairs into person_profiles "
+        "with source='mention'. Existing rows are preserved.",
+    )
+    ap.add_argument("--top", type=int, default=30, help="Top-N person URNs to display")
+    args = ap.parse_args()
+
     conn = sqlite3.connect(DB_PATH)
     try:
-        urn_to_name = harvest_names(conn)
-        print(f"# URN→name pairs harvested from @-mentions: {len(urn_to_name)}\n")
+        from_profiles = load_person_profiles(conn)
+        from_mentions = harvest_names_from_mentions(conn)
+        # person_profiles wins over @-mention disagreements (manual review > heuristic)
+        urn_to_name: dict[str, str] = {**from_mentions, **from_profiles}
 
-        top = top_authors_with_names(conn, urn_to_name, top_n=30)
-        print("## Top 30 person URNs by activity count in items.author")
+        new_from_mentions = {
+            urn: name for urn, name in from_mentions.items() if urn not in from_profiles
+        }
+        print(f"# person_profiles rows loaded     : {len(from_profiles)}")
+        print(f"# @-mention pairs harvested       : {len(from_mentions)}")
+        print(f"# new pairs from mentions (no row): {len(new_from_mentions)}")
+        print(f"# merged URN→name map size        : {len(urn_to_name)}\n")
+
+        top = top_authors_with_names(conn, urn_to_name, top_n=args.top)
+        print(f"## Top {args.top} person URNs by activity count in items.author")
         print(f"{'rank':>4}  {'count':>5}  urn                            name")
         for i, (urn, n, name) in enumerate(top, 1):
             print(f"{i:>4}  {n:>5}  {urn:<30} {name or '— unresolved —'}")
 
         unresolved = [(urn, n) for urn, n, name in top if not name]
         if unresolved:
-            print(f"\n## Unresolved in the top 30: {len(unresolved)}")
+            print(f"\n## Unresolved in the top {args.top}: {len(unresolved)}")
             print("Run linkedin_url_lookup.py against any post URLs you know they wrote.")
 
-        print(f"\n## Sample of 20 URN→name pairs harvested:")
-        for urn, name in list(urn_to_name.items())[:20]:
-            print(f"  {urn:<30} {name}")
+        if args.write:
+            from lestash.core.database import upsert_person_profile
+            written = 0
+            for urn, name in new_from_mentions.items():
+                upsert_person_profile(conn, urn, display_name=name, source="mention")
+                written += 1
+            print(f"\n## Wrote {written} new rows to person_profiles (source='mention')")
+        else:
+            print(f"\n## Dry run. Re-run with --write to upsert "
+                  f"{len(new_from_mentions)} new pair(s) into person_profiles.")
         return 0
     finally:
         conn.close()

--- a/scripts/linkedin_url_lookup.py
+++ b/scripts/linkedin_url_lookup.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""One-shot: paste LinkedIn post URLs, get author + any matching engagement in the LeStash DB.
+
+Usage:
+    echo "https://www.linkedin.com/posts/benedictevans_...-activity-7417910935379480576-iyKE" \
+        | scripts/linkedin_url_lookup.py
+    scripts/linkedin_url_lookup.py URL [URL ...]
+
+Why this script exists: LinkedIn's /rest/posts/{urn} endpoint is gated to Marketing
+Partners (see ux-compose-and-categories design discussion). Self-serve tokens
+(r_dma_portability_self_serve, w_member_social) can't fetch arbitrary posts.
+
+But /feed/update/urn:li:activity:<id>/ serves an unauthenticated public preview
+with og:title + og:description populated. That's enough to identify the author
+and check whether the LeStash DB shows engagement against that activity URN.
+
+ToS caveat: this scrapes a public preview, no auth bypass. Don't rate-grind.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+from urllib.request import Request, urlopen
+
+DB_PATH = Path.home() / ".config/lestash/lestash.db"
+UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0 Safari/537.36"
+
+ACTIVITY_URN_RE = re.compile(r"urn:li:activity:(\d+)")
+ACTIVITY_FROM_SLUG_RE = re.compile(r"activity-(\d+)")
+OG_TITLE_RE = re.compile(r'<meta property="og:title" content="([^"]+)"')
+OG_DESC_RE = re.compile(r'<meta property="og:description" content="([^"]+)"')
+# og:title pattern: "<title> | <Author Name> posted on the topic | LinkedIn"
+AUTHOR_FROM_TITLE_RE = re.compile(r"\|\s*([^|]+?)\s+posted on", re.IGNORECASE)
+
+
+def extract_activity_id(url_or_urn: str) -> str | None:
+    """Pull a 19-digit activity ID from a URL slug, /feed/update path, or a URN."""
+    s = url_or_urn.strip()
+    for r in (ACTIVITY_URN_RE, ACTIVITY_FROM_SLUG_RE):
+        m = r.search(s)
+        if m:
+            return m.group(1)
+    return None
+
+
+def fetch_preview(activity_id: str) -> dict[str, str | None]:
+    """Fetch /feed/update/urn:li:activity:<id>/ unauthenticated; return og fields."""
+    url = f"https://www.linkedin.com/feed/update/urn:li:activity:{activity_id}/"
+    req = Request(url, headers={"User-Agent": UA})
+    try:
+        with urlopen(req, timeout=15) as resp:
+            html = resp.read().decode("utf-8", errors="replace")
+            status = resp.status
+    except Exception as e:
+        return {"status": "ERR", "error": str(e), "title": None, "author": None, "description": None}
+
+    title = (OG_TITLE_RE.search(html) or [None, None])[1] if OG_TITLE_RE.search(html) else None
+    desc = (OG_DESC_RE.search(html) or [None, None])[1] if OG_DESC_RE.search(html) else None
+    author = None
+    if title:
+        # HTML-decode the apostrophe entity LinkedIn uses, then match
+        title_clean = title.replace("&amp;#39;", "'").replace("&#39;", "'")
+        m = AUTHOR_FROM_TITLE_RE.search(title_clean)
+        if m:
+            author = m.group(1).strip()
+    return {"status": str(status), "title": title, "author": author, "description": desc}
+
+
+def query_db_for_engagement(activity_id: str) -> list[dict[str, object]]:
+    """Find every is_own_content=1 LinkedIn item whose target URN matches this activity ID."""
+    urn = f"urn:li:activity:{activity_id}"
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+              id,
+              substr(created_at, 1, 10)                                  AS date,
+              json_extract(metadata, '$.resource_name')                  AS kind,
+              substr(replace(content, char(10), ' '), 1, 200)            AS snippet,
+              json_extract(metadata, '$.reaction_type')                  AS reaction
+            FROM items
+            WHERE source_type = 'linkedin'
+              AND is_own_content = 1
+              AND (
+                json_extract(metadata, '$.commented_on') = :urn
+                OR json_extract(metadata, '$.reacted_to') = :urn
+                OR json_extract(metadata, '$.raw.activity.repostedContent.ugcPost') = :urn
+              )
+            ORDER BY created_at DESC
+            """,
+            {"urn": urn},
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        {"item_id": r[0], "date": r[1], "kind": r[2], "snippet": r[3], "reaction": r[4]}
+        for r in rows
+    ]
+
+
+def process(urls: Iterable[str]) -> None:
+    seen: set[str] = set()
+    for raw in urls:
+        url = raw.strip()
+        if not url or url.startswith("#"):
+            continue
+        aid = extract_activity_id(url)
+        if not aid:
+            print(f"## {url}\n  ⚠ no activity ID found in URL\n")
+            continue
+        if aid in seen:
+            print(f"## activity {aid} (duplicate, skipped)\n")
+            continue
+        seen.add(aid)
+
+        preview = fetch_preview(aid)
+        hits = query_db_for_engagement(aid)
+
+        print(f"## activity {aid}")
+        print(f"  preview status: {preview['status']}")
+        print(f"  author        : {preview['author'] or '—'}")
+        if preview.get("title"):
+            print(f"  title         : {preview['title'][:120]}")
+        if preview.get("description"):
+            print(f"  description   : {preview['description'][:120]}")
+        if hits:
+            print(f"  ✓ {len(hits)} match(es) in LeStash DB:")
+            for h in hits:
+                kind = h["kind"]
+                react = f" [{h['reaction']}]" if h["reaction"] else ""
+                print(f"    - item {h['item_id']} · {h['date']} · {kind}{react}")
+                print(f"      {h['snippet']}")
+        else:
+            print("  · no engagement in DB")
+        print()
+        time.sleep(1.0)  # gentle on LinkedIn
+
+
+def main() -> int:
+    if not DB_PATH.exists():
+        print(f"DB not found at {DB_PATH}", file=sys.stderr)
+        return 2
+    if len(sys.argv) > 1:
+        process(sys.argv[1:])
+    else:
+        process(sys.stdin)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/linkedin_url_lookup.py
+++ b/scripts/linkedin_url_lookup.py
@@ -35,8 +35,14 @@ ACTIVITY_URN_RE = re.compile(r"urn:li:activity:(\d+)")
 ACTIVITY_FROM_SLUG_RE = re.compile(r"activity-(\d+)")
 OG_TITLE_RE = re.compile(r'<meta property="og:title" content="([^"]+)"')
 OG_DESC_RE = re.compile(r'<meta property="og:description" content="([^"]+)"')
-# og:title pattern: "<title> | <Author Name> posted on the topic | LinkedIn"
-AUTHOR_FROM_TITLE_RE = re.compile(r"\|\s*([^|]+?)\s+posted on", re.IGNORECASE)
+OG_URL_RE = re.compile(r'<meta property="og:url" content="([^"]+)"')
+# /posts/<handle>_<slug>-activity-<id>-<suffix>  — handle is the author's vanity URL
+HANDLE_FROM_OGURL_RE = re.compile(r"linkedin\.com/posts/([^_/]+)_")
+# Title shape A: "… | <Author> posted on the topic | LinkedIn"
+AUTHOR_POSTED_ON_RE = re.compile(r"\|\s*([^|]+?)\s+posted on", re.IGNORECASE)
+# Title shape B/C: "<title> [—|] <Author> | <Author> | N comments" — author appears as a
+# standalone pipe segment, typically TWICE. Pick the most-repeated short segment.
+PIPE_SEGMENT_RE = re.compile(r"\s*\|\s*")
 
 
 def extract_activity_id(url_or_urn: str) -> str | None:
@@ -60,16 +66,59 @@ def fetch_preview(activity_id: str) -> dict[str, str | None]:
     except Exception as e:
         return {"status": "ERR", "error": str(e), "title": None, "author": None, "description": None}
 
-    title = (OG_TITLE_RE.search(html) or [None, None])[1] if OG_TITLE_RE.search(html) else None
-    desc = (OG_DESC_RE.search(html) or [None, None])[1] if OG_DESC_RE.search(html) else None
-    author = None
-    if title:
-        # HTML-decode the apostrophe entity LinkedIn uses, then match
-        title_clean = title.replace("&amp;#39;", "'").replace("&#39;", "'")
-        m = AUTHOR_FROM_TITLE_RE.search(title_clean)
+    def _g(r: re.Pattern[str]) -> str | None:
+        m = r.search(html)
+        return m.group(1) if m else None
+
+    title = _g(OG_TITLE_RE)
+    desc = _g(OG_DESC_RE)
+    og_url = _g(OG_URL_RE)
+    handle = None
+    if og_url:
+        m = HANDLE_FROM_OGURL_RE.search(og_url)
         if m:
-            author = m.group(1).strip()
-    return {"status": str(status), "title": title, "author": author, "description": desc}
+            handle = m.group(1)
+    author = _extract_author(title, handle)
+    return {
+        "status": str(status),
+        "title": title,
+        "author": author,
+        "handle": handle,
+        "og_url": og_url,
+        "description": desc,
+    }
+
+
+def _extract_author(title: str | None, handle: str | None) -> str | None:
+    """Pull a human author name out of og:title, with og:url's handle as fallback."""
+    if title:
+        clean = title.replace("&amp;#39;", "'").replace("&#39;", "'").replace("&amp;", "&")
+        m = AUTHOR_POSTED_ON_RE.search(clean)
+        if m:
+            return m.group(1).strip()
+        # Pipe-segment heuristic: split, drop empties, drop suffixes like "N comments"
+        # and "LinkedIn", keep candidates that look like a person name (1-4 words).
+        segments = [s.strip() for s in PIPE_SEGMENT_RE.split(clean) if s.strip()]
+        cands = [
+            s for s in segments
+            if 1 <= len(s.split()) <= 4
+            and not s.lower().endswith("comments")
+            and not s.lower().endswith("reactions")
+            and s.lower() != "linkedin"
+        ]
+        # Prefer one that appears more than once (author is repeated in B/C forms)
+        for s in cands:
+            if cands.count(s) >= 2:
+                return s
+        # Fallback to the em-dash-then-name pattern: "<title> — <Name>"
+        for sep in (" — ", " – ", " - "):
+            if sep in clean:
+                tail = clean.split(sep, 1)[1]
+                tail_first = PIPE_SEGMENT_RE.split(tail, 1)[0].strip()
+                if 1 <= len(tail_first.split()) <= 4:
+                    return tail_first
+    # Last resort: derive from the URL handle (e.g. "benedictevans" → "benedictevans")
+    return handle
 
 
 def query_db_for_engagement(activity_id: str) -> list[dict[str, object]]:
@@ -126,6 +175,8 @@ def process(urls: Iterable[str]) -> None:
         print(f"## activity {aid}")
         print(f"  preview status: {preview['status']}")
         print(f"  author        : {preview['author'] or '—'}")
+        if preview.get("handle"):
+            print(f"  handle        : {preview['handle']}")
         if preview.get("title"):
             print(f"  title         : {preview['title'][:120]}")
         if preview.get("description"):


### PR DESCRIPTION
## Summary

Design doc for three UX jobs the current app doesn't (or barely) supports:

- **Publish a saved item to micro.blog** — the `lestash-microblog` plugin is read-only today; LinkedIn already proves the publish pattern.
- **Fix YouTube embed rendering** — `spacex-ipo-imminent.html` shows `[youtu.be/…](…)` which micro.blog won't auto-embed. micro.blog only embeds bare URLs on their own line. The compose pipeline should produce the embed-friendly form.
- **Make categories fast** — "Sophie's work" should take seconds. No autocomplete / no bulk / no save-filter-as-category today.

## What's in the doc

- Surface map of current UI verified against `app/src/index.html` and plugin code
- Compose modal mock + per-source prefill rules
- Three quick-category paths: save-filter (smart collection), typeahead, bulk-tag
- Mermaid component diagram + 4 sequence flows (publish, typeahead, bulk-tag, smart collection)
- ERD + two new tables: `syndications` (round-trip publish records) and `collections.kind/filter_spec` (smart collections)
- New `Publisher` Protocol (LinkedIn migrates to it, micro.blog implements from day one)
- Canon-TDD test lists driving interface shape (`Publisher`, `EmbedRenderer`, tag autocomplete, bulk-tag, smart collections)
- 14-slice roadmap, each independently shippable

## Key design calls worth review

1. YouTube bug is in the **compose pipeline**, not rendering — lint pass + preview catch wrapped-link-vs-bare-URL before publish.
2. Tags and collections both stay. "Sophie's work" wants to be a **smart collection**, not a tag.
3. `Publisher` is a **Protocol**, not a base class — low-coupling adoption path for the existing LinkedIn code.
4. `lint()` is **sync + pure** — the test list forced this; can run on every keystroke.
5. Three distinct publish exceptions (`AlreadyPublished` / `PublishRejected` / `PublishFailed`) — collapsing to one would lose calling-code distinctions the test list already requires.

## Test plan

- [ ] Read `docs/ux-compose-and-categories-design.md` end-to-end
- [ ] Check mermaid diagrams render on GitHub
- [ ] Validate the YouTube embed rule against a real micro.blog post (paste bare URL, observe auto-embed)
- [ ] Confirm "tags + collections + smart collections" model matches your mental model — push back if it feels over/under-engineered
- [ ] Sanity-check the 14-slice ordering: slices 1–4 should unlock SpaceX-IPO; 7–10 should unlock Sophie's-work; 5–6 fix the YouTube bug