### PR TITLE
feat(audible): import all library books, not just annotated ones

### DIFF
--- a/packages/lestash-audible/src/lestash_audible/source.py
+++ b/packages/lestash-audible/src/lestash_audible/source.py
@@ -339,11 +339,9 @@ class AudibleSource(SourcePlugin):
                         # Fetch bookmarks for this book
                         records = get_bookmarks(client, book_asin)
                         annotations = _extract_annotations(records)
-                        if not annotations:
-                            continue
 
-                        # Fetch chapters for context
-                        chapters = get_chapters(client, book_asin)
+                        # Fetch chapters for context (only if there are annotations)
+                        chapters = get_chapters(client, book_asin) if annotations else None
 
                         # Insert book as parent (with chapters in metadata)
                         book_item = book_to_item(book, chapters=chapters)
@@ -363,8 +361,7 @@ class AudibleSource(SourcePlugin):
                     conn.commit()
 
             console.print(
-                f"[green]Imported {total_bookmarks} bookmarks/notes"
-                f" from {total_books} books[/green]"
+                f"[green]Imported {total_books} books, {total_bookmarks} bookmarks/notes[/green]"
             )
 
         return app
@@ -388,11 +385,9 @@ class AudibleSource(SourcePlugin):
 
                 records = get_bookmarks(client, asin)
                 annotations = _extract_annotations(records)
-                if not annotations:
-                    continue
 
-                # Fetch chapters for context
-                chapters = get_chapters(client, asin)
+                # Fetch chapters for context (only if there are annotations)
+                chapters = get_chapters(client, asin) if annotations else None
 
                 # Yield book as parent (with chapters)
                 yield book_to_item(book, chapters=chapters)


### PR DESCRIPTION
## Summary

Cherry-picked from `feat/audible-download` (2026-04-05, never merged).

Previously the sync skipped any book without bookmarks or notes, so the LeStash Audible feed only ever showed the books you'd annotated. After this change the full listening library is imported. Chapters are still fetched only for books with annotations (cheaper, and they're the only books that need them for in-context notes).

Two equivalent hunks — once in the CLI sync path, once in the streaming `sync()` path.

## Test plan

- [x] `pytest packages/lestash-audible/tests/` — 67 pass
- [ ] After deploy, run an Audible sync and confirm the books-no-annotations rows appear in the feed