### PR TITLE
chore+ci: refresh uv.lock and drop Python 3.12 from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v6
 

--- a/uv.lock
+++ b/uv.lock
@@ -1206,7 +1206,7 @@ wheels = [
 
 [[package]]
 name = "le-stash-workspace"
-version = "1.56.3"
+version = "1.58.0"
 source = { virtual = "." }
 dependencies = [
     { name = "lestash" },
@@ -1259,7 +1259,7 @@ dev = [
 
 [[package]]
 name = "lestash"
-version = "1.56.3"
+version = "1.58.0"
 source = { editable = "packages/lestash" }
 dependencies = [
     { name = "anthropic" },
@@ -1296,7 +1296,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-arxiv"
-version = "1.56.3"
+version = "1.58.0"
 source = { editable = "packages/lestash-arxiv" }
 dependencies = [
     { name = "arxiv" },
@@ -1311,7 +1311,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-audible"
-version = "1.56.3"
+version = "1.58.0"
 source = { editable = "packages/lestash-audible" }
 dependencies = [
     { name = "audible" },
@@ -1326,7 +1326,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-bluesky"
-version = "1.56.3"
+version = "1.58.0"
 source = { editable = "packages/lestash-bluesky" }
 dependencies = [
     { name = "atproto" },
@@ -1341,7 +1341,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-claude-code"
-version = "1.56.3"
+version = "1.58.0"
 source = { editable = "packages/lestash-claude-code" }
 dependencies = [
     { name = "lestash" },
@@ -1352,7 +1352,7 @@ requires-dist = [{ name = "lestash", editable = "packages/lestash" }]
 
 [[package]]
 name = "lestash-linkedin"
-version = "1.56.3"
+version = "1.58.0"
 source = { editable = "packages/lestash-linkedin" }
 dependencies = [
     { name = "authlib" },
@@ -1369,7 +1369,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-microblog"
-version = "1.56.3"
+version = "1.58.0"
 source = { editable = "packages/lestash-microblog" }
 dependencies = [
     { name = "httpx" },
@@ -1384,7 +1384,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-server"
-version = "1.56.3"
+version = "1.58.0"
 source = { editable = "packages/lestash-server" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1407,7 +1407,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-voice"
-version = "1.56.3"
+version = "1.58.0"
 source = { editable = "packages/lestash-voice" }
 dependencies = [
     { name = "faster-whisper" },
@@ -1422,7 +1422,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-youtube"
-version = "1.56.3"
+version = "1.58.0"
 source = { editable = "packages/lestash-youtube" }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

Two small chores that fell out of unrelated work, bundled into one tiny PR:

1. **Refresh `uv.lock`** to match the v1.58.0 release — pure version-string drift on workspace and per-package entries, no dependency changes.
2. **Drop `"3.12"` from the test matrix** in `.github/workflows/ci.yml`. Lint and Type Check remain pinned to 3.12 (single version, not in the matrix) so the `requires-python = ">=3.12"` floor still gets exercised by the linters on every CI run. To drop 3.12 support fully would also mean bumping every `requires-python` to `>=3.13` — out of scope for this PR.

## Test plan

- [x] CI runs only `Test (Python 3.13)` for the test job
- [x] Lint and Type Check pass on 3.12 (unchanged)
- [ ] `uv sync --dev` is a no-op locally after pulling this branch