### PR TITLE
chore(ci): path-filter workflows and validate native builds on PRs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,13 +4,38 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  pull_request:
+    branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'app/**'
+              - '.github/workflows/android.yml'
+
   build-apk:
+    needs: changes
+    if: >-
+      needs.changes.outputs.app == 'true'
+      || startsWith(github.ref, 'refs/tags/')
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'packages/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'packages/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -4,13 +4,38 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  pull_request:
+    branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'app/**'
+              - '.github/workflows/desktop.yml'
+
   build-desktop:
+    needs: changes
+    if: >-
+      needs.changes.outputs.app == 'true'
+      || startsWith(github.ref, 'refs/tags/')
+      || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Motivation

Two inefficiencies in the current CI:

1. **Every push to `main` runs everything** — the full Python suite (lint/typecheck/test/build) plus the two ~3min native builds (Android, Desktop) regardless of which files changed. A Rust/Kotlin-only change runs the Python tests; a Python-only change runs the native builds.
2. **Native builds only run post-merge** — `android.yml`/`desktop.yml` trigger on push to `main` only, never on PRs. That's why the recent semver break (#165) and `scopeUri` compile error (#166) both landed on `main` red instead of being caught in review.

## Changes

**`ci.yml`** — path-filter Python jobs to Python-relevant paths:
- `packages/**`, `pyproject.toml`, `uv.lock`, `.github/workflows/ci.yml`
- Native-only changes no longer trigger lint/typecheck/test/build.

**`android.yml` / `desktop.yml`** — discriminate + validate on PRs:
- Add a `dorny/paths-filter` `changes` job; the build runs only when `app/**` (or the workflow file) changes, **or** on a tag, **or** via `workflow_dispatch`.
- Add a path-gated `pull_request` trigger so native changes are **compiled in the PR**. All publish/release steps are already ref-guarded to `main`/tags, so PR runs build without publishing.
- `cancel-in-progress` only for `pull_request` events — superseded PR runs are cancelled, but `main`/tag release builds never are.

**`release.yml`** — intentionally left unfiltered. `python-semantic-release` versions off commit *type* (`fix:`/`feat:`), not changed paths, so filtering it would drop releases for native/CI/docs fixes.

## Safety notes

- `main` is not branch-protected, so there's no "skipped required check blocks merge" gotcha.
- Tag pushes and manual dispatch always build (the `if:` exempts them from the path gate), so releases are unaffected.
- YAML validated locally for all three workflows.

## Caveat

This PR only touches `app/**` indirectly via the workflow files, so on this PR the Android/Desktop builds will run (the workflow file is in the `app` filter) — which is the desired self-test that the gated PR build works.