### PR TITLE
fix(linkedin): fall back to resourceUri when activity.object is missing

### DIFF
--- a/packages/lestash-linkedin/src/lestash_linkedin/extractors/changelog.py
+++ b/packages/lestash-linkedin/src/lestash_linkedin/extractors/changelog.py
@@ -5,6 +5,7 @@ Unknown resource types are preserved with generic content for discovery.
 """
 
 import logging
+import re
 from datetime import datetime
 
 from lestash.models.item import ItemCreate, MediaCreate
@@ -61,6 +62,25 @@ def _activity_urn_to_url(urn: str | None) -> str | None:
     if not urn or not urn.startswith("urn:li:activity:"):
         return None
     return f"{LINKEDIN_BASE_URL}/{urn}"
+
+
+# resourceUri shape: /socialActions/<PARENT-URN>/(comments|likes)/<id>
+# Parent URN may be activity:, ugcPost:, share:, comment:(...), groupPost:NN-MM, etc.
+_RESOURCE_URI_PARENT_RE = re.compile(r"/socialActions/(urn:li:[^/]+)/(?:comments|likes)/")
+
+
+def _parent_urn_from_resource_uri(event: ChangelogEvent) -> str | None:
+    """Pull the parent post/comment URN out of `resourceUri` as a fallback.
+
+    LinkedIn's changelog occasionally omits `activity.object` even though the
+    parent URN sits right there in `resourceUri`. Without this fallback the
+    item lands with `commented_on`/`reacted_to` set to None and downstream
+    enrichment (post_cache lookups, parent resolution) breaks.
+    """
+    if not event.resource_uri:
+        return None
+    m = _RESOURCE_URI_PARENT_RE.search(event.resource_uri)
+    return m.group(1) if m else None
 
 
 def extract_changelog_item(event_data: dict) -> ItemCreate:
@@ -178,8 +198,8 @@ def _extract_comment(event: ChangelogEvent) -> ItemCreate:
     if activity.created and activity.created.get("time"):
         created_at = datetime.fromtimestamp(activity.created["time"] / 1000)
 
-    # Generate URL to the commented post
-    url = _activity_urn_to_url(activity.object)
+    parent_urn = activity.object or _parent_urn_from_resource_uri(event)
+    url = _activity_urn_to_url(parent_urn)
 
     return _create_item(
         event=event,
@@ -187,8 +207,8 @@ def _extract_comment(event: ChangelogEvent) -> ItemCreate:
         author=activity.actor or activity.author,
         created_at=created_at,
         extra_metadata={
-            "commented_on": activity.object,
-            "target_snowflake_ts": _urn_to_snowflake_ts(activity.object),
+            "commented_on": parent_urn,
+            "target_snowflake_ts": _urn_to_snowflake_ts(parent_urn),
         },
         url=url,
     )
@@ -222,18 +242,20 @@ def _extract_reaction(event: ChangelogEvent) -> ItemCreate:
     emoji = REACTION_EMOJIS.get(activity.reaction_type, "👍")
     reaction_type = activity.reaction_type or "LIKE"
 
+    parent_urn = activity.object or _parent_urn_from_resource_uri(event)
+
     # Include target reference if available
     target_ref = ""
-    if activity.object:
+    if parent_urn:
         # Extract short ID from URN (e.g., "urn:li:activity:123" -> "activity:123")
-        parts = activity.object.split(":")
+        parts = parent_urn.split(":")
         if len(parts) >= 3:
             target_ref = f" on {parts[-2]}:{parts[-1]}"
 
     content = f"{emoji} {reaction_type}{target_ref}"
 
     # Generate URL to the reacted post
-    url = _activity_urn_to_url(activity.object)
+    url = _activity_urn_to_url(parent_urn)
 
     return _create_item(
         event=event,
@@ -242,8 +264,8 @@ def _extract_reaction(event: ChangelogEvent) -> ItemCreate:
         created_at=created_at,
         extra_metadata={
             "reaction_type": activity.reaction_type,
-            "reacted_to": activity.object,
-            "target_snowflake_ts": _urn_to_snowflake_ts(activity.object),
+            "reacted_to": parent_urn,
+            "target_snowflake_ts": _urn_to_snowflake_ts(parent_urn),
         },
         url=url,
     )

--- a/packages/lestash-linkedin/tests/test_extractors.py
+++ b/packages/lestash-linkedin/tests/test_extractors.py
@@ -76,6 +76,57 @@ class TestCommentExtraction:
         item = extract_changelog_item(comment_event)
         assert item.url == "https://www.linkedin.com/feed/update/urn:li:activity:123456"
 
+    def test_falls_back_to_resource_uri_when_object_missing_ugcpost(self):
+        """activity.object can be absent live (observed June 2026). Recover
+        the parent URN from resourceUri so commented_on stays populated."""
+        event = {
+            "resourceName": "socialActions/comments",
+            "resourceId": "7468021750157713409",
+            "resourceUri": (
+                "/socialActions/urn:li:ugcPost:7468004947981217792/comments/7468021750157713409"
+            ),
+            "method": "CREATE",
+            "processedAt": 1780515143951,
+            "activity": {
+                "message": {"text": "reply text"},
+                "actor": "urn:li:person:xu59iSkkD6",
+                # NOTE: no "object" field
+            },
+        }
+        item = extract_changelog_item(event)
+        assert item.metadata["commented_on"] == "urn:li:ugcPost:7468004947981217792"
+
+    def test_falls_back_to_resource_uri_for_compound_comment_urn(self):
+        """Reply-to-a-comment shape: parent URN includes parens."""
+        event = {
+            "resourceName": "socialActions/comments",
+            "resourceUri": "/socialActions/urn:li:comment:(activity:111,222)/comments/333",
+            "method": "CREATE",
+            "processedAt": 1780000000000,
+            "activity": {
+                "message": {"text": "reply"},
+                "actor": "urn:li:person:abc",
+            },
+        }
+        item = extract_changelog_item(event)
+        assert item.metadata["commented_on"] == "urn:li:comment:(activity:111,222)"
+
+    def test_object_takes_precedence_over_resource_uri(self):
+        """When both are present, the explicit activity.object wins."""
+        event = {
+            "resourceName": "socialActions/comments",
+            "resourceUri": "/socialActions/urn:li:ugcPost:999/comments/1",
+            "method": "CREATE",
+            "processedAt": 1780000000000,
+            "activity": {
+                "message": {"text": "hi"},
+                "actor": "urn:li:person:abc",
+                "object": "urn:li:activity:42",
+            },
+        }
+        item = extract_changelog_item(event)
+        assert item.metadata["commented_on"] == "urn:li:activity:42"
+
 
 class TestReactionExtraction:
     """Test extraction of reactions to ItemCreate."""
@@ -99,6 +150,24 @@ class TestReactionExtraction:
     def test_generates_url_to_reacted_post(self, reaction_event):
         item = extract_changelog_item(reaction_event)
         assert item.url == "https://www.linkedin.com/feed/update/urn:li:activity:789012"
+
+    def test_reaction_falls_back_to_resource_uri_when_object_missing(self):
+        """Same fallback as comments — parent URN parsed out of resourceUri."""
+        event = {
+            "resourceName": "socialActions/likes",
+            "resourceUri": (
+                "/socialActions/urn:li:ugcPost:7421481531749187585/likes/urn:li:person:xyz"
+            ),
+            "method": "CREATE",
+            "processedAt": 1769434436256,
+            "activity": {
+                "reactionType": "LIKE",
+                "actor": "urn:li:person:xyz",
+            },
+        }
+        item = extract_changelog_item(event)
+        assert item.metadata["reacted_to"] == "urn:li:ugcPost:7421481531749187585"
+        assert "ugcPost:7421481531749187585" in item.content
 
 
 class TestInvitationExtraction:

--- a/scripts/linkedin_backfill_target_urns.py
+++ b/scripts/linkedin_backfill_target_urns.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""One-shot: for existing items where commented_on / reacted_to is NULL but
+the parent URN is encoded in raw.resourceUri, write the URN into metadata.
+
+Companion to the extractor fix that adds the same fallback going forward.
+Existing items synced before the fix don't get re-extracted automatically,
+so this script repairs them in place.
+
+Reads raw.resourceUri (format: /socialActions/<URN>/(comments|likes)/<id>),
+extracts the URN, and updates the JSON column. Read-only without --write.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path.home() / ".config/lestash/lestash.db"
+
+_RESOURCE_URI_PARENT_RE = re.compile(r"/socialActions/(urn:li:[^/]+)/(?:comments|likes)/")
+
+
+def parent_urn_from_resource_uri(resource_uri: str | None) -> str | None:
+    if not resource_uri:
+        return None
+    m = _RESOURCE_URI_PARENT_RE.search(resource_uri)
+    return m.group(1) if m else None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--write", action="store_true", help="Apply UPDATEs.")
+    args = ap.parse_args()
+
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        rows = conn.execute(
+            """
+            SELECT id,
+                   metadata,
+                   json_extract(metadata, '$.resource_name'),
+                   json_extract(metadata, '$.raw.resourceUri')
+            FROM items
+            WHERE source_type='linkedin' AND is_own_content=1
+              AND json_extract(metadata, '$.resource_name') IN
+                    ('socialActions/comments', 'socialActions/likes')
+              AND json_extract(metadata, '$.commented_on') IS NULL
+              AND json_extract(metadata, '$.reacted_to') IS NULL
+            """
+        ).fetchall()
+
+        updates: list[tuple[int, str]] = []  # (item_id, new_metadata_json)
+        unrecoverable: list[tuple[int, str | None]] = []
+        for item_id, meta_str, resource_name, resource_uri in rows:
+            parent_urn = parent_urn_from_resource_uri(resource_uri)
+            if not parent_urn:
+                unrecoverable.append((item_id, resource_uri))
+                continue
+            meta = json.loads(meta_str)
+            key = "commented_on" if resource_name == "socialActions/comments" else "reacted_to"
+            meta[key] = parent_urn
+            updates.append((item_id, json.dumps(meta)))
+
+        print(f"# rows scanned          : {len(rows)}")
+        print(f"# recoverable           : {len(updates)}")
+        print(f"# no URN in resourceUri : {len(unrecoverable)}")
+        if unrecoverable:
+            print("  sample of unrecoverable:")
+            for item_id, uri in unrecoverable[:5]:
+                print(f"    item {item_id}: resourceUri={uri!r}")
+
+        if not args.write:
+            print("\n# Dry run. Re-run with --write to apply.")
+            return 0
+
+        with conn:
+            for item_id, new_meta in updates:
+                conn.execute(
+                    "UPDATE items SET metadata = ? WHERE id = ?",
+                    (new_meta, item_id),
+                )
+        print(f"\n# applied {len(updates)} UPDATE(s).")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/linkedin_cache_engaged_posts.py
+++ b/scripts/linkedin_cache_engaged_posts.py
@@ -167,8 +167,8 @@ def main() -> int:
         for i, (urn, kind) in enumerate(worklist, 1):
             kind_id = urn_to_fetchable_id(urn)
             assert kind_id is not None  # filtered above
-            _, fid = kind_id
-            preview = fetch_preview(fid)
+            urn_kind, fid = kind_id
+            preview = fetch_preview(fid, urn_kind=urn_kind)
             status = preview.get("status")
             if status == "ERR":
                 err += 1

--- a/scripts/linkedin_cache_engaged_posts.py
+++ b/scripts/linkedin_cache_engaged_posts.py
@@ -66,10 +66,7 @@ def collect_target_urns(conn: sqlite3.Connection) -> dict[str, list[str]]:
               AND json_extract(metadata, '$.raw.activity.repostedContent.ugcPost') IS NOT NULL
         """,
     }
