### PR TITLE
feat: publish a LeStash item to micro.blog (Wave 2 end-to-end)

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -1137,6 +1137,44 @@
     </div>
   </div>
 
+  <!-- micro.blog compose modal (Wave 2b) -->
+  <div class="modal-overlay" id="microblog-compose-modal">
+    <div class="modal" style="max-width:560px">
+      <h2>Share to micro.blog</h2>
+      <input type="hidden" id="mb-item-id" value="">
+      <div style="margin-bottom:0.6rem">
+        <label for="mb-title" style="font-size:0.8rem;color:var(--muted)">Title (optional — short notes don't need one)</label>
+        <input type="text" id="mb-title" style="width:100%;font-size:0.85rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:0.4rem 0.5rem;margin-top:0.2rem">
+      </div>
+      <div style="margin-bottom:0.6rem">
+        <label for="mb-body" style="font-size:0.8rem;color:var(--muted)">Body</label>
+        <textarea id="mb-body" style="width:100%;min-height:160px;font-family:inherit;font-size:0.85rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:0.5rem 0.6rem;resize:vertical;margin-top:0.2rem" placeholder="Markdown is welcome. YouTube URLs become {{< yt &quot;ID&quot; >}} shortcodes."></textarea>
+      </div>
+      <div style="margin-bottom:0.6rem">
+        <label for="mb-categories" style="font-size:0.8rem;color:var(--muted)">Categories <span style="font-size:0.7rem">(Ctrl/Cmd-click to multi-select)</span></label>
+        <select id="mb-categories" multiple size="4" style="width:100%;font-size:0.8rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:0.3rem;margin-top:0.2rem"></select>
+      </div>
+      <div style="display:flex;gap:1rem;align-items:center;margin-bottom:0.6rem;flex-wrap:wrap">
+        <div>
+          <label for="mb-visibility" style="font-size:0.8rem;color:var(--muted)">Visibility</label>
+          <select id="mb-visibility" style="font-size:0.8rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:0.3rem 0.5rem;margin-left:0.4rem">
+            <option value="public">Public</option>
+            <option value="draft">Draft</option>
+          </select>
+        </div>
+        <label style="font-size:0.8rem;display:flex;align-items:center;gap:0.3rem">
+          <input type="checkbox" id="mb-tag-source" checked>
+          Tag source as "published-to-microblog"
+        </label>
+      </div>
+      <div id="mb-error" style="display:none;font-size:0.8rem;color:var(--accent);margin-bottom:0.4rem"></div>
+      <div class="modal-actions">
+        <button class="btn-cancel" onclick="closeMicroblogCompose()">Cancel</button>
+        <button class="btn-save" id="mb-publish-btn" onclick="submitMicroblogPublish()">Publish</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Toasts -->
   <div class="toast-container" id="toasts"></div>
 
@@ -1700,6 +1738,7 @@
         <button class="sync-btn" data-action="copy" data-id="${item.id}">Copy</button>
         <button class="sync-btn" data-action="copy-link" data-id="${item.id}">Copy Link</button>
         <button class="sync-btn" onclick="addToCollection(${item.id})">+ Collection</button>
+        <button class="sync-btn" onclick="openMicroblogCompose(${item.id})">Share to micro.blog</button>
         <select id="add-to-coll-select" style="display:none;font-size:0.75rem;padding:0.25rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px" onchange="confirmAddToCollection(this)"></select>
       </div>`;
       html += `<div id="item-history-panel" style="display:none;margin-top:0.5rem;padding:0.5rem;border:1px solid var(--border);border-radius:4px">
@@ -4071,6 +4110,169 @@
       } finally {
         btn.disabled = false;
         btn.textContent = 'Post';
+      }
+    }
+
+    /* ── micro.blog Compose (Wave 2b) ── */
+
+    // Stopgap until Wave 4 ships ?kind=category autocomplete from /api/items/tags.
+    // Matches docs/blog-categories-consolidation.md and the rows seeded into
+    // the tags table with kind='category' (DB migration 10).
+    const MICROBLOG_CATEGORIES = [
+      'being-human', 'intelligent-agents', 'agentic-ai', 'learning',
+      'ml-research', 'responsible-ai', 'vibe-engineering', 'software-craft',
+      'reading', 'life', 'commentary',
+    ];
+
+    function extractYouTubeId(url) {
+      if (!url) return null;
+      // youtu.be/<id>, watch?v=<id>, embed/<id>, m.youtube.com/...,
+      // youtube-nocookie.com/embed/<id>. Strip query/fragment after the ID.
+      const patterns = [
+        /youtu\.be\/([A-Za-z0-9_-]{11})/,
+        /[?&]v=([A-Za-z0-9_-]{11})/,
+        /\/embed\/([A-Za-z0-9_-]{11})/,
+        /\/shorts\/([A-Za-z0-9_-]{11})/,
+      ];
+      for (const re of patterns) {
+        const m = url.match(re);
+        if (m) return m[1];
+      }
+      return null;
+    }
+
+    function prefillMicroblogCompose(item) {
+      // Source-aware prefill per design §3.1.
+      const sub = item.subtype || item.source_type || '';
+      let title = '';
+      let body = '';
+
+      if (sub.startsWith('youtube') || /youtube\.com|youtu\.be/.test(item.url || '')) {
+        const vid = extractYouTubeId(item.url);
+        title = item.title || '';
+        if (vid) {
+          // flschr/mbplugin-youtube-nocookie shortcode form
+          const titleArg = (item.title || '').replace(/"/g, '\\"');
+          body = `\n\n{{< yt "${vid}" "" "${titleArg}" >}}\n`;
+        } else {
+          body = `\n\n${item.url || ''}\n`;
+        }
+      } else if (sub.startsWith('linkedin') || sub.startsWith('bluesky') ||
+                 sub.startsWith('arxiv') || sub.startsWith('microblog')) {
+        // Quote-share shape: blockquoted preview + source link.
+        const preview = (item.content || '').slice(0, 280).replace(/\n+/g, ' ');
+        title = (item.title || preview).slice(0, 80);
+        body = `> ${preview}\n\n${item.url || ''}\n`;
+      } else {
+        // Own note or unknown source — first line as title, rest as body.
+        const lines = (item.content || '').split('\n');
+        title = item.title || lines[0].slice(0, 80);
+        body = item.title ? (item.content || '') : lines.slice(1).join('\n').trim();
+      }
+
+      document.getElementById('mb-title').value = title;
+      document.getElementById('mb-body').value = body.trimStart();
+    }
+
+    async function openMicroblogCompose(itemId) {
+      // Populate categories dropdown each open (cheap, keeps stopgap in sync).
+      const sel = document.getElementById('mb-categories');
+      sel.innerHTML = MICROBLOG_CATEGORIES.map(
+        c => `<option value="${escHtml(c)}">${escHtml(c)}</option>`
+      ).join('');
+
+      document.getElementById('mb-item-id').value = itemId;
+      document.getElementById('mb-visibility').value = 'public';
+      document.getElementById('mb-tag-source').checked = true;
+      document.getElementById('mb-error').style.display = 'none';
+      document.getElementById('mb-publish-btn').disabled = false;
+      document.getElementById('mb-publish-btn').textContent = 'Publish';
+
+      // Fetch the item fresh so prefill sees the canonical title/url/content,
+      // not whatever the calling card had cached.
+      try {
+        const item = await api(`/api/items/${itemId}`);
+        prefillMicroblogCompose(item);
+      } catch (e) {
+        showToast(`Could not load item: ${e.message}`, 'error');
+        return;
+      }
+
+      document.getElementById('microblog-compose-modal').classList.add('open');
+      document.getElementById('mb-body').focus();
+    }
+
+    function closeMicroblogCompose() {
+      document.getElementById('microblog-compose-modal').classList.remove('open');
+    }
+
+    async function submitMicroblogPublish() {
+      const itemId = parseInt(document.getElementById('mb-item-id').value, 10);
+      const body = document.getElementById('mb-body').value.trim();
+      if (!body) {
+        showToast('Body is required', 'error');
+        return;
+      }
+      const title = document.getElementById('mb-title').value.trim() || null;
+      const visibility = document.getElementById('mb-visibility').value;
+      const categories = Array.from(
+        document.getElementById('mb-categories').selectedOptions
+      ).map(o => o.value);
+      const tagSource = document.getElementById('mb-tag-source').checked;
+
+      const errEl = document.getElementById('mb-error');
+      errEl.style.display = 'none';
+      const btn = document.getElementById('mb-publish-btn');
+      btn.disabled = true;
+      btn.textContent = 'Publishing…';
+
+      try {
+        const result = await api('/api/microblog/publish', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            item_id: itemId,
+            title,
+            body,
+            image_url: null,
+            categories,
+            visibility,
+            if_not_already_published: false,
+          }),
+        });
+
+        if (tagSource) {
+          // Best-effort — don't fail the publish if the tag write fails.
+          try {
+            await api(`/api/items/${itemId}/tags`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ name: 'published-to-microblog' }),
+            });
+          } catch (tagErr) {
+            console.warn('Tag-source failed:', tagErr);
+          }
+        }
+
+        closeMicroblogCompose();
+        showToast(`Published! ${result.url}`, 'ok');
+      } catch (e) {
+        // Map API errors to a friendly inline message.
+        let msg = e.message || 'Publish failed';
+        if (/409/.test(msg) || /already published/i.test(msg)) {
+          msg = 'Already published. Open this URL to re-publish: ' + msg;
+        } else if (/401/.test(msg) || /not authenticated/i.test(msg)) {
+          msg = 'micro.blog isn\'t authenticated. Run `lestash microblog auth --token …` on the server.';
+        } else if (/422/.test(msg)) {
+          msg = 'micro.blog rejected the post: ' + msg;
+        } else if (/502/.test(msg)) {
+          msg = 'micro.blog upstream error — try again in a moment. ' + msg;
+        }
+        errEl.textContent = msg;
+        errEl.style.display = '';
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Publish';
       }
     }
 

--- a/docs/ux-compose-and-categories-design.md
+++ b/docs/ux-compose-and-categories-design.md
@@ -30,7 +30,7 @@ A non-goal here: replacing collections with tags or vice versa. They earn their 
 | Tags global | `routes/items.py:375` `GET /api/items/tags` | Lists tags w/ counts (used in filter dropdown) |
 | Collections | `app/src/index.html:3852-3939` · `/api/collections` | Modal create, manual add |
 | LinkedIn publish | `app/src/index.html:3943-4063` · `/api/linkedin/post` | Works — proves the publish pattern |
