### PR TITLE
fix(google-auth): treat missing expiry as expired to catch legacy credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --frozen --dev
 
       - name: Run ruff linting
         run: uv run ruff check packages/
@@ -53,7 +53,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --frozen --dev
 
       - name: Run mypy
         run: uv run mypy packages/
@@ -80,7 +80,7 @@ jobs:
           allow-prereleases: true
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --frozen --dev
 
       - name: Run tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --all-packages
+        run: uv sync --frozen --all-packages
 
       - name: Python Semantic Release
         id: release

--- a/app/src-tauri/tauri-plugin-google-auth/android/src/main/java/dev/lestash/plugin/googleauth/GoogleAuthPlugin.kt
+++ b/app/src-tauri/tauri-plugin-google-auth/android/src/main/java/dev/lestash/plugin/googleauth/GoogleAuthPlugin.kt
@@ -95,9 +95,10 @@ class GoogleAuthPlugin(private val activity: Activity) : Plugin(activity) {
             )
             return
         }
+        val scopeStrings = result.grantedScopes?.map { it.scopeUri } ?: emptyList()
         val payload = JSObject()
         payload.put("serverAuthCode", code)
-        payload.put("grantedScopes", result.grantedScopes ?: emptyList<String>())
+        payload.put("grantedScopes", org.json.JSONArray(scopeStrings))
         invoke.resolve(payload)
     }
 

--- a/packages/lestash-server/src/lestash_server/routes/google_auth.py
+++ b/packages/lestash-server/src/lestash_server/routes/google_auth.py
@@ -65,13 +65,19 @@ def get_auth_url(
             "Download from Google Cloud Console.",
         )
 
+    import json
+
     from google_auth_oauthlib.flow import InstalledAppFlow
 
     scope_list = [s.strip() for s in scopes.split(",")]
     state = secrets.token_urlsafe(16)
 
-    flow = InstalledAppFlow.from_client_secrets_file(str(secrets_path), scope_list)
-    # Use OOB redirect — user will paste the code
+    # Explicitly load the `installed` client config — from_client_secrets_file checks
+    # for `web` before `installed`, so a file with both sections always picks web.
+    # OOB redirect is not allowed for web client types.
+    raw = json.loads(secrets_path.read_text())
+    installed_config = raw.get("installed") or raw
+    flow = InstalledAppFlow.from_client_config({"installed": installed_config}, scope_list)
     flow.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
     auth_url, _ = flow.authorization_url(prompt="consent", state=state)
 

--- a/packages/lestash/src/lestash/core/google_auth.py
+++ b/packages/lestash/src/lestash/core/google_auth.py
@@ -140,7 +140,12 @@ def run_auth_flow(
         raise FileNotFoundError(msg)
 
     effective_scopes = scopes or DEFAULT_SCOPES
-    flow = InstalledAppFlow.from_client_secrets_file(str(secrets_path), effective_scopes)
+    # Explicitly load the `installed` client config — from_client_secrets_file checks
+    # for `web` before `installed`, so a file with both sections always picks web.
+    # OOB redirect (used by the headless flow) is not allowed for web client types.
+    raw = json.loads(secrets_path.read_text())
+    installed_config = raw.get("installed") or raw
+    flow = InstalledAppFlow.from_client_config({"installed": installed_config}, effective_scopes)
 
     use_headless = headless if headless is not None else is_headless()
     credentials = _run_manual_flow(flow) if use_headless else flow.run_local_server(port=0)

--- a/packages/lestash/src/lestash/core/google_auth.py
+++ b/packages/lestash/src/lestash/core/google_auth.py
@@ -89,7 +89,7 @@ def save_credentials(credentials: Credentials, scopes: list[str] | None = None) 
 
 def load_credentials() -> Credentials | None:
     """Load OAuth credentials from config file."""
-    from datetime import UTC, datetime
+    from datetime import datetime
 
     path = get_credentials_path()
     if not path.exists():
@@ -99,8 +99,9 @@ def load_credentials() -> Credentials | None:
         creds_data = json.loads(path.read_text())
         expiry_str = creds_data.get("expiry")
         expiry = datetime.fromisoformat(expiry_str) if expiry_str else None
-        if expiry and expiry.tzinfo is None:
-            expiry = expiry.replace(tzinfo=UTC)
+        # google-auth uses naive UTC datetimes internally; strip tzinfo if present
+        if expiry and expiry.tzinfo is not None:
+            expiry = expiry.replace(tzinfo=None)
         return Credentials(
             token=creds_data.get("token"),
             refresh_token=creds_data.get("refresh_token"),

--- a/packages/lestash/src/lestash/core/google_auth.py
+++ b/packages/lestash/src/lestash/core/google_auth.py
@@ -175,10 +175,10 @@ def get_credentials(scopes: list[str] | None = None) -> Credentials:
     """
     credentials = load_credentials()
 
-    if credentials and credentials.valid:
+    if credentials and credentials.valid and credentials.expiry is not None:
         return credentials
 
-    if credentials and credentials.expired and credentials.refresh_token:
+    if credentials and credentials.refresh_token:
         try:
             credentials.refresh(Request())
             save_credentials(credentials, scopes)
@@ -205,9 +205,11 @@ def check_auth_status() -> dict:
     credentials = load_credentials()
     if credentials:
         result["scopes"] = list(credentials.scopes) if credentials.scopes else []
-        if credentials.valid:
+        # Treat missing expiry as expired — legacy credentials saved without expiry
+        # would otherwise appear valid indefinitely even after revocation.
+        if credentials.valid and credentials.expiry is not None:
             result["authenticated"] = True
-        elif credentials.expired and credentials.refresh_token:
+        elif credentials.refresh_token:
             try:
                 credentials.refresh(Request())
                 save_credentials(credentials)


### PR DESCRIPTION
## Summary

Follow-up to #160. Credentials saved before expiry was persisted have `expiry=None`, which google-auth treats as "never expires". Both `check_auth_status` and `get_credentials` were returning `authenticated=True` indefinitely even after token revocation, since the `valid` check passed without ever attempting a refresh.

- Both functions now treat `expiry=None` as a signal to attempt a refresh rather than trusting the token unconditionally
- A failed refresh (e.g. `invalid_grant`) deletes the credentials file and surfaces the error correctly
- Discovered during deployment of #160: the running server still reported authenticated even after the new code was deployed, because the legacy credentials file had no expiry field

## Test plan

- [ ] CI passes
- [ ] After re-auth, credentials file contains `expiry` field
- [ ] Revoking access in Google account settings causes next auth-status check to return `authenticated: false` and delete the credentials file