-    return {
-        kind: [r[0] for r in conn.execute(sql).fetchall()]
-        for kind, sql in queries.items()
-    }
+    return {kind: [r[0] for r in conn.execute(sql).fetchall()] for kind, sql in queries.items()}
 
 
 def urn_to_fetchable_id(urn: str) -> tuple[str, str] | None:
@@ -150,21 +147,25 @@ def main() -> int:
             print(f"  {kind:14s} distinct in DB: {len(targets[kind])}")
         print(f"  already in post_cache       : {len(cached)}")
         print(f"  skipped (unfetchable URN)   : {skipped_unfetchable}")
-        print(f"  to fetch this run           : {len(worklist)}"
-              + (f"  (--limit {args.limit})" if args.limit else ""))
+        print(
+            f"  to fetch this run           : {len(worklist)}"
+            + (f"  (--limit {args.limit})" if args.limit else "")
+        )
         if args.limit:
             worklist = worklist[: args.limit]
 
         if not args.write:
-            print(f"\n# Dry run. Re-run with --write to fetch + cache "
-                  f"{len(worklist)} URN(s). Estimated wall-time: "
-                  f"~{int(len(worklist) * args.sleep)}s.")
+            print(
+                f"\n# Dry run. Re-run with --write to fetch + cache "
+                f"{len(worklist)} URN(s). Estimated wall-time: "
+                f"~{int(len(worklist) * args.sleep)}s."
+            )
             return 0
 
         from lestash.core.database import upsert_post_cache
 
         ok = miss = err = 0
