### PR TITLE
fix(ci): use single numeric segment for dev version to satisfy semver

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -66,7 +66,7 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
-            VERSION="0.1.0-dev.$(date -u +%Y%m%d.%H%M)"
+            VERSION="0.1.0-dev.$(date -u +%Y%m%d%H%M)"
           fi
           VERSION_CODE=$(( $(date -u +%s) / 60 ))
           jq --arg v "$VERSION" '.version = $v' app/src-tauri/tauri.conf.json > tmp.json && mv tmp.json app/src-tauri/tauri.conf.json

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -73,7 +73,7 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
-            VERSION="0.1.0-dev.$(date -u +%Y%m%d.%H%M)"
+            VERSION="0.1.0-dev.$(date -u +%Y%m%d%H%M)"
           fi
           jq --arg v "$VERSION" '.version = $v' app/src-tauri/tauri.conf.json > tmp.json && mv tmp.json app/src-tauri/tauri.conf.json
           echo "App version: ${VERSION}"
@@ -133,7 +133,7 @@ jobs:
       - name: Extract dev version from artifacts
         if: github.ref == 'refs/heads/main'
         run: |
-          DEV_VERSION=$(ls release-files/*.AppImage 2>/dev/null | head -1 | grep -oP '\d+\.\d+\.\d+-dev\.\d+\.\d+' || echo "0.1.0-dev")
+          DEV_VERSION=$(ls release-files/*.AppImage 2>/dev/null | head -1 | grep -oP '\d+\.\d+\.\d+-dev\.\d+' || echo "0.1.0-dev")
           echo "DEV_VERSION=${DEV_VERSION}" >> "$GITHUB_ENV"
 
       - name: Delete old dev-desktop release


### PR DESCRIPTION
## Problem

Desktop Build and Android Build on `main` fail with:

```
failed to parse config: `tauri.conf.json > version` must be a semver string
```

The injected dev version `0.1.0-dev.$(date -u +%Y%m%d.%H%M)` produces a standalone numeric pre-release identifier from `%H%M` (e.g. `.0305`). Semver forbids leading zeros in numeric identifiers, so every build run between **00:00–09:59 UTC** is invalid and Tauri rejects it. This is why the failures look intermittent — they're time-of-day dependent.

The committed `tauri.conf.json` (`"version": "0.1.0"`) is fine; only the CI-injected dev version is broken.

## Fix

- `android.yml` / `desktop.yml`: collapse the date/time into a single identifier `%Y%m%d%H%M`, which always begins with a non-zero digit → `0.1.0-dev.202606100305` (valid semver).
- `desktop.yml`: update the AppImage-filename regex in the dev-tag step from `\d+\.\d+\.\d+-dev\.\d+\.\d+` to `\d+\.\d+\.\d+-dev\.\d+` to match the new single-segment format.

## Verification

- `0.1.0-dev.202606100305` parses as valid semver; the old `0.1.0-dev.20260610.0305` does not.
- No remaining references to the old two-segment pattern in `.github/workflows/`.