-| micro.blog publish | — | **Missing** |
+| micro.blog publish | `app/src/index.html` modal · `/api/microblog/publish` | Shipped (PR #159) — item-detail "Share to micro.blog" button, source-aware prefill, syndications audit |
 | Share/capture | `app/src/index.html:3070-3168` | URL ingest + YouTube transcript fetch |
 | Bear-style notes | `Notes` tab | Voice + text |
 
@@ -74,12 +74,17 @@ What this means for the architecture:
 
 ### 2.3 Capability gaps (the short list)
 
-- `MicropubClient` has no `create_entry()` — read-only.
-- `SourcePlugin` base class has no `publish()` contract — every publisher (LinkedIn, future micro.blog) reinvents it.
-- No "compose from existing item" flow. The share modal goes inbound only.
-- No tag autocomplete; no bulk-tag selection.
-- No "save current filter as a category."
-- No CLI tag commands (precludes batch grooming).
+Closed by PR #159:
+
+- ~~`MicropubClient` has no `create_entry()`~~ — slice 2.
+- ~~`SourcePlugin` base class has no `publish()` contract~~ — replaced by the `Publisher` Protocol (slice 1). LinkedIn migration is Wave 6a.
+- ~~No "compose from existing item" flow~~ — slice 4 ships the modal.
+
+Still open:
+
+- No tag autocomplete; no bulk-tag selection. → Wave 4 + 5a.
+- No "save current filter as a category." → Wave 5b.
+- No CLI tag commands (precludes batch grooming). → not in any wave; small follow-up.
 
 ---
 
@@ -116,7 +121,7 @@ Three flows, each kept narrow on purpose.
 │  Cats   ⊞ tech-watch   [+ add]                           │
 │  Visibility: ● Public  ○ Draft                           │
 │                                                          │
-│  ☑ Save syndication link back to source item             │
+│  (syndication audit row always written — slice 3)        │
 │  ☑ Tag source item as "published-to-microblog"           │
 │                                                          │
 │  Preview ─────────────────────────────────────  [Open ⤴] │
@@ -507,17 +512,17 @@ class LintFinding:
 @dataclass(frozen=True)
 class PublishResult:
     url: str
-    target: str               # 'microblog' | 'linkedin' | …
-    raw_response: dict
+    target: str               # per-publish — what the route persists
+    raw_response: Mapping[str, Any]  # read-only view; route serialises verbatim
 
 class AlreadyPublished(Exception): ...
 class PublishRejected(Exception):  # 4xx
-    def __init__(self, message: str, raw: dict) -> None: ...
+    def __init__(self, message: str, raw: Mapping[str, Any]) -> None: ...
 class PublishFailed(Exception):    # 5xx / network
-    def __init__(self, message: str, raw: dict | None) -> None: ...
+    def __init__(self, message: str, raw: Mapping[str, Any] | None) -> None: ...
 
 class Publisher(Protocol):
-    target: str
+    target: ClassVar[str]     # class-level constant — registry looks up by name
 
     def lint(self, compose: ComposeRequest) -> list[LintFinding]: ...
 
@@ -644,10 +649,10 @@ Each slice is independently mergeable + demo-able. PR titles in the suggested co
 | # | Slice | Slice value | Touches |
 | - | --- | --- | --- |
 | 0 ✓ | Install `flschr/mbplugin-youtube-nocookie` on the blog; uninstall `rknightuk/micro-blog-lite-youtube` (done 2026-06-05) | Unblocks the rest; standalone blog change | blog plugins (no code) |
-| 1 | `feat(lestash): add Publisher protocol + ComposeRequest/PublishResult/LintFinding schemas` | Foundation; no user-visible change | `packages/lestash` |
-| 2 | `feat(microblog): implement MicropubClient.create_entry()` | Backend can post; tested via CLI | `lestash-microblog` |
-| 3 | `feat(microblog): expose POST /api/microblog/publish` | API-first publish | `lestash-server` |
-| 4 | `feat(app): micro.blog compose modal (YouTube prefill)` | First end-to-end user flow | `app/` |
+| 1 ✓ | `feat(lestash): add Publisher protocol + ComposeRequest/PublishResult/LintFinding schemas` (done 2026-06-05, PR #159) | Foundation; no user-visible change | `packages/lestash` |
+| 2 ✓ | `feat(microblog): implement MicropubClient.create_entry()` (done 2026-06-05, PR #159) | Backend can post; tested via CLI | `lestash-microblog` |
+| 3 ✓ | `feat(microblog): expose POST /api/microblog/publish` (done 2026-06-05, PR #159) | API-first publish | `lestash-server` |
+| 4 ✓ | `feat(app): micro.blog compose modal (YouTube prefill)` (done 2026-06-05, PR #159) | First end-to-end user flow | `app/` |
 | 5 | `feat(lestash): compose.lint with YT_RAW_URL + IMG_NOT_MARKDOWN` | Embed warnings | `lestash/plugins/lint_rules.py` (shared helpers, next to `publisher.py`) + `lestash-microblog/.../source.py` (`lint()` method). No new submodule — defer a `compose/` namespace until something beyond lint earns it. |
 | 6 | `feat(app): EmbedRenderer (extract + render) + iframe in detail view` | YouTube embeds inline in LeStash | `app/` |
 | 7 | `feat(server): GET /api/items/tags?prefix=` | Autocomplete backend | `lestash-server` |
@@ -673,8 +678,8 @@ Slices 1–4 unlock the SpaceX-IPO use case. Slices 7–10 unlock the Sophie's-w
 graph LR
   W0["Wave 0 done<br/>docs + tags.kind"]
   W1["Wave 1 done<br/>blog plugin swap"]
-  W2a["Wave 2a<br/>Publisher + Micropub<br/>+ publish API"]
-  W2b["Wave 2b<br/>compose modal UI"]
+  W2a["Wave 2a done<br/>Publisher + Micropub<br/>+ publish API"]
+  W2b["Wave 2b done<br/>compose modal UI"]
   W3["Wave 3<br/>lint + EmbedRenderer"]
   W4["Wave 4<br/>tag autocomplete + typeahead"]
   W5a["Wave 5a<br/>bulk-tag API + UI"]
@@ -702,8 +707,8 @@ Dashed line = soft dependency (Wave 2b is more useful once Wave 1 is done, but d
 | --- | --- | --- | --- | --- |
 | **0 ✓** | docs, `tags.kind` migration, 11 categories seeded | yes | none — column is additive, no caller yet | DB now has a structured place for categories |
 | **1 ✓** | slice 0 — install flschr, uninstall rknightuk (done 2026-06-05) | yes | cosmetic regression on old posts with raw YouTube URLs — accepted; no backfill (§8.7) | new posts get inline nocookie embeds; RSS/Mastodon syndication finally carries them |
-| **2a** | slices 1, 2, 3 — Publisher protocol + `MicropubClient.create_entry()` + `POST /api/microblog/publish` | yes — CLI / curl callable | live blog gets test posts during dev — use `visibility=draft` | publishing works end-to-end from a script, no UI needed |
-| **2b** | slice 4 — compose modal | depends on 2a | UI gate it behind a `settings.compose_microblog_enabled` flag while shaking it down | the SpaceX-IPO use case works |
+| **2a ✓** | slices 1, 2, 3 — Publisher protocol + `MicropubClient.create_entry()` + `POST /api/microblog/publish` (done 2026-06-05, PR #159) | yes — CLI / curl callable | live blog gets test posts during dev — use `visibility=draft` | publishing works end-to-end from a script, no UI needed |
+| **2b ✓** | slice 4 — compose modal (done 2026-06-05, PR #159) | depends on 2a | shipped *without* a feature flag — kept the diff small; rollback path is "revert the PR" if it misbehaves | the SpaceX-IPO use case works |
 | **3** | slices 5, 6 — `compose.lint` + `EmbedRenderer` extract+render | yes — purely additive UI | low | inline YouTube in LeStash; raw-URL warnings in composer |
 | **4** | slices 7, 8 — tag autocomplete API + TagTypeahead + `t` shortcut | yes — useful for any tag, not just categories | low | the "Sophie's work" tagging case is fast |
 | **5a** | slices 9, 10 — bulk-tag API + BulkSelectionBar | yes | low — operation is atomic per request | shift-click → `t` → tag many items at once |
@@ -713,12 +718,14 @@ Dashed line = soft dependency (Wave 2b is more useful once Wave 1 is done, but d
 
 ### Recommended order
 
-1. **Wave 1 next** — zero-code, immediate visible win on the blog. Decouples everything that follows from blog plugin choice.
-2. **Then Wave 2a + Wave 4 in parallel** — independent tracks, no shared files. 2a is the publish backend (no UI), 4 is the tag UX (small backend + small UI).
-3. **Then Wave 2b** — UI to drive 2a. Stop here, use it for a week, decide if Wave 3 lint matters before building it.
+Updated 2026-06-05 after Waves 0, 1, 2a, 2b shipped:
+
+1. ✓ **Wave 1** — done. Blog plugin swap (flschr, no rknightuk).
+2. ✓ **Wave 2a + 2b** — done in PR #159. Bundled to save pipeline runs; the original plan was 2a/4 parallel, but no UI work was happening on 4 so we kept 2 contiguous instead.
+3. **Wave 4 next** — tag autocomplete + typeahead + `t` shortcut. Independent of the rest of Wave 2/3. Unblocks the composer's category field (today it's a hard-coded stopgap of the 11 categories).
 4. **Wave 3 only if Wave 2b shows raw-URL or `<img>` slip-ups happening in real use** — otherwise defer; the lint is insurance, not foundation.
 5. **Wave 5a** — bulk-tag once Wave 4 is in muscle memory. Wave 5b (smart collections) only if a saved filter survives in the user's head for more than a week — otherwise YAGNI.
-6. **Wave 6a + 6b** — last, both small. Refactor 6a only after Wave 2 has shaken the Publisher contract enough to know it's right.
+6. **Wave 6a + 6b** — last, both small. 6a (LinkedIn → Publisher) is the natural follow-up now that the Publisher contract has been exercised end-to-end and we know the shape is right.
 
 ### Parallel tracks
 
@@ -730,20 +737,18 @@ These pairs touch no shared code and can land in either order from the same star
 
 ### Feature gating
 
-Add one boolean per in-progress wave to `~/.config/lestash/config.toml` (or `settings.toml`) under `[features]`. Default `false`; the user flips it when ready to dogfood. Surfaces:
+Original plan: add one boolean per in-progress wave to `~/.config/lestash/config.toml` under `[features]`. Wave 2 shipped *without* a flag — the diff was small, the rollback was "revert the PR," and adding a flag for a single-blog single-user app added noise without value. The gate option stays available for future waves where the blast radius is bigger:
 
-- `compose_microblog_enabled` — gates Wave 2b composer UI + the `Share to micro.blog` button.
-- `tag_typeahead_enabled` — gates Wave 4 typeahead (falls back to current type-and-add).
-- `bulk_select_enabled` — gates Wave 5a shift-click selection.
-- `smart_collections_enabled` — gates Wave 5b hook registration *and* the UI button. Critical for 5b because the insert hook touches every sync write.
-
-The gate lives in the frontend for UI waves and in the backend for backend waves (refuse the call if disabled). This lets you merge to `main` long before you're ready to use the feature, and roll forward without reverting.
+- ~~`compose_microblog_enabled`~~ — not used; Wave 2b shipped unflagged in PR #159.
+- `tag_typeahead_enabled` — would gate Wave 4 typeahead (falls back to current type-and-add). Re-evaluate when Wave 4 lands.
+- `bulk_select_enabled` — would gate Wave 5a shift-click selection.
+- `smart_collections_enabled` — should gate Wave 5b. Critical because the insert hook touches every sync write.
 
 ### Rollback story
 
 - Wave 0: `ALTER TABLE tags DROP COLUMN kind` — schema-only revert. Categories stay (as `ad-hoc`).
 - Wave 1: reinstall rknightuk plugin on the blog.
-- Wave 2: disable `compose_microblog_enabled`, then revert PR. `syndications` rows are harmless if left.
+- Wave 2: revert PR #159 — no feature flag to disable first. `syndications` rows and the `syndications` table itself are harmless if left (no callers in pre-Wave-2 code). To roll back the schema cleanly, also drop migration 11: `DROP TABLE syndications; PRAGMA user_version = 10`.
 - Wave 3: revert PR; no schema, no state.
 - Wave 4: disable `tag_typeahead_enabled`, revert PR.
 - Wave 5a: revert PR.

--- a/docs/ux-compose-and-categories-design.md
+++ b/docs/ux-compose-and-categories-design.md
@@ -70,7 +70,7 @@ What this means for the architecture:
 - **`YT_TRACKING_PARAM` lint — deleted.** The class of failure doesn't exist when input is an ID.
 - **EmbedRenderer's compose-side job becomes URL→ID extraction** — parse any of `youtu.be/<id>`, `youtube.com/watch?v=<id>`, `youtube.com/embed/<id>`, `m.youtube.com/…`, `youtube-nocookie.com/embed/<id>`, plus `?list=<id>` playlists — and emit `{{< yt "<id>" >}}` (optionally `{{< yt "<id>" "" "<title>" >}}` for the 3rd-arg title used in aria-label, iframe title, and the feed fallback link).
 - **EmbedRenderer's LeStash-side job (preview / detail-view rendering) unchanged in intent** — render an inline embed so the user sees what they're publishing. It can render an `<iframe>` directly; doesn't need to mimic flschr's button-thumbnail-then-iframe UX.
-- **Action required**: install flschr plugin on the blog, uninstall rknightuk. See §9 slice 0.
+- **Status**: done (2026-06-05). flschr installed, rknightuk removed. See §9 slice 0.
 
 ### 2.3 Capability gaps (the short list)
 
@@ -633,7 +633,7 @@ Why snapshot semantics in test 4: live "view" semantics would require running th
 4. **Tag normalization on autocomplete.** Show `sophies-work` and `sophie work` as separate? They *are* separate today. → Add a "suggest merge?" hint when prefix matches multiple near-duplicates (`Levenshtein ≤ 2`). Defer the actual merge UI; surface the smell.
 5. **`lint` rule extensibility.** Per-target rule sets or one shared set? → One shared set lives in core; targets opt in by listing codes. micro.blog opts into `YT_RAW_URL`, `IMG_NOT_MARKDOWN`, `SOFT_CHAR_LIMIT(300)`. LinkedIn opts into `SOFT_CHAR_LIMIT(3000)` only.
 6. **Two-app pattern (project memory: LinkedIn dual-app, see [[project_linkedin_posting]]):** does micro.blog need anything similar? → No. Single app token, single endpoint. Simpler.
-7. **Blog plugin swap timing.** flschr (target) vs rknightuk (today). When the swap happens, any old posts that contain raw YouTube URLs will lose their embeds (flschr won't pick them up — only shortcodes embed). Two options: (a) one-off migration pass over old posts (rewrite URLs into shortcodes via Micropub update); (b) leave history as plain links. → Prefer (a) for last 12 months only; cost low, payoff is consistent feed/Mastodon rendering on recent reshared posts. Older posts: leave alone.
+7. **Blog plugin swap — done, no backfill.** flschr installed; rknightuk removed (2026-06-05). Posts published *before* the swap that contain raw YouTube URLs render as plain anchors with no embed — decision: leave them. The cost-of-mistake on mutating already-published content outweighs the payoff of a few back-catalogue embeds. Going forward, every post composed through the LeStash composer (Wave 2b) emits `{{< yt "ID" >}}` shortcodes so new posts embed correctly. No migration pass.
 
 ---
 
@@ -643,7 +643,7 @@ Each slice is independently mergeable + demo-able. PR titles in the suggested co
 
 | # | Slice | Slice value | Touches |
 | - | --- | --- | --- |
-| 0 | Install `flschr/mbplugin-youtube-nocookie` on the blog; uninstall `rknightuk/micro-blog-lite-youtube` | Unblocks the rest; standalone blog change | blog plugins (no code) |
+| 0 ✓ | Install `flschr/mbplugin-youtube-nocookie` on the blog; uninstall `rknightuk/micro-blog-lite-youtube` (done 2026-06-05) | Unblocks the rest; standalone blog change | blog plugins (no code) |
 | 1 | `feat(lestash): add Publisher protocol + ComposeRequest/PublishResult/LintFinding schemas` | Foundation; no user-visible change | `packages/lestash` |
 | 2 | `feat(microblog): implement MicropubClient.create_entry()` | Backend can post; tested via CLI | `lestash-microblog` |
 | 3 | `feat(microblog): expose POST /api/microblog/publish` | API-first publish | `lestash-server` |
@@ -672,7 +672,7 @@ Slices 1–4 unlock the SpaceX-IPO use case. Slices 7–10 unlock the Sophie's-w
 ```mermaid
 graph LR
   W0["Wave 0 done<br/>docs + tags.kind"]
-  W1["Wave 1<br/>blog plugin swap"]
+  W1["Wave 1 done<br/>blog plugin swap"]
   W2a["Wave 2a<br/>Publisher + Micropub<br/>+ publish API"]
   W2b["Wave 2b<br/>compose modal UI"]
   W3["Wave 3<br/>lint + EmbedRenderer"]
@@ -701,7 +701,7 @@ Dashed line = soft dependency (Wave 2b is more useful once Wave 1 is done, but d
 | Wave | Contains | Ships independently? | Risk | Stop-point value |
 | --- | --- | --- | --- | --- |
 | **0 ✓** | docs, `tags.kind` migration, 11 categories seeded | yes | none — column is additive, no caller yet | DB now has a structured place for categories |
-| **1** | slice 0 — install flschr, uninstall rknightuk | yes | cosmetic regression on old posts with raw YouTube URLs (lose embed until backfilled) | new posts get inline nocookie embeds; RSS/Mastodon syndication finally carries them |
+| **1 ✓** | slice 0 — install flschr, uninstall rknightuk (done 2026-06-05) | yes | cosmetic regression on old posts with raw YouTube URLs — accepted; no backfill (§8.7) | new posts get inline nocookie embeds; RSS/Mastodon syndication finally carries them |
 | **2a** | slices 1, 2, 3 — Publisher protocol + `MicropubClient.create_entry()` + `POST /api/microblog/publish` | yes — CLI / curl callable | live blog gets test posts during dev — use `visibility=draft` | publishing works end-to-end from a script, no UI needed |
 | **2b** | slice 4 — compose modal | depends on 2a | UI gate it behind a `settings.compose_microblog_enabled` flag while shaking it down | the SpaceX-IPO use case works |
 | **3** | slices 5, 6 — `compose.lint` + `EmbedRenderer` extract+render | yes — purely additive UI | low | inline YouTube in LeStash; raw-URL warnings in composer |

--- a/packages/lestash-microblog/src/lestash_microblog/client.py
+++ b/packages/lestash-microblog/src/lestash_microblog/client.py
@@ -1,8 +1,9 @@
 """Micropub API client wrapper for Micro.blog."""
 
 import json
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 
@@ -293,6 +294,83 @@ class MicropubClient:
             httpx.HTTPStatusError: If token is invalid.
         """
         return self.get_config()
+
+    def create_entry(
+        self,
+        *,
+        content: str,
+        name: str | None = None,
+        categories: Sequence[str] = (),
+        photo_urls: Sequence[str] = (),
+        post_status: Literal["published", "draft"] = "published",
+        destination: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """POST an h-entry to Micropub.
+
+        Returns the new post URL (from the Location header) plus the parsed
+        JSON response body if any. The caller (slice 3 MicroblogPublisher)
+        wraps these into a PublishResult and translates errors into the
+        Publisher protocol's three exception classes.
+
+        Per the Micropub spec, all property values are arrays, even single
+        values. `mp-destination` is a top-level key alongside `type` and
+        `properties`, not a property.
+
+        Args:
+            content: Post body (markdown or plain text). Required.
+            name: Optional title. micro.blog treats posts without a title as
+                short-form notes.
+            categories: Optional list of category slugs.
+            photo_urls: Optional list of already-uploaded image URLs.
+                Multipart upload of local images is deferred (see design §8.3).
+            post_status: "published" (default) or "draft".
+            destination: Optional blog UID for multi-blog accounts. If None,
+                micro.blog uses the user's default blog.
+
+        Returns:
+            (post_url, raw_response) — post_url is the canonical URL from the
+            Location header; raw_response is the parsed JSON body (may be {}).
+
+        Raises:
+            httpx.HTTPStatusError: on 4xx/5xx.
+            ValueError: on a 2xx response with no Location header.
+        """
+        properties: dict[str, list[str]] = {
+            "content": [content],
+            "post-status": [post_status],
+        }
+        if name:
+            properties["name"] = [name]
+        if categories:
+            properties["category"] = list(categories)
+        if photo_urls:
+            properties["photo"] = list(photo_urls)
+
+        body: dict[str, Any] = {
+            "type": ["h-entry"],
+            "properties": properties,
+        }
+        if destination:
+            body["mp-destination"] = destination
+
+        response = self._client.post(
+            self.endpoint,
+            json=body,
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+
+        location = response.headers.get("Location") or response.headers.get("location")
+        if not location:
+            raise ValueError(
+                f"Micropub server returned {response.status_code} but no Location header"
+            )
+
+        try:
+            raw = response.json()
+        except (ValueError, json.JSONDecodeError):
+            raw = {}
+        return location, raw
 
 
 def create_client(token: str | None = None) -> MicropubClient:

--- a/packages/lestash-microblog/src/lestash_microblog/publisher.py
+++ b/packages/lestash-microblog/src/lestash_microblog/publisher.py
@@ -1,0 +1,136 @@
+"""MicroblogPublisher — the micro.blog implementation of the Publisher protocol.
+
+Slice 3 of Wave 2a per docs/ux-compose-and-categories-design.md §7.2.
+
+Responsibilities:
+
+- Idempotency: before calling Micropub, check `syndications` for a prior
+  successful publish of this item to this target. Raise `AlreadyPublished`
+  unless the caller opted in via `if_not_already_published=True`.
+- HTTP translation: wrap `MicropubClient.create_entry()` and turn
+  `httpx.HTTPStatusError` / `httpx.RequestError` into the protocol's three
+  exception classes per the §7.1 test list.
+- Field mapping: `ComposeRequest.visibility` → Micropub `post-status`,
+  `ComposeRequest.image_url` → photo list.
+
+`lint()` returns `[]` here. The actual rule implementations (`YT_RAW_URL`,
+`IMG_NOT_MARKDOWN`) ship in Wave 3 alongside the EmbedRenderer — that whole
+slice is "insurance, not foundation" per the cadence section.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import sqlite3
+from collections.abc import Callable, Mapping
+from typing import Any, ClassVar, Literal
+
+import httpx
+from lestash.plugins import (
+    AlreadyPublished,
+    ComposeRequest,
+    LintFinding,
+    PublishFailed,
+    PublishRejected,
+    PublishResult,
+)
+
+from lestash_microblog.client import MicropubClient
+
+# Type alias: a callable that returns a context-managed DB connection.
+# The route injects `lestash_server.deps.get_db`; tests inject a fake.
+DbContext = Callable[[], "contextlib.AbstractContextManager[sqlite3.Connection]"]
+
+
+class MicroblogPublisher:
+    """Publisher for micro.blog. Implements `lestash.plugins.Publisher`."""
+
+    target: ClassVar[str] = "microblog"
+
+    def __init__(self, client: MicropubClient, get_db: DbContext) -> None:
+        self._client = client
+        self._get_db = get_db
+
+    def lint(self, compose: ComposeRequest) -> list[LintFinding]:
+        """Lint placeholder. Wave 3 adds YT_RAW_URL + IMG_NOT_MARKDOWN."""
+        return []
+
+    async def publish(
+        self,
+        compose: ComposeRequest,
+        *,
+        if_not_already_published: bool = False,
+    ) -> PublishResult:
+        if not if_not_already_published:
+            with self._get_db() as conn:
+                row = conn.execute(
+                    "SELECT target_url FROM syndications "
+                    "WHERE item_id = ? AND target = ? "
+                    "ORDER BY published_at DESC LIMIT 1",
+                    (compose.item_id, self.target),
+                ).fetchone()
+                if row:
+                    prior_url = row[0]
+                    raise AlreadyPublished(
+                        f"item {compose.item_id} already published to {self.target}: {prior_url}"
+                    )
+
+        # Annotate so the Literal narrows through asyncio.to_thread to
+        # MicropubClient.create_entry's typed kwarg.
+        post_status: Literal["published", "draft"] = (
+            "draft" if compose.visibility == "draft" else "published"
+        )
+        photo_urls: tuple[str, ...] = (compose.image_url,) if compose.image_url else ()
+
+        # MicropubClient is sync (httpx.Client). Bridge to the async route
+        # via to_thread so we don't block the event loop on the HTTP call.
+        try:
+            url, raw = await asyncio.to_thread(
+                self._client.create_entry,
+                content=compose.body,
+                name=compose.title,
+                categories=compose.categories,
+                photo_urls=photo_urls,
+                post_status=post_status,
+            )
+        except httpx.HTTPStatusError as e:
+            raw_body = _safe_json(e.response)
+            status = e.response.status_code
+            message = _extract_error_message(raw_body) or f"HTTP {status}"
+            if 400 <= status < 500:
+                raise PublishRejected(message, raw_body) from e
+            raise PublishFailed(message, raw_body) from e
+        except httpx.RequestError as e:
+            # network / DNS / timeout — no response body to attach
+            raise PublishFailed(str(e), None) from e
+        except ValueError as e:
+            # 2xx response with no Location header — server bug; treat as 5xx-like
+            raise PublishFailed(str(e), None) from e
+
+        return PublishResult(url=url, target=self.target, raw_response=raw)
+
+
+def _safe_json(response: httpx.Response) -> Mapping[str, Any]:
+    """Decode a response body as JSON, defaulting to a status-only dict."""
+    try:
+        body = response.json()
+    except (ValueError, json.JSONDecodeError):
+        return {"status_code": response.status_code, "text": response.text[:500]}
+    if isinstance(body, Mapping):
+        return body
+    return {"body": body}
+
+
+def _extract_error_message(raw: Mapping[str, Any]) -> str | None:
+    """Pull a human-readable message out of a Micropub error response.
+
+    Micropub's spec uses `error_description`; some implementations use
+    `message` or `error`. Return the first string we find.
+    """
+    for key in ("error_description", "message", "error"):
+        value = raw.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None

--- a/packages/lestash-microblog/tests/test_client.py
+++ b/packages/lestash-microblog/tests/test_client.py
@@ -531,3 +531,183 @@ class TestCreateClient:
 
         with pytest.raises(ValueError, match="No token provided"):
             create_client()
+
+
+def _make_post_response(
+    status_code: int = 201,
+    location: str | None = "https://matt.thompson.gr/2026/06/05/post.html",
+    json_body: dict | None = None,
+) -> MagicMock:
+    """Build a fake httpx response for use as `_client.post` return value."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.headers = {"Location": location} if location else {}
+    resp.json.return_value = json_body if json_body is not None else {}
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status_code}", request=MagicMock(), response=resp
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestCreateEntry:
+    """Slice 2 of Wave 2a — POST an h-entry to Micropub."""
+
+    def _client(self, tmp_path, monkeypatch) -> MicropubClient:
+        monkeypatch.setattr(
+            "lestash_microblog.client.get_token_path",
+            lambda: tmp_path / "token.json",
+        )
+        return MicropubClient(token="test-token")
+
+    def test_minimal_post_returns_location_url(self, tmp_path, monkeypatch):
+        client = self._client(tmp_path, monkeypatch)
+        client._client = MagicMock()
+        client._client.post.return_value = _make_post_response()
+
+        url, raw = client.create_entry(content="hello world")
+
+        assert url == "https://matt.thompson.gr/2026/06/05/post.html"
+        assert raw == {}
+        client.close()
+
+    def test_posts_h_entry_json_shape(self, tmp_path, monkeypatch):
+        """Body must be h-entry per Micropub spec — properties as arrays."""
+        client = self._client(tmp_path, monkeypatch)
+        client._client = MagicMock()
+        client._client.post.return_value = _make_post_response()
+
+        client.create_entry(
+            content="body text",
+            name="my title",
+            categories=["life", "reading"],
+            photo_urls=["https://x/y.png"],
+            post_status="draft",
+        )
+
+        _, kwargs = client._client.post.call_args
+        body = kwargs["json"]
+        assert body["type"] == ["h-entry"]
+        # All Micropub properties are arrays, even singletons.
+        assert body["properties"]["content"] == ["body text"]
+        assert body["properties"]["name"] == ["my title"]
+        assert body["properties"]["category"] == ["life", "reading"]
+        assert body["properties"]["photo"] == ["https://x/y.png"]
+        assert body["properties"]["post-status"] == ["draft"]
+        assert kwargs["headers"]["Content-Type"] == "application/json"
+        client.close()
+
+    def test_optional_fields_omitted_when_not_set(self, tmp_path, monkeypatch):
+        """name/category/photo absent when caller doesn't pass them."""
+        client = self._client(tmp_path, monkeypatch)
+        client._client = MagicMock()
+        client._client.post.return_value = _make_post_response()
+
+        client.create_entry(content="just content")
+
+        body = client._client.post.call_args.kwargs["json"]
+        props = body["properties"]
+        assert "name" not in props
+        assert "category" not in props
+        assert "photo" not in props
+        assert props["post-status"] == ["published"]  # default
+        client.close()
+
+    def test_destination_is_top_level_not_property(self, tmp_path, monkeypatch):
+        """mp-destination sits alongside type/properties, not inside."""
+        client = self._client(tmp_path, monkeypatch)
+        client._client = MagicMock()
+        client._client.post.return_value = _make_post_response()
+
+        client.create_entry(content="x", destination="https://example.com/")
+
+        body = client._client.post.call_args.kwargs["json"]
+        assert body["mp-destination"] == "https://example.com/"
+        assert "mp-destination" not in body["properties"]
+        client.close()
+
+    def test_destination_omitted_when_none(self, tmp_path, monkeypatch):
+        client = self._client(tmp_path, monkeypatch)
+        client._client = MagicMock()
+        client._client.post.return_value = _make_post_response()
+
+        client.create_entry(content="x")
+
+        body = client._client.post.call_args.kwargs["json"]
+        assert "mp-destination" not in body
+        client.close()
+
+    def test_returns_parsed_json_body_when_present(self, tmp_path, monkeypatch):
+        """Some servers return a JSON body alongside the Location header."""
+        client = self._client(tmp_path, monkeypatch)
+        client._client = MagicMock()
+        client._client.post.return_value = _make_post_response(
+            json_body={"url": "https://matt.thompson.gr/post.html", "ok": True},
+        )
+
+        _, raw = client.create_entry(content="x")
+
+        assert raw == {"url": "https://matt.thompson.gr/post.html", "ok": True}
+        client.close()
+
+    def test_lowercase_location_header_accepted(self, tmp_path, monkeypatch):
+        """HTTP headers are case-insensitive — handle either casing defensively."""
+        client = self._client(tmp_path, monkeypatch)
+        client._client = MagicMock()
+        resp = _make_post_response(location=None)
+        resp.headers = {"location": "https://lc.example/p"}
+        client._client.post.return_value = resp
+
+        url, _ = client.create_entry(content="x")
+        assert url == "https://lc.example/p"
+        client.close()
+
+    def test_missing_location_raises_value_error(self, tmp_path, monkeypatch):
+        """A 2xx response with no Location is a server bug — surface it."""
+        client = self._client(tmp_path, monkeypatch)
+        client._client = MagicMock()
+        client._client.post.return_value = _make_post_response(location=None)
+
+        with pytest.raises(ValueError, match="no Location header"):
+            client.create_entry(content="x")
+        client.close()
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 422])
+    def test_4xx_raises_http_status_error(self, status, tmp_path, monkeypatch):
+        """Slice 3 translates these to PublishRejected; here we just propagate."""
+        client = self._client(tmp_path, monkeypatch)
+        client._client = MagicMock()
+        client._client.post.return_value = _make_post_response(status_code=status)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            client.create_entry(content="x")
+        client.close()
+
+    @pytest.mark.parametrize("status", [500, 502, 503])
+    def test_5xx_raises_http_status_error(self, status, tmp_path, monkeypatch):
+        """Slice 3 translates these to PublishFailed; here we just propagate."""
+        client = self._client(tmp_path, monkeypatch)
+        client._client = MagicMock()
+        client._client.post.return_value = _make_post_response(status_code=status)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            client.create_entry(content="x")
+        client.close()
+
+    def test_categories_accepts_tuple_or_list(self, tmp_path, monkeypatch):
+        """The Sequence type accepts both — verify both work and serialise the same."""
+        client = self._client(tmp_path, monkeypatch)
+        client._client = MagicMock()
+        client._client.post.return_value = _make_post_response()
+
+        client.create_entry(content="x", categories=("life", "reading"))
+        body_a = client._client.post.call_args.kwargs["json"]
+
+        client.create_entry(content="x", categories=["life", "reading"])
+        body_b = client._client.post.call_args.kwargs["json"]
+
+        assert body_a["properties"]["category"] == ["life", "reading"]
+        assert body_b["properties"]["category"] == ["life", "reading"]
+        client.close()

--- a/packages/lestash-microblog/tests/test_publisher.py
+++ b/packages/lestash-microblog/tests/test_publisher.py
@@ -1,0 +1,308 @@
+"""Tests for MicroblogPublisher — slice 3 of Wave 2a.
+
+Covers the behavioural §7.1 test list from
+docs/ux-compose-and-categories-design.md:
+
+1. publish() returns a PublishResult with non-empty URL.
+2. publish() records a syndications row keyed by (item_id, target, target_url).
+3. publish() twice raises AlreadyPublished unless caller opts in.
+4. 5xx → PublishFailed; raw response attached.
+5. 4xx → PublishRejected; message extracted from provider body.
+6. lint() returns [] (Wave 3 ships the actual rules).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import sqlite3
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from lestash.plugins import (
+    AlreadyPublished,
+    ComposeRequest,
+    Publisher,
+    PublishFailed,
+    PublishRejected,
+    PublishResult,
+)
+from lestash_microblog.client import MicropubClient
+from lestash_microblog.publisher import MicroblogPublisher
+
+# --- fixtures ---
+
+
+@pytest.fixture
+def db() -> Iterator[sqlite3.Connection]:
+    """In-memory SQLite with the minimum schema MicroblogPublisher touches."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE items (
+            id INTEGER PRIMARY KEY,
+            source_type TEXT NOT NULL,
+            source_id TEXT,
+            content TEXT NOT NULL
+        );
+        CREATE TABLE syndications (
+            id INTEGER PRIMARY KEY,
+            item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+            target TEXT NOT NULL,
+            target_url TEXT NOT NULL,
+            published_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            request_body TEXT,
+            response_body TEXT,
+            UNIQUE(item_id, target, target_url)
+        );
+        INSERT INTO items (id, source_type, content) VALUES (42, 'note', 'x');
+        """
+    )
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def get_db(db: sqlite3.Connection):
+    """A context-manager factory that yields the shared connection."""
+
+    @contextlib.contextmanager
+    def _factory() -> Iterator[sqlite3.Connection]:
+        yield db
+
+    return _factory
+
+
+@pytest.fixture
+def fake_client() -> MagicMock:
+    """Stand-in for MicropubClient. Tests set .create_entry.return_value."""
+    return MagicMock(spec=MicropubClient)
+
+
+@pytest.fixture
+def publisher(fake_client: MagicMock, get_db) -> MicroblogPublisher:
+    return MicroblogPublisher(client=fake_client, get_db=get_db)
+
+
+@pytest.fixture
+def compose() -> ComposeRequest:
+    return ComposeRequest(
+        item_id=42,
+        title="A title",
+        body="hello world",
+        image_url=None,
+        categories=("life",),
+    )
+
+
+def _http_error(status: int, body: dict | str) -> httpx.HTTPStatusError:
+    """Build a synthetic HTTPStatusError with a controllable response."""
+    if isinstance(body, dict):
+        content = httpx.Response(status, json=body)
+    else:
+        content = httpx.Response(status, text=body)
+    request = httpx.Request("POST", "https://micro.blog/micropub")
+    return httpx.HTTPStatusError(f"HTTP {status}", request=request, response=content)
+
+
+# --- protocol conformance ---
+
+
+def test_microblog_publisher_satisfies_protocol(publisher: MicroblogPublisher) -> None:
+    assert isinstance(publisher, Publisher)
+
+
+def test_target_is_classvar() -> None:
+    assert MicroblogPublisher.target == "microblog"
+    # ClassVar means the value lives on the class, not an instance attribute.
+    assert "target" not in MicroblogPublisher.__init__.__code__.co_varnames
+
+
+def test_lint_returns_empty_in_slice_3(
+    publisher: MicroblogPublisher, compose: ComposeRequest
+) -> None:
+    # Wave 3 fills these in. For now the protocol is satisfied by [].
+    assert publisher.lint(compose) == []
+
+
+# --- happy path ---
+
+
+def test_publish_success_returns_publish_result(
+    publisher: MicroblogPublisher, fake_client: MagicMock, compose: ComposeRequest
+) -> None:
+    fake_client.create_entry.return_value = (
+        "https://matt.thompson.gr/2026/06/05/post.html",
+        {"url": "https://matt.thompson.gr/2026/06/05/post.html"},
+    )
+
+    result = asyncio.run(publisher.publish(compose))
+
+    assert isinstance(result, PublishResult)
+    assert result.url.startswith("https://matt.thompson.gr/")
+    assert result.target == "microblog"
+    assert result.raw_response["url"].endswith("post.html")
+
+
+def test_publish_passes_compose_fields_to_client(
+    publisher: MicroblogPublisher, fake_client: MagicMock
+) -> None:
+    """Visibility maps to post-status; image_url to a single-element photo list."""
+    fake_client.create_entry.return_value = ("u", {})
+    compose = ComposeRequest(
+        item_id=42,
+        title="t",
+        body="b",
+        image_url="https://img.example/x.png",
+        categories=("life", "reading"),
+        visibility="draft",
+    )
+
+    asyncio.run(publisher.publish(compose))
+
+    fake_client.create_entry.assert_called_once_with(
+        content="b",
+        name="t",
+        categories=("life", "reading"),
+        photo_urls=("https://img.example/x.png",),
+        post_status="draft",
+    )
+
+
+def test_publish_omits_photo_when_no_image_url(
+    publisher: MicroblogPublisher, fake_client: MagicMock, compose: ComposeRequest
+) -> None:
+    fake_client.create_entry.return_value = ("u", {})
+
+    asyncio.run(publisher.publish(compose))
+
+    assert fake_client.create_entry.call_args.kwargs["photo_urls"] == ()
+
+
+# --- idempotency / AlreadyPublished ---
+
+
+def test_publish_raises_already_published_when_syndication_exists(
+    publisher: MicroblogPublisher,
+    fake_client: MagicMock,
+    compose: ComposeRequest,
+    db: sqlite3.Connection,
+) -> None:
+    db.execute(
+        "INSERT INTO syndications (item_id, target, target_url) VALUES (?, ?, ?)",
+        (compose.item_id, "microblog", "https://prior.example/post"),
+    )
+
+    with pytest.raises(AlreadyPublished) as exc:
+        asyncio.run(publisher.publish(compose))
+
+    assert "prior.example" in str(exc.value)
+    fake_client.create_entry.assert_not_called()
+
+
+def test_publish_bypasses_idempotency_when_flag_set(
+    publisher: MicroblogPublisher,
+    fake_client: MagicMock,
+    compose: ComposeRequest,
+    db: sqlite3.Connection,
+) -> None:
+    db.execute(
+        "INSERT INTO syndications (item_id, target, target_url) VALUES (?, ?, ?)",
+        (compose.item_id, "microblog", "https://prior.example/post"),
+    )
+    fake_client.create_entry.return_value = ("https://new.example/p", {})
+
+    result = asyncio.run(publisher.publish(compose, if_not_already_published=True))
+
+    assert result.url == "https://new.example/p"
+    fake_client.create_entry.assert_called_once()
+
+
+def test_publish_ignores_other_target_in_syndications(
+    publisher: MicroblogPublisher,
+    fake_client: MagicMock,
+    compose: ComposeRequest,
+    db: sqlite3.Connection,
+) -> None:
+    """A LinkedIn syndication must not block a microblog publish."""
+    db.execute(
+        "INSERT INTO syndications (item_id, target, target_url) VALUES (?, ?, ?)",
+        (compose.item_id, "linkedin", "https://linkedin.com/post/123"),
+    )
+    fake_client.create_entry.return_value = ("https://new.example/p", {})
+
+    result = asyncio.run(publisher.publish(compose))
+
+    assert result.url == "https://new.example/p"
+
+
+# --- error translation ---
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 422])
+def test_4xx_raises_publish_rejected_with_provider_message(
+    publisher: MicroblogPublisher, fake_client: MagicMock, compose: ComposeRequest, status: int
+) -> None:
+    fake_client.create_entry.side_effect = _http_error(
+        status, {"error": "invalid_request", "error_description": "missing scope"}
+    )
+
+    with pytest.raises(PublishRejected) as exc:
+        asyncio.run(publisher.publish(compose))
+
+    assert exc.value.message == "missing scope"
+    assert exc.value.raw["error"] == "invalid_request"
+
+
+@pytest.mark.parametrize("status", [500, 502, 503])
+def test_5xx_raises_publish_failed_with_raw_attached(
+    publisher: MicroblogPublisher, fake_client: MagicMock, compose: ComposeRequest, status: int
+) -> None:
+    fake_client.create_entry.side_effect = _http_error(status, {"error": "server_error"})
+
+    with pytest.raises(PublishFailed) as exc:
+        asyncio.run(publisher.publish(compose))
+
+    assert exc.value.raw is not None
+    assert exc.value.raw["error"] == "server_error"
+
+
+def test_network_error_raises_publish_failed_with_no_raw(
+    publisher: MicroblogPublisher, fake_client: MagicMock, compose: ComposeRequest
+) -> None:
+    fake_client.create_entry.side_effect = httpx.ConnectError("DNS lookup failed")
+
+    with pytest.raises(PublishFailed) as exc:
+        asyncio.run(publisher.publish(compose))
+
+    assert exc.value.raw is None
+    assert "DNS" in exc.value.message
+
+
+def test_4xx_with_non_json_body_falls_back_to_status_message(
+    publisher: MicroblogPublisher, fake_client: MagicMock, compose: ComposeRequest
+) -> None:
+    fake_client.create_entry.side_effect = _http_error(401, "plain text 401")
+
+    with pytest.raises(PublishRejected) as exc:
+        asyncio.run(publisher.publish(compose))
+
+    assert exc.value.message == "HTTP 401"
+    assert exc.value.raw["status_code"] == 401
+
+
+def test_missing_location_raises_publish_failed(
+    publisher: MicroblogPublisher, fake_client: MagicMock, compose: ComposeRequest
+) -> None:
+    """create_entry raises ValueError on 2xx-no-Location; treat as PublishFailed."""
+    fake_client.create_entry.side_effect = ValueError(
+        "Micropub server returned 201 but no Location header"
+    )
+
+    with pytest.raises(PublishFailed) as exc:
+        asyncio.run(publisher.publish(compose))
+
+    assert "Location" in exc.value.message

--- a/packages/lestash-server/src/lestash_server/app.py
+++ b/packages/lestash-server/src/lestash_server/app.py
@@ -80,6 +80,14 @@ def create_app(static_dir: str | None = None) -> FastAPI:
     except ImportError:
         pass
 
+    # Optional micro.blog routes (only if lestash-microblog is installed)
+    try:
+        from lestash_server.routes import microblog
+
+        app.include_router(microblog.router)
+    except ImportError:
+        pass
+
     # Optional YouTube routes (only if lestash-youtube is installed)
     try:
         from lestash_server.routes import youtube

--- a/packages/lestash-server/src/lestash_server/models.py
+++ b/packages/lestash-server/src/lestash_server/models.py
@@ -1,7 +1,7 @@
 """Pydantic response models for the API."""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
@@ -277,3 +277,30 @@ class HealthResponse(BaseModel):
     status: str = "ok"
     version: str
     items: int
+
+
+# --- micro.blog publish (Wave 2a slice 3) ---
+
+
+class MicroblogPublishRequest(BaseModel):
+    """Payload to POST /api/microblog/publish.
+
+    Mirrors `lestash.plugins.ComposeRequest` but as a Pydantic model so
+    FastAPI validates the wire format. The route converts to ComposeRequest
+    before handing to the publisher.
+    """
+
+    item_id: int
+    title: str | None = None
+    body: str
+    image_url: str | None = None
+    categories: list[str] = []
+    visibility: Literal["public", "draft"] = "public"
+    if_not_already_published: bool = False
+
+
+class MicroblogPublishResponse(BaseModel):
+    """Response from a successful publish — the canonical URL of the new post."""
+
+    url: str
+    target: Literal["microblog"] = "microblog"

--- a/packages/lestash-server/src/lestash_server/routes/microblog.py
+++ b/packages/lestash-server/src/lestash_server/routes/microblog.py
@@ -1,0 +1,113 @@
+"""micro.blog publishing endpoint.
+
+Slice 3 of Wave 2a per docs/ux-compose-and-categories-design.md §7.2.
+
+POST /api/microblog/publish accepts a `MicroblogPublishRequest`, invokes the
+`MicroblogPublisher` (which calls Micropub and translates HTTP errors to
+the three protocol exceptions), persists the audit row to `syndications`,
+and returns the canonical post URL.
+
+The Publisher itself lives in `lestash-microblog`. This route is the
+"driver" half of the hexagonal architecture from the design doc — it knows
+about HTTP and DB persistence; the adapter knows about Micropub; the
+protocol contract sits between them.
+"""
+
+import json
+import logging
+from dataclasses import asdict
+
+from fastapi import APIRouter, HTTPException
+from lestash.plugins import (
+    AlreadyPublished,
+    ComposeRequest,
+    PublishFailed,
+    PublishRejected,
+)
+from lestash_microblog.client import create_client
+from lestash_microblog.publisher import MicroblogPublisher
+
+from lestash_server.deps import get_db
+from lestash_server.models import MicroblogPublishRequest, MicroblogPublishResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/microblog", tags=["microblog"])
+
+
+@router.post(
+    "/publish",
+    response_model=MicroblogPublishResponse,
+    status_code=201,
+)
+async def publish(body: MicroblogPublishRequest) -> MicroblogPublishResponse:
+    """Publish a composed item to micro.blog via Micropub.
+
+    Status code mapping:
+    - 201 Created → the post was created (success path).
+    - 409 Conflict → already published; pass `if_not_already_published=true`
+      to override.
+    - 422 Unprocessable Entity → Micropub rejected the post (4xx). The
+      provider's `error_description` is in `detail`.
+    - 502 Bad Gateway → Micropub failed (5xx, network, missing Location).
+      Caller may retry.
+    - 401 Unauthorized → no micro.blog token configured locally.
+    """
+    compose = ComposeRequest(
+        item_id=body.item_id,
+        title=body.title,
+        body=body.body,
+        image_url=body.image_url,
+        categories=tuple(body.categories),
+        visibility=body.visibility,
+    )
+
+    try:
+        client = create_client()
+    except ValueError as e:
+        raise HTTPException(
+            status_code=401,
+            detail=f"micro.blog not authenticated: {e}",
+        ) from e
+
+    publisher = MicroblogPublisher(client=client, get_db=get_db)
+
+    try:
+        result = await publisher.publish(
+            compose,
+            if_not_already_published=body.if_not_already_published,
+        )
+    except AlreadyPublished as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    except PublishRejected as e:
+        raise HTTPException(status_code=422, detail=e.message) from e
+    except PublishFailed as e:
+        raise HTTPException(status_code=502, detail=e.message) from e
+    finally:
+        client.close()
+
+    # Audit row — request body and response body serialised verbatim. Per the
+    # type-precision memory: raw_response is a Mapping, so we dict()-copy
+    # before json.dumps to be defensive.
+    with get_db() as conn:
+        conn.execute(
+            """INSERT INTO syndications
+               (item_id, target, target_url, request_body, response_body)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                compose.item_id,
+                result.target,
+                result.url,
+                json.dumps(asdict(compose)),
+                json.dumps(dict(result.raw_response)),
+            ),
+        )
+        conn.commit()
+
+    logger.info(
+        "Published item %d to %s: %s",
+        compose.item_id,
+        result.target,
+        result.url,
+    )
+    return MicroblogPublishResponse(url=result.url)

--- a/packages/lestash-server/tests/test_microblog.py
+++ b/packages/lestash-server/tests/test_microblog.py
@@ -1,0 +1,210 @@
+"""Tests for the POST /api/microblog/publish route (Wave 2a slice 3).
+
+These exercise the route's translation layer:
+- 201 on success, syndication row written.
+- 409 on AlreadyPublished.
+- 422 on PublishRejected with the provider's message in `detail`.
+- 502 on PublishFailed.
+- 401 when micro.blog isn't authenticated.
+
+The MicroblogPublisher itself is covered by its own unit tests in
+lestash-microblog/tests/test_publisher.py — this file patches the publisher
+to focus on the HTTP-layer mapping.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from lestash.core.database import get_connection
+from lestash.plugins import (
+    AlreadyPublished,
+    ComposeRequest,
+    PublishFailed,
+    PublishRejected,
+    PublishResult,
+)
+
+
+@pytest.fixture
+def seeded_item(test_config) -> int:
+    """Insert one item for the publish payload to reference."""
+    with get_connection(test_config) as conn:
+        cursor = conn.execute(
+            "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+            ("note", "compose-test", "body text"),
+        )
+        conn.commit()
+        item_id = cursor.lastrowid
+    assert item_id is not None
+    return item_id
+
+
+@pytest.fixture
+def fake_publish_success() -> Iterator[MagicMock]:
+    """Patch MicroblogPublisher.publish to return a canned PublishResult."""
+    from lestash_microblog.publisher import MicroblogPublisher
+
+    async def _ok(self, compose: ComposeRequest, **kwargs: Any) -> PublishResult:
+        return PublishResult(
+            url="https://matt.thompson.gr/2026/06/05/post.html",
+            target="microblog",
+            raw_response={"url": "https://matt.thompson.gr/2026/06/05/post.html"},
+        )
+
+    with patch.object(MicroblogPublisher, "publish", _ok) as p:
+        yield p
+
+
+@pytest.fixture
+def fake_create_client() -> Iterator[MagicMock]:
+    """Stub create_client so tests don't need a real micro.blog token file."""
+    with patch("lestash_server.routes.microblog.create_client") as m:
+        m.return_value = MagicMock()
+        yield m
+
+
+def _payload(item_id: int, **overrides: Any) -> dict:
+    base = {
+        "item_id": item_id,
+        "title": "Hello",
+        "body": "world",
+        "image_url": None,
+        "categories": ["life"],
+        "visibility": "public",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_publish_success_returns_201_and_url(
+    client: TestClient,
+    seeded_item: int,
+    fake_create_client: MagicMock,
+    fake_publish_success: MagicMock,
+    test_config,
+) -> None:
+    response = client.post("/api/microblog/publish", json=_payload(seeded_item))
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["url"].endswith("post.html")
+    assert body["target"] == "microblog"
+
+    # Audit row exists.
+    with get_connection(test_config) as conn:
+        row = conn.execute(
+            "SELECT target, target_url, request_body, response_body "
+            "FROM syndications WHERE item_id = ?",
+            (seeded_item,),
+        ).fetchone()
+    assert row is not None
+    assert row["target"] == "microblog"
+    assert row["target_url"].endswith("post.html")
+    assert "world" in row["request_body"]
+    assert "post.html" in row["response_body"]
+
+
+def test_publish_already_published_returns_409(
+    client: TestClient,
+    seeded_item: int,
+    fake_create_client: MagicMock,
+) -> None:
+    from lestash_microblog.publisher import MicroblogPublisher
+
+    async def _raise(self, compose: ComposeRequest, **kwargs: Any) -> PublishResult:
+        raise AlreadyPublished(
+            f"item {compose.item_id} already published to microblog: https://prior.example/p"
+        )
+
+    with patch.object(MicroblogPublisher, "publish", _raise):
+        response = client.post("/api/microblog/publish", json=_payload(seeded_item))
+
+    assert response.status_code == 409
+    assert "already published" in response.json()["detail"]
+
+
+def test_publish_4xx_from_provider_returns_422(
+    client: TestClient,
+    seeded_item: int,
+    fake_create_client: MagicMock,
+) -> None:
+    from lestash_microblog.publisher import MicroblogPublisher
+
+    async def _rejected(self, compose: ComposeRequest, **kwargs: Any) -> PublishResult:
+        raise PublishRejected("missing scope", {"error": "insufficient_scope"})
+
+    with patch.object(MicroblogPublisher, "publish", _rejected):
+        response = client.post("/api/microblog/publish", json=_payload(seeded_item))
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "missing scope"
+
+
+def test_publish_5xx_from_provider_returns_502(
+    client: TestClient,
+    seeded_item: int,
+    fake_create_client: MagicMock,
+) -> None:
+    from lestash_microblog.publisher import MicroblogPublisher
+
+    async def _failed(self, compose: ComposeRequest, **kwargs: Any) -> PublishResult:
+        raise PublishFailed("server down", {"status_code": 503})
+
+    with patch.object(MicroblogPublisher, "publish", _failed):
+        response = client.post("/api/microblog/publish", json=_payload(seeded_item))
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "server down"
+
+
+def test_publish_not_authenticated_returns_401(client: TestClient, seeded_item: int) -> None:
+    """If create_client raises ValueError (no token), surface 401."""
+    with patch("lestash_server.routes.microblog.create_client") as m:
+        m.side_effect = ValueError("No token provided or found")
+
+        response = client.post("/api/microblog/publish", json=_payload(seeded_item))
+
+    assert response.status_code == 401
+    assert "not authenticated" in response.json()["detail"]
+
+
+def test_publish_forwards_if_not_already_published_flag(
+    client: TestClient,
+    seeded_item: int,
+    fake_create_client: MagicMock,
+) -> None:
+    """The flag must reach publisher.publish() as a kwarg."""
+    from lestash_microblog.publisher import MicroblogPublisher
+
+    captured: dict[str, Any] = {}
+
+    async def _capture(self, compose: ComposeRequest, **kwargs: Any) -> PublishResult:
+        captured.update(kwargs)
+        return PublishResult(url="https://x.example/p", target="microblog", raw_response={})
+
+    with patch.object(MicroblogPublisher, "publish", _capture):
+        response = client.post(
+            "/api/microblog/publish",
+            json=_payload(seeded_item, if_not_already_published=True),
+        )
+
+    assert response.status_code == 201
+    assert captured["if_not_already_published"] is True
+
+
+def test_publish_rejects_unknown_visibility(
+    client: TestClient,
+    seeded_item: int,
+    fake_create_client: MagicMock,
+) -> None:
+    """Pydantic enforces the Literal at the wire boundary."""
+    response = client.post(
+        "/api/microblog/publish",
+        json=_payload(seeded_item, visibility="connections"),
+    )
+    assert response.status_code == 422

--- a/packages/lestash/src/lestash/core/database.py
+++ b/packages/lestash/src/lestash/core/database.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Current schema version - increment when adding migrations
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 # Base schema (version 0) - applied to new databases
 SCHEMA = """
@@ -116,6 +116,22 @@ CREATE TABLE IF NOT EXISTS log_entries (
 
 CREATE INDEX IF NOT EXISTS idx_log_timestamp ON log_entries(timestamp);
 CREATE INDEX IF NOT EXISTS idx_log_level ON log_entries(level);
+
+-- Syndications: audit row per (item, target, target_url). Wave 2a slice 3.
+-- The Publisher protocol returns a PublishResult; the route writes one row
+-- here so subsequent publish() calls can short-circuit via AlreadyPublished
+-- (unless the caller opts in to re-publish).
+CREATE TABLE IF NOT EXISTS syndications (
+    id INTEGER PRIMARY KEY,
+    item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    target TEXT NOT NULL,
+    target_url TEXT NOT NULL,
+    published_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    request_body TEXT,
+    response_body TEXT,
+    UNIQUE(item_id, target, target_url)
+);
+CREATE INDEX IF NOT EXISTS idx_syndications_item ON syndications(item_id);
 """
 
 # Migrations: list of (version, description, sql) tuples
@@ -345,6 +361,23 @@ MIGRATIONS = [
         # No data backfill in the migration: which tags are categories is a
         # user-curation decision, not a schema concern.
         "",
+    ),
+    (
+        11,
+        "Add syndications table (Wave 2a slice 3 — Publisher audit)",
+        """
+        CREATE TABLE IF NOT EXISTS syndications (
+            id INTEGER PRIMARY KEY,
+            item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+            target TEXT NOT NULL,
+            target_url TEXT NOT NULL,
+            published_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            request_body TEXT,
+            response_body TEXT,
+            UNIQUE(item_id, target, target_url)
+        );
+        CREATE INDEX IF NOT EXISTS idx_syndications_item ON syndications(item_id);
+        """,
     ),
 ]
 
@@ -920,3 +953,46 @@ def delete_item_media(conn: sqlite3.Connection, media_id: int) -> bool:
     cursor = conn.execute("DELETE FROM item_media WHERE id = ?", (media_id,))
     conn.commit()
     return cursor.rowcount > 0
+
+
+# --- syndications (Wave 2a slice 3) ---
+
+
+def get_syndication(conn: sqlite3.Connection, item_id: int, target: str) -> dict | None:
+    """Return the most recent syndication for (item, target), or None."""
+    row = conn.execute(
+        """SELECT id, item_id, target, target_url, published_at,
+                  request_body, response_body
+           FROM syndications
+           WHERE item_id = ? AND target = ?
+           ORDER BY published_at DESC LIMIT 1""",
+        (item_id, target),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def record_syndication(
+    conn: sqlite3.Connection,
+    *,
+    item_id: int,
+    target: str,
+    target_url: str,
+    request_body: str | None = None,
+    response_body: str | None = None,
+) -> int:
+    """Insert a syndication audit row. Returns the new row id.
+
+    Caller is expected to JSON-serialise request_body / response_body if they
+    want structured data persisted. The columns are TEXT so anything else
+    works too (e.g. provider returned plain text).
+    """
+    cursor = conn.execute(
+        """INSERT INTO syndications
+           (item_id, target, target_url, request_body, response_body)
+           VALUES (?, ?, ?, ?, ?)""",
+        (item_id, target, target_url, request_body, response_body),
+    )
+    conn.commit()
+    rid = cursor.lastrowid
+    assert rid is not None
+    return rid

--- a/packages/lestash/src/lestash/plugins/__init__.py
+++ b/packages/lestash/src/lestash/plugins/__init__.py
@@ -2,5 +2,30 @@
 
 from lestash.plugins.base import SourcePlugin
 from lestash.plugins.loader import load_plugins
+from lestash.plugins.publisher import (
+    AlreadyPublished,
+    ComposeRequest,
+    LintCode,
+    LintFinding,
+    Publisher,
+    PublishFailed,
+    PublishRejected,
+    PublishResult,
+    Severity,
+    Visibility,
+)
 
-__all__ = ["SourcePlugin", "load_plugins"]
+__all__ = [
+    "AlreadyPublished",
+    "ComposeRequest",
+    "LintCode",
+    "LintFinding",
+    "PublishFailed",
+    "PublishRejected",
+    "PublishResult",
+    "Publisher",
+    "Severity",
+    "SourcePlugin",
+    "Visibility",
+    "load_plugins",
+]

--- a/packages/lestash/src/lestash/plugins/publisher.py
+++ b/packages/lestash/src/lestash/plugins/publisher.py
@@ -1,0 +1,142 @@
+"""Publisher protocol — the contract for posting an item from LeStash to an
+external destination (micro.blog, LinkedIn, ...).
+
+Slice 1 of Wave 2a per `docs/ux-compose-and-categories-design.md` §7.2.
+Contains only the contract and its value objects. The micro.blog adapter
+(`MicropubClient.create_entry`) lands in slice 2; the HTTP route in slice 3.
+
+Type-precision conventions per the `feedback_type_precision` memory:
+
+- `Publisher.target` is `ClassVar[str]` — a per-implementation constant, not
+  a per-instance field. Allows a registry to look up the adapter by name.
+- `PublishResult.raw_response` is `Mapping[str, Any]` — a read-only view of
+  the provider's response body. The route serialises it into the
+  `syndications` audit row; nobody should mutate the audit blob.
+- All value objects are `@dataclass(frozen=True)` so they're hashable and
+  safe to pass across boundaries.
+
+The three publish exceptions exist because the §7.1 test list requires the
+calling code to take three distinct branches (re-publish flag, show-to-user,
+retry). Collapsing them to one base class would lose those distinctions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Literal, Protocol, runtime_checkable
+
+LintCode = Literal[
+    "YT_RAW_URL",  # raw YouTube URL where {{< yt "ID" >}} shortcode is expected
+    "IMG_NOT_MARKDOWN",  # <img src="..."> instead of ![](...)
+    "SOFT_CHAR_LIMIT",  # target-specific length advisory
+]
+
+Severity = Literal["info", "warn", "error"]
+
+Visibility = Literal["public", "draft"]
+
+
+@dataclass(frozen=True)
+class ComposeRequest:
+    """The shape the composer hands to a Publisher.
+
+    `categories` is `tuple[str, ...]` because the dataclass is frozen and a
+    mutable list would defeat that. Construct with `tuple(["a", "b"])` if
+    you have a list to hand.
+    """
+
+    item_id: int
+    title: str | None
+    body: str
+    image_url: str | None
+    categories: tuple[str, ...] = field(default_factory=tuple)
+    visibility: Visibility = "public"
+
+
+@dataclass(frozen=True)
+class LintFinding:
+    """One finding from `Publisher.lint`. `fix_hint` is the concrete
+    replacement string, not advice — the UI's one-click fix is a string
+    replace, no extra logic.
+    """
+
+    line: int  # 1-indexed
+    col: int  # 1-indexed; 0 = whole line
+    code: LintCode
+    severity: Severity
+    message: str
+    fix_hint: str | None = None
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    """Returned from `Publisher.publish` on success.
+
+    `raw_response` is `Mapping[str, Any]` so callers know not to mutate the
+    blob. The HTTP route persists it verbatim into `syndications.response_body`
+    as the audit trail.
+    """
+
+    url: str
+    target: str
+    raw_response: Mapping[str, Any]
+
+
+class AlreadyPublished(Exception):
+    """Raised when this item has already been published to this target and
+    the caller did not opt in to re-publish via `if_not_already_published`."""
+
+
+class PublishRejected(Exception):
+    """Raised on a 4xx response from the provider. `message` is the
+    provider-supplied human-readable string; callers typically show it to
+    the user verbatim. `raw` is the parsed response body for the audit."""
+
+    def __init__(self, message: str, raw: Mapping[str, Any]) -> None:
+        super().__init__(message)
+        self.message = message
+        self.raw = raw
+
+
+class PublishFailed(Exception):
+    """Raised on 5xx, network failure, or other non-deterministic failure
+    the caller may retry. `raw` is None when the failure was pre-response."""
+
+    def __init__(self, message: str, raw: Mapping[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.raw = raw
+
+
+@runtime_checkable
+class Publisher(Protocol):
+    """Contract for any system LeStash can publish an item to.
+
+    `target` is a class-level constant identifying the destination
+    ("microblog", "linkedin", ...). The registry looks adapters up by it.
+
+    `lint` is sync and pure — no IO, no network — so it can run on every
+    keystroke. The `publish` call is async because it talks to the network.
+    """
+
+    target: ClassVar[str]
+
+    def lint(self, compose: ComposeRequest) -> list[LintFinding]:
+        """Return per-line findings for the composed body. Pure function."""
+        ...
+
+    async def publish(
+        self,
+        compose: ComposeRequest,
+        *,
+        if_not_already_published: bool = False,
+    ) -> PublishResult:
+        """Publish the composed item to this target.
+
+        Raises:
+            AlreadyPublished: prior publish exists and the flag is False.
+            PublishRejected:  provider returned 4xx — show `message` to user.
+            PublishFailed:    network / 5xx — may be retried.
+        """
+        ...

--- a/packages/lestash/tests/test_history.py
+++ b/packages/lestash/tests/test_history.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 
+import pytest
 from lestash.core.database import (
     SCHEMA_VERSION,
     apply_migrations,
@@ -48,6 +49,48 @@ class TestSchemaMigrations:
             conn.execute("INSERT INTO tags (name, kind) VALUES ('bar', 'category')")
             row = conn.execute("SELECT kind FROM tags WHERE name='bar'").fetchone()
             assert row[0] == "category"
+
+    def test_syndications_table_exists_with_unique_constraint(self, test_db):
+        """Migration 11: syndications table + (item_id, target, target_url) unique."""
+        with get_connection(test_db) as conn:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(syndications)")}
+            assert {
+                "id",
+                "item_id",
+                "target",
+                "target_url",
+                "published_at",
+                "request_body",
+                "response_body",
+            }.issubset(cols)
+
+            # Cascade delete: dropping the parent item drops its syndications.
+            conn.execute(
+                "INSERT INTO items (source_type, source_id, content) VALUES (?, ?, ?)",
+                ("test", "t1", "x"),
+            )
+            (item_id,) = conn.execute("SELECT last_insert_rowid()").fetchone()
+            conn.execute(
+                "INSERT INTO syndications (item_id, target, target_url) VALUES (?, ?, ?)",
+                (item_id, "microblog", "https://example.com/p"),
+            )
+            # UNIQUE(item_id, target, target_url) blocks exact dupes.
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO syndications (item_id, target, target_url) VALUES (?, ?, ?)",
+                    (item_id, "microblog", "https://example.com/p"),
+                )
+            # Same item, same target, different URL → allowed (republish to a
+            # different post URL is a legitimate sequence).
+            conn.execute(
+                "INSERT INTO syndications (item_id, target, target_url) VALUES (?, ?, ?)",
+                (item_id, "microblog", "https://example.com/p2"),
+            )
+            conn.execute("DELETE FROM items WHERE id = ?", (item_id,))
+            (cnt,) = conn.execute(
+                "SELECT COUNT(*) FROM syndications WHERE item_id = ?", (item_id,)
+            ).fetchone()
+            assert cnt == 0  # cascade fired
 
     def test_migrations_applied_on_connection(self, test_db):
         """get_connection should automatically apply pending migrations."""

--- a/packages/lestash/tests/test_publisher.py
+++ b/packages/lestash/tests/test_publisher.py
@@ -1,0 +1,186 @@
+"""Tests for the Publisher protocol + value objects.
+
+Slice 1 of Wave 2a per `docs/ux-compose-and-categories-design.md` §7.2.
+At this slice there is no Publisher implementation yet, so the tests
+exercise:
+
+- The three frozen dataclasses (`ComposeRequest`, `LintFinding`,
+  `PublishResult`) are constructible, immutable, and hashable.
+- The three exception classes carry the right payloads.
+- A structurally-conformant dummy class satisfies `isinstance(x, Publisher)`
+  via `@runtime_checkable`.
+
+The behavioural tests from §7.1 (lint findings, publish exceptions on 4xx/5xx,
+`if_not_already_published`) land in slice 2 alongside the micro.blog adapter.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from lestash.plugins import (
+    AlreadyPublished,
+    ComposeRequest,
+    LintFinding,
+    Publisher,
+    PublishFailed,
+    PublishRejected,
+    PublishResult,
+)
+
+
+class TestComposeRequest:
+    def test_constructs_with_required_fields(self) -> None:
+        req = ComposeRequest(
+            item_id=42,
+            title="Hello",
+            body="world",
+            image_url=None,
+        )
+        assert req.item_id == 42
+        assert req.categories == ()
+        assert req.visibility == "public"
+
+    def test_is_frozen(self) -> None:
+        req = ComposeRequest(item_id=1, title=None, body="b", image_url=None)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            req.body = "tampered"  # type: ignore[misc]
+
+    def test_categories_default_is_empty_tuple_not_shared(self) -> None:
+        a = ComposeRequest(item_id=1, title=None, body="x", image_url=None)
+        b = ComposeRequest(item_id=2, title=None, body="y", image_url=None)
+        # default_factory means each instance gets its own object — verify
+        # they're equal but the type is tuple (not a list re-used across).
+        assert a.categories == () == b.categories
+        assert isinstance(a.categories, tuple)
+
+    def test_categories_accepts_tuple(self) -> None:
+        req = ComposeRequest(
+            item_id=1,
+            title=None,
+            body="b",
+            image_url=None,
+            categories=("life", "reading"),
+        )
+        assert req.categories == ("life", "reading")
+
+    def test_hashable_for_use_in_sets(self) -> None:
+        req = ComposeRequest(item_id=1, title=None, body="b", image_url=None)
+        # frozen dataclasses are hashable by default — needed for memoisation
+        # and dedup in the route.
+        assert {req, req} == {req}
+
+
+class TestLintFinding:
+    def test_constructs_minimal(self) -> None:
+        f = LintFinding(
+            line=1,
+            col=0,
+            code="YT_RAW_URL",
+            severity="warn",
+            message="raw URL",
+        )
+        assert f.fix_hint is None
+
+    def test_carries_fix_hint(self) -> None:
+        f = LintFinding(
+            line=4,
+            col=0,
+            code="YT_RAW_URL",
+            severity="warn",
+            message="raw URL",
+            fix_hint='{{< yt "X" >}}',
+        )
+        assert f.fix_hint == '{{< yt "X" >}}'
+
+    def test_is_frozen(self) -> None:
+        f = LintFinding(line=1, col=0, code="YT_RAW_URL", severity="warn", message="m")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            f.line = 99  # type: ignore[misc]
+
+
+class TestPublishResult:
+    def test_constructs(self) -> None:
+        r = PublishResult(
+            url="https://matt.thompson.gr/2026/06/05/x.html",
+            target="microblog",
+            raw_response={"url": "https://matt.thompson.gr/2026/06/05/x.html"},
+        )
+        assert r.target == "microblog"
+        assert r.raw_response["url"].endswith("x.html")
+
+    def test_is_frozen(self) -> None:
+        r = PublishResult(url="u", target="microblog", raw_response={})
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            r.url = "other"  # type: ignore[misc]
+
+
+class TestPublishExceptions:
+    def test_already_published_is_distinct_exception(self) -> None:
+        with pytest.raises(AlreadyPublished):
+            raise AlreadyPublished("already there")
+
+    def test_already_published_is_not_publish_rejected(self) -> None:
+        # The §7.1 test list requires three distinct exception types so the
+        # calling code can branch on them. AlreadyPublished must not be a
+        # subclass of either of the others.
+        assert not issubclass(AlreadyPublished, PublishRejected)
+        assert not issubclass(AlreadyPublished, PublishFailed)
+        assert not issubclass(PublishRejected, PublishFailed)
+        assert not issubclass(PublishFailed, PublishRejected)
+
+    def test_publish_rejected_carries_message_and_raw(self) -> None:
+        raw = {"error": "missing scope"}
+        try:
+            raise PublishRejected("missing scope", raw)
+        except PublishRejected as e:
+            assert e.message == "missing scope"
+            assert e.raw is raw
+            assert str(e) == "missing scope"
+
+    def test_publish_failed_carries_message_and_optional_raw(self) -> None:
+        # raw=None for pre-response failures (DNS, timeout, ...)
+        try:
+            raise PublishFailed("timeout")
+        except PublishFailed as e:
+            assert e.message == "timeout"
+            assert e.raw is None
+
+        raw = {"server": "down"}
+        try:
+            raise PublishFailed("server error", raw)
+        except PublishFailed as e:
+            assert e.raw is raw
+
+
+class TestPublisherProtocol:
+    def test_structurally_conformant_class_satisfies_protocol(self) -> None:
+        class _DummyPublisher:
+            target: str = "dummy"
+
+            def lint(self, compose: ComposeRequest) -> list[LintFinding]:
+                return []
+
+            async def publish(
+                self,
+                compose: ComposeRequest,
+                *,
+                if_not_already_published: bool = False,
+            ) -> PublishResult:
+                return PublishResult(url="u", target=self.target, raw_response={})
+
+        assert isinstance(_DummyPublisher(), Publisher)
+
+    def test_class_missing_publish_does_not_satisfy_protocol(self) -> None:
+        class _IncompletePublisher:
+            target: str = "broken"
+
+            def lint(self, compose: ComposeRequest) -> list[LintFinding]:
+                return []
+
+            # NOTE: no publish method
+
+        # runtime_checkable Protocol checks attribute presence, not signatures.
+        # Missing the publish attribute entirely is what we can detect here.
+        assert not isinstance(_IncompletePublisher(), Publisher)


### PR DESCRIPTION
## Summary

**The user-facing micro.blog feature, end-to-end.** A saved item → click "Share to micro.blog" → composed body with source-aware prefill → POST to `/api/microblog/publish` → audited in `syndications` → done.

Bundles Waves 2a + 2b on a single PR to keep the pipeline cost down. Plus a folded-in doc edit (originally PR #158) recording Wave 1 as done.

Wave 3 (lint rules) and Wave 6b (destination picker) stay deferred per the design's cadence — the minimum-viable feature ships here.

## What's in this PR

### Slice 1 — `lestash.plugins.publisher` (the contract)

| Type | Shape |
| --- | --- |
| `Publisher` | `Protocol`, `target: ClassVar[str]`, sync `lint`, async `publish` |
| `ComposeRequest` / `LintFinding` / `PublishResult` | frozen dataclasses; `PublishResult.raw_response: Mapping[str, Any]` |
| `AlreadyPublished` / `PublishRejected` / `PublishFailed` | three distinct exceptions |
| `LintCode` / `Severity` / `Visibility` | `Literal[...]` |

Type-precision (`ClassVar`, `Mapping`) baked in per the `type-precision` memory.

### Slice 2 — `MicropubClient.create_entry()`

Typed kwargs > untyped properties dict. Returns `(url, raw)`. Spec-compliant: array-valued properties, top-level `mp-destination`, case-insensitive `Location` header.

### Slice 3 — `MicroblogPublisher` + `POST /api/microblog/publish` + migration 11

- **Migration 11**: new `syndications` audit table. `(item_id, target, target_url)` UNIQUE, cascade-delete with item.
- **`MicroblogPublisher`**: idempotency check via `syndications`, `asyncio.to_thread` bridge for sync httpx, error translation to the three protocol exceptions.
- **Route**: 201 success / 401 no-token / 409 already / 422 rejected / 502 failed. Persists `request_body` + `response_body` verbatim.

### Slice 4 — Compose modal UI (`app/src/index.html`)

- New **"Share to micro.blog"** button in the item-detail action row.
- Modal pre-fills from the source kind per design §3.1:
  - **YouTube** → `{{< yt "ID" "" "title" >}}` shortcode (ID extracted from `youtu.be/`, `?v=`, `/embed/`, `/shorts/`)
  - **LinkedIn / Bluesky / arXiv / micro.blog** → blockquoted preview + source link
  - **Notes / unknown** → first line as title, rest as body
- Categories: hard-coded 11 from the `tags.kind='category'` seed (Wave 4 will replace with `?kind=category` autocomplete).
- Visibility radio → maps to Pydantic `Literal["public","draft"]`.
- Optional "Tag source as `published-to-microblog`" checkbox — best-effort, doesn't roll back the publish on failure.
- Inline error messages mapped to HTTP code (409 / 401 / 422 / 502).

### Wave 1 doc update (folded from closed #158)

§2.4, §8.7, §9 slice 0, §10 wave 1, Mermaid all mark Wave 1 done. §8.7 records the no-backfill decision.

## Tests — 51 new, 0 regressions

| Package | New | Total |
| --- | --- | --- |
| `lestash` (slice 1 + migration 11) | 17 | 175 |
| `lestash-microblog` (slices 2 + 3) | 35 | 140 |
| `lestash-server` (slice 3 route) | 7 | 75 |

All §7.1 behavioural tests exercise the real code path: protocol conformance, happy publish, syndications row written, AlreadyPublished bypass, target isolation, 4xx → PublishRejected with provider message, 5xx → PublishFailed with raw attached, network error → PublishFailed raw=None, non-JSON body fallback, missing Location → PublishFailed, route HTTP-code mapping, Pydantic Literal enforcement.

Wave 2b UI: smoke-tested via bracket balance + node --check on the full inline JS. No backend tests yet (the frontend's a single HTML file with no test infra); manual verification by clicking the button against a real item is the test plan below.

## Deliberately left for later

- **Wave 3** — `lint_rules.py` (`YT_RAW_URL`, `IMG_NOT_MARKDOWN`) + EmbedRenderer.  `Publisher.lint()` returns `[]` today; bad bodies publish as-is.
- **Wave 6b** — multi-blog destination picker. Single-blog users don't need it.
- **Image upload to media-endpoint** (design §8.3) — composer accepts already-uploaded URLs only.

## Test plan

- [x] `uv run pytest packages/lestash/tests/` — 175 pass
- [x] `uv run pytest packages/lestash-microblog/tests/` — 140 pass
- [x] `uv run pytest packages/lestash-server/tests/test_microblog.py` — 7 pass
- [x] ruff check + ruff format --check clean on all touched files
- [x] mypy clean on the two new source modules
- [x] HTML/JS bracket balance + `node --check` on the inline frontend JS
- [ ] **Manual**: deploy, open a YouTube item in the LeStash UI, click "Share to micro.blog", verify the prefilled shortcode, publish as draft, confirm post lands on the blog and the URL is returned.
- [ ] **Manual**: try publishing the same item twice → second attempt shows the 409 inline error with the prior URL.