### PR TITLE
fix(android): grantedScopes is already List<String>, drop .scopeUri map

### DIFF
--- a/app/src-tauri/tauri-plugin-google-auth/android/src/main/java/dev/lestash/plugin/googleauth/GoogleAuthPlugin.kt
+++ b/app/src-tauri/tauri-plugin-google-auth/android/src/main/java/dev/lestash/plugin/googleauth/GoogleAuthPlugin.kt
@@ -95,7 +95,7 @@ class GoogleAuthPlugin(private val activity: Activity) : Plugin(activity) {
             )
             return
         }
-        val scopeStrings = result.grantedScopes?.map { it.scopeUri } ?: emptyList()
+        val scopeStrings = result.grantedScopes ?: emptyList()
         val payload = JSObject()
         payload.put("serverAuthCode", code)
         payload.put("grantedScopes", org.json.JSONArray(scopeStrings))


### PR DESCRIPTION
## Problem

Android Build on `main` fails to compile:

```
e: GoogleAuthPlugin.kt:98:59 Unresolved reference: scopeUri
```

Introduced by #162. Line 98 was:

```kotlin
val scopeStrings = result.grantedScopes?.map { it.scopeUri } ?: emptyList()
```

This assumes `grantedScopes` is a `List<Scope>` (where `.scopeUri` exists). But there's a type asymmetry in the GMS Identity API:

| | Type |
|---|------|
| Input — `AuthorizationRequest.setRequestedScopes` (line 47) | `List<Scope>` — strings wrapped via `Scope(it)` |
| Output — `AuthorizationResult.getGrantedScopes()` (line 98) | **`List<String>`** — already URI strings |

So in the `.map`, `it` is a `String`, which has no `.scopeUri` → unresolved reference, build fails. No APK is produced.

## Fix

`grantedScopes` is already the list of URI strings the JS side wants — no conversion needed:

```kotlin
val scopeStrings = result.grantedScopes ?: emptyList()
```

The `import ...Scope` stays — still used on line 47 for the request.

## Verification

Compile-only error, so the proof is a green **Android Build** check on this PR. Desktop/CI are unaffected (different code path).