### PR TITLE
chore(ci): keep uv.lock in sync and enforce it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --frozen --dev
+        run: uv sync --locked --dev
 
       - name: Run ruff linting
         run: uv run ruff check packages/
@@ -63,7 +63,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --frozen --dev
+        run: uv sync --locked --dev
 
       - name: Run mypy
         run: uv run mypy packages/
@@ -90,7 +90,7 @@ jobs:
           allow-prereleases: true
 
       - name: Install dependencies
-        run: uv sync --frozen --dev
+        run: uv sync --locked --dev
 
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,8 @@ version_toml = [
 ]
 branch = "main"
 commit_parser = "angular"
+# Keep uv.lock in sync with the version bumps PSR writes into the pyproject
+# files above, and include it in the release commit. Without this the lock
+# drifts every release and CI's `uv sync --locked` would fail.
+build_command = "uv lock"
+assets = ["uv.lock"]

--- a/uv.lock
+++ b/uv.lock
@@ -1206,7 +1206,7 @@ wheels = [
 
 [[package]]
 name = "le-stash-workspace"
-version = "1.58.0"
+version = "1.63.4"
 source = { virtual = "." }
 dependencies = [
     { name = "lestash" },
@@ -1259,7 +1259,7 @@ dev = [
 
 [[package]]
 name = "lestash"
-version = "1.58.0"
+version = "1.63.4"
 source = { editable = "packages/lestash" }
 dependencies = [
     { name = "anthropic" },
@@ -1296,7 +1296,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-arxiv"
-version = "1.58.0"
+version = "1.63.4"
 source = { editable = "packages/lestash-arxiv" }
 dependencies = [
     { name = "arxiv" },
@@ -1311,7 +1311,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-audible"
-version = "1.58.0"
+version = "1.63.4"
 source = { editable = "packages/lestash-audible" }
 dependencies = [
     { name = "audible" },
@@ -1326,7 +1326,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-bluesky"
-version = "1.58.0"
+version = "1.63.4"
 source = { editable = "packages/lestash-bluesky" }
 dependencies = [
     { name = "atproto" },
@@ -1341,7 +1341,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-claude-code"
-version = "1.58.0"
+version = "1.63.4"
 source = { editable = "packages/lestash-claude-code" }
 dependencies = [
     { name = "lestash" },
@@ -1352,7 +1352,7 @@ requires-dist = [{ name = "lestash", editable = "packages/lestash" }]
 
 [[package]]
 name = "lestash-linkedin"
-version = "1.58.0"
+version = "1.63.4"
 source = { editable = "packages/lestash-linkedin" }
 dependencies = [
     { name = "authlib" },
@@ -1369,7 +1369,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-microblog"
-version = "1.58.0"
+version = "1.63.4"
 source = { editable = "packages/lestash-microblog" }
 dependencies = [
     { name = "httpx" },
@@ -1384,7 +1384,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-server"
-version = "1.58.0"
+version = "1.63.4"
 source = { editable = "packages/lestash-server" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1407,7 +1407,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-voice"
-version = "1.58.0"
+version = "1.63.4"
 source = { editable = "packages/lestash-voice" }
 dependencies = [
     { name = "faster-whisper" },
@@ -1422,7 +1422,7 @@ requires-dist = [
 
 [[package]]
 name = "lestash-youtube"
-version = "1.58.0"
+version = "1.63.4"
 source = { editable = "packages/lestash-youtube" }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Problem

`main`'s committed `uv.lock` had drifted out of sync: workspace package versions read **1.58.0** in the lock but **1.63.4** in the `pyproject.toml` files.

Root cause:
- **Python Semantic Release** bumps `project.version` across all 11 package `pyproject.toml` files on every release, but has no step to regenerate or commit `uv.lock` — so the lock fell behind on each release.
- **CI ran `uv sync --frozen`**, which installs the lock as-is *without validating* it against pyproject, so the drift never surfaced. (`uv sync --locked` fails with "lockfile needs to be updated".)

Impact was cosmetic so far (editable workspace packages install from source regardless of the version string), but the lock wasn't actually being enforced — a real dependency drift could slip through `--frozen` silently.

## Fix

- **PSR keeps the lock current**: `build_command = "uv lock"` regenerates the lock after the version bump, and `assets = ["uv.lock"]` includes it in the release commit.
- **CI enforces it**: `uv sync --frozen` → `uv sync --locked` (all 3 jobs), so any future pyproject/lock drift fails loudly on the PR instead of passing silently.
- **Re-lock now** to bring the committed lock back in sync (the diff is version-only, 1.58.0 → 1.63.4).

## Verification

- `uv sync --locked --dev` passes on this branch (failed on `main`).
- `uv.lock` diff is version-only (11 lines).
- `ci.yml` YAML validated; all 3 install steps now use `--locked`.

Note: `release.yml`'s bootstrap `uv sync --frozen --all-packages` is left as-is — it just installs the env to run PSR; PSR's own `uv lock` step does the re-locking.