-        for i, (urn, kind) in enumerate(worklist, 1):
+        for i, (urn, _kind) in enumerate(worklist, 1):
             kind_id = urn_to_fetchable_id(urn)
             assert kind_id is not None  # filtered above
             urn_kind, fid = kind_id
@@ -172,7 +173,7 @@ def main() -> int:
             status = preview.get("status")
             if status == "ERR":
                 err += 1
-                print(f"[{i}/{len(worklist)}] ERR {preview.get('error','?')} {urn}")
+                print(f"[{i}/{len(worklist)}] ERR {preview.get('error', '?')} {urn}")
             elif status != "200":
                 miss += 1
                 print(f"[{i}/{len(worklist)}] {status} {urn}")
@@ -202,8 +203,10 @@ def main() -> int:
 
         conn.commit()
         print(f"\n# done. ok={ok}  miss={miss}  err={err}")
-        print(f"# post_cache rows after: "
-              f"{conn.execute('SELECT COUNT(*) FROM post_cache').fetchone()[0]}")
+        print(
+            f"# post_cache rows after: "
+            f"{conn.execute('SELECT COUNT(*) FROM post_cache').fetchone()[0]}"
+        )
         return 0
     finally:
         conn.close()

--- a/scripts/linkedin_url_lookup.py
+++ b/scripts/linkedin_url_lookup.py
@@ -19,17 +19,19 @@ ToS caveat: this scrapes a public preview, no auth bypass. Don't rate-grind.
 
 from __future__ import annotations
 
