### PR TITLE
fix(ci): install uv inside PSR build command so re-lock works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,5 +78,7 @@ commit_parser = "angular"
 # Keep uv.lock in sync with the version bumps PSR writes into the pyproject
 # files above, and include it in the release commit. Without this the lock
 # drifts every release and CI's `uv sync --locked` would fail.
-build_command = "uv lock"
+# python-semantic-release runs in its own container where uv is NOT on PATH
+# (the setup-uv step only installs it on the runner host), so install it here.
+build_command = "pip install uv && uv lock"
 assets = ["uv.lock"]


### PR DESCRIPTION
## Problem

The Release workflow failed on the merge of #168:

\`\`\`
🛠 Running build command: uv lock
bash: line 1: uv: command not found
Build failed, aborting release
\`\`\`

Introduced by #169. `python-semantic-release@v10` runs as a **Docker container action** (its own Python 3.14 env at `/opt/psr/.venv`). The `astral-sh/setup-uv` step installs `uv` on the runner host, but the PSR container doesn't inherit that PATH, so `build_command = "uv lock"` couldn't find `uv`.

The release **aborted before committing or tagging** — `main` is intact, no `v1.64.0` tag, nothing published. But every push to main would fail Release until fixed.

## Fix

`build_command = "pip install uv && uv lock"` — install uv inside the PSR container before re-locking. (The container has pip + network; the publish step already reaches PyPI.)

## Note

The Release workflow only runs on push to `main`, not on PRs, so this fix can't be fully exercised until merge. CI (`--locked`) runs here and the lock is in sync, so it should pass. After merge, the next release should bump versions, re-lock, and commit `uv.lock` in the tagged commit.