### PR TITLE
fix(google-auth): persist token expiry and expose reconnect button

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -2569,7 +2569,7 @@
         const hasYoutube = data.scopes.some(s => s.includes('youtube'));
         const hasDrive = data.scopes.some(s => s.includes('drive'));
         if (data.authenticated && hasYoutube && hasDrive) {
-          statusEl.innerHTML = `<span style="color:var(--ok)">Connected</span> <span style="color:var(--muted);font-size:0.75rem">(YouTube + Drive)</span>`;
+          statusEl.innerHTML = `<span style="color:var(--ok)">Connected</span> <span style="color:var(--muted);font-size:0.75rem">(YouTube + Drive)</span> <button class="sync-btn" onclick="startGoogleAuth()" style="margin-left:0.5rem;font-size:0.75rem;padding:0.15rem 0.5rem">Reconnect</button>`;
           flowEl.style.display = 'none';
           driveSection.style.display = '';
         } else {

--- a/packages/lestash/src/lestash/core/google_auth.py
+++ b/packages/lestash/src/lestash/core/google_auth.py
@@ -89,7 +89,7 @@ def save_credentials(credentials: Credentials, scopes: list[str] | None = None) 
 
 def load_credentials() -> Credentials | None:
     """Load OAuth credentials from config file."""
-    from datetime import datetime, timezone
+    from datetime import UTC, datetime
 
     path = get_credentials_path()
     if not path.exists():
@@ -100,7 +100,7 @@ def load_credentials() -> Credentials | None:
         expiry_str = creds_data.get("expiry")
         expiry = datetime.fromisoformat(expiry_str) if expiry_str else None
         if expiry and expiry.tzinfo is None:
-            expiry = expiry.replace(tzinfo=timezone.utc)
+            expiry = expiry.replace(tzinfo=UTC)
         return Credentials(
             token=creds_data.get("token"),
             refresh_token=creds_data.get("refresh_token"),

--- a/packages/lestash/src/lestash/core/google_auth.py
+++ b/packages/lestash/src/lestash/core/google_auth.py
@@ -80,6 +80,7 @@ def save_credentials(credentials: Credentials, scopes: list[str] | None = None) 
         "client_id": credentials.client_id,
         "client_secret": credentials.client_secret,
         "scopes": list(credentials.scopes) if credentials.scopes else (scopes or DEFAULT_SCOPES),
+        "expiry": credentials.expiry.isoformat() if credentials.expiry else None,
     }
     path = get_credentials_path()
     path.write_text(json.dumps(creds_data, indent=2))
@@ -88,12 +89,18 @@ def save_credentials(credentials: Credentials, scopes: list[str] | None = None) 
 
 def load_credentials() -> Credentials | None:
     """Load OAuth credentials from config file."""
+    from datetime import datetime, timezone
+
     path = get_credentials_path()
     if not path.exists():
         return None
 
     try:
         creds_data = json.loads(path.read_text())
+        expiry_str = creds_data.get("expiry")
+        expiry = datetime.fromisoformat(expiry_str) if expiry_str else None
+        if expiry and expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=timezone.utc)
         return Credentials(
             token=creds_data.get("token"),
             refresh_token=creds_data.get("refresh_token"),
@@ -101,6 +108,7 @@ def load_credentials() -> Credentials | None:
             client_id=creds_data.get("client_id"),
             client_secret=creds_data.get("client_secret"),
             scopes=creds_data.get("scopes", DEFAULT_SCOPES),
+            expiry=expiry,
         )
     except (json.JSONDecodeError, OSError, KeyError):
         return None
@@ -175,8 +183,12 @@ def get_credentials(scopes: list[str] | None = None) -> Credentials:
             credentials.refresh(Request())
             save_credentials(credentials, scopes)
             return credentials
-        except Exception:
-            pass
+        except Exception as e:
+            if "invalid_grant" in str(e).lower():
+                get_credentials_path().unlink(missing_ok=True)
+            raise ValueError(
+                f"Google credentials are no longer valid ({e}). Re-authenticate via the UI."
+            ) from e
 
     raise ValueError("No valid Google credentials. Run 'lestash google auth' to authenticate.")
 
@@ -202,6 +214,8 @@ def check_auth_status() -> dict:
                 result["authenticated"] = True
             except Exception as e:
                 result["refresh_error"] = str(e)
+                if "invalid_grant" in str(e).lower():
+                    get_credentials_path().unlink(missing_ok=True)
 
     return result
 


### PR DESCRIPTION
## Summary

- `save_credentials` never stored `credentials.expiry`, so `load_credentials` always reconstructed credentials with `expiry=None` — which google-auth interprets as "never expires". This meant `credentials.valid` was always `True` while a token string existed, even after the token had been revoked.
- `check_auth_status` therefore always returned `authenticated: True`, and the UI hid the **Connect Google** button, making it impossible to re-authenticate from the UI.

## Changes

- **`google_auth.py`** — `save_credentials` now serialises `credentials.expiry` to ISO-8601; `load_credentials` restores it with a UTC tzinfo guard for naive datetimes
- **`google_auth.py`** — on `invalid_grant` during a refresh attempt, the stale credentials file is deleted so the next `auth-status` call correctly returns `authenticated: False`
- **`index.html`** — UI always shows a **Reconnect** button alongside the Connected status, so re-auth is possible even when credentials appear valid

## Test plan

- [ ] Re-authenticate via the Reconnect button after restarting the server
- [ ] Verify new credentials file contains an `expiry` field
- [ ] Delete credentials file, confirm UI shows "Connect Google"
- [ ] Confirm YouTube sync succeeds after re-auth