-import json
 import re
 import sqlite3
 import sys
 import time
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 from urllib.request import Request, urlopen
 
 DB_PATH = Path.home() / ".config/lestash/lestash.db"
-UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0 Safari/537.36"
+UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/130.0 Safari/537.36"
+)
 
 ACTIVITY_URN_RE = re.compile(r"urn:li:activity:(\d+)")
 ACTIVITY_FROM_SLUG_RE = re.compile(r"activity-(\d+)")
@@ -69,7 +71,13 @@ def fetch_preview(activity_id: str, urn_kind: str = "activity") -> dict[str, str
             html = resp.read().decode("utf-8", errors="replace")
             status = resp.status
     except Exception as e:
-        return {"status": "ERR", "error": str(e), "title": None, "author": None, "description": None}
+        return {
+            "status": "ERR",
+            "error": str(e),
+            "title": None,
+            "author": None,
+            "description": None,
+        }
 
     def _g(r: re.Pattern[str]) -> str | None:
         m = r.search(html)
@@ -105,7 +113,8 @@ def _extract_author(title: str | None, handle: str | None) -> str | None:
         # and "LinkedIn", keep candidates that look like a person name (1-4 words).
         segments = [s.strip() for s in PIPE_SEGMENT_RE.split(clean) if s.strip()]
         cands = [
-            s for s in segments
+            s
+            for s in segments
             if 1 <= len(s.split()) <= 4
             and not s.lower().endswith("comments")
             and not s.lower().endswith("reactions")

--- a/scripts/linkedin_url_lookup.py
+++ b/scripts/linkedin_url_lookup.py
@@ -55,9 +55,14 @@ def extract_activity_id(url_or_urn: str) -> str | None:
     return None
 
 
-def fetch_preview(activity_id: str) -> dict[str, str | None]:
-    """Fetch /feed/update/urn:li:activity:<id>/ unauthenticated; return og fields."""
-    url = f"https://www.linkedin.com/feed/update/urn:li:activity:{activity_id}/"
+def fetch_preview(activity_id: str, urn_kind: str = "activity") -> dict[str, str | None]:
+    """Fetch /feed/update/urn:li:<kind>:<id>/ unauthenticated; return og fields.
+
+    `urn_kind` selects the URN namespace: 'activity' (default), 'ugcPost',
+    'share'. LinkedIn redirects all three to the canonical /posts/ URL when
+    public; the og:* meta tags are the same.
+    """
+    url = f"https://www.linkedin.com/feed/update/urn:li:{urn_kind}:{activity_id}/"
     req = Request(url, headers={"User-Agent": UA})
     try:
         with urlopen(req, timeout=15) as resp:


### PR DESCRIPTION
## Summary

LinkedIn's changelog occasionally omits `activity.object` even though the parent post/comment URN is right there in `resourceUri`. The extractor was unconditionally reading `activity.object`, so for those events `commented_on` / `reacted_to` landed as `None` — breaking `post_cache` lookups, the enrichment display path, and downstream parent resolution.

**Concrete trigger that surfaced this**: item 25744 — Matt's quote-reply on a Gergely Orosz post about Kelsey Hightower — had no parent reference in its API response despite the parent URN sitting in `metadata.raw.resourceUri`.

## Changes

- **`packages/lestash-linkedin/.../extractors/changelog.py`** — new `_parent_urn_from_resource_uri()` helper, regex-parses any LinkedIn URN shape (`activity:`, `ugcPost:`, `share:`, compound `comment:(...)`, `groupPost:`) out of `/socialActions/<URN>/(comments|likes)/<id>`. Used as a fallback in both `_extract_comment` and `_extract_reaction` when `activity.object` is absent. Explicit field still wins when present.
- **`packages/lestash-linkedin/tests/test_extractors.py`** — 4 new tests covering ugcPost-shape fallback, compound comment URN, reaction fallback, and the precedence case. All 63 tests pass.
- **`scripts/linkedin_backfill_target_urns.py`** — one-shot data-fix companion for items synced before this change. Walks affected rows, parses the parent URN out of `raw.resourceUri`, writes it into `metadata.commented_on` / `metadata.reacted_to`. Read-only without `--write`.

## Scope of the live-DB backfill

| Parent URN shape | Kind | Count |
| --- | --- | --- |
| `activity:` | comments | 135 |
| `comment:` (replies) | comments | 19 |
| `ugcPost:` | comments | 12 |
| `activity:` | likes | 6 |
| `comment:` (replies) | likes | 3 |
| **Total** | | **175** |

All 175 recovered, 0 unrecoverable.

After the backfill, `linkedin_cache_engaged_posts.py` was re-run to populate `post_cache` for the newly-pointable URNs (~174 fetches at 1s each).

## Test plan

- [x] `uv run pytest packages/lestash-linkedin/tests/test_extractors.py` — 63 pass
- [x] `uv run ruff check + format` clean on touched files
- [x] `uv run mypy` clean on the extractor
- [ ] After deploy + next LinkedIn sync, no new items land with `commented_on` / `reacted_to` NULL when `resourceUri` carries a URN