### PR TITLE
chore(ci): use uv sync --frozen to enforce committed lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --frozen --dev
 
       - name: Run ruff linting
         run: uv run ruff check packages/
@@ -53,7 +53,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --frozen --dev
 
       - name: Run mypy
         run: uv run mypy packages/
@@ -80,7 +80,7 @@ jobs:
           allow-prereleases: true
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --frozen --dev
 
       - name: Run tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --all-packages
+        run: uv sync --frozen --all-packages
 
       - name: Python Semantic Release
         id: release


### PR DESCRIPTION
## Summary

- `uv sync` without `--frozen` silently updates `uv.lock` during CI runs and local installs, leaving it perpetually dirty
- Added `--frozen` to all `uv sync` calls in `ci.yml` and `release.yml`

With `--frozen`, uv will fail fast if `uv.lock` is out of sync with `pyproject.toml`, enforcing that the lock file is always deliberately committed before merging.

## Test plan

- [ ] CI passes (lock file is currently in sync)
- [ ] Verify that a PR with a stale `uv.lock` correctly fails CI