### PR TITLE
feat(sources): honor enabled flag in sync --all + enable/disable commands

### DIFF
--- a/packages/lestash/src/lestash/cli/sources.py
+++ b/packages/lestash/src/lestash/cli/sources.py
@@ -51,6 +51,46 @@ def list_sources() -> None:
     console.print(table)
 
 
+def _disabled_sources(conn) -> set[str]:
+    """Source types explicitly marked disabled in the sources table."""
+    return {
+        row[0]
+        for row in conn.execute("SELECT source_type FROM sources WHERE enabled = 0").fetchall()
+    }
+
+
+def _set_source_enabled(source_name: str, enabled: bool, config: Config | None = None) -> None:
+    """Upsert the enabled flag for a source (creates the row if absent)."""
+    config = config or Config.load()
+    with get_connection(config) as conn:
+        conn.execute(
+            """
+            INSERT INTO sources (source_type, enabled) VALUES (?, ?)
+            ON CONFLICT(source_type) DO UPDATE SET enabled = excluded.enabled
+            """,
+            (source_name, 1 if enabled else 0),
+        )
+        conn.commit()
+
+
+@app.command("disable")
+def disable_source(
+    source_name: Annotated[str, typer.Argument(help="Source to stop syncing")],
+) -> None:
+    """Stop a source from being synced by `sync --all` (existing data is kept)."""
+    _set_source_enabled(source_name, False)
+    console.print(f"[yellow]Disabled {source_name}[/yellow] — `sync --all` will skip it.")
+
+
+@app.command("enable")
+def enable_source(
+    source_name: Annotated[str, typer.Argument(help="Source to resume syncing")],
+) -> None:
+    """Re-enable a previously disabled source."""
+    _set_source_enabled(source_name, True)
+    console.print(f"[green]Enabled {source_name}[/green]")
+
+
 @app.command("sync")
 def sync_source(
     source_name: Annotated[str | None, typer.Argument(help="Source to sync (omit for all)")] = None,
@@ -63,15 +103,21 @@ def sync_source(
         console.print("[red]No source plugins installed.[/red]")
         raise typer.Exit(1)
 
+    config = Config.load()
+
     if source_name:
+        # An explicit source name syncs even if disabled.
         sources_to_sync = [source_name]
     elif all_sources:
-        sources_to_sync = list(plugins.keys())
+        # --all syncs every registered plugin except those explicitly disabled.
+        with get_connection(config) as conn:
+            disabled = _disabled_sources(conn)
+        sources_to_sync = [name for name in plugins if name not in disabled]
+        for name in sorted(disabled & set(plugins)):
+            console.print(f"[dim]Skipping {name} (disabled)[/dim]")
     else:
         console.print("[red]Specify a source name or use --all[/red]")
         raise typer.Exit(1)
-
-    config = Config.load()
 
     for name in sources_to_sync:
         if name not in plugins:

--- a/packages/lestash/tests/test_sources_enable.py
+++ b/packages/lestash/tests/test_sources_enable.py
@@ -1,0 +1,38 @@
+"""Tests for enabling/disabling sources so `sync --all` can skip them."""
+
+from __future__ import annotations
+
+from lestash.cli.sources import _disabled_sources, _set_source_enabled
+from lestash.core.database import get_connection
+
+
+def test_disable_then_enable_roundtrip(test_db) -> None:
+    config = test_db
+
+    # Nothing disabled to start.
+    with get_connection(config) as conn:
+        assert _disabled_sources(conn) == set()
+
+    # Disabling creates the row (source need not exist yet).
+    _set_source_enabled("claude-code", False, config)
+    with get_connection(config) as conn:
+        assert "claude-code" in _disabled_sources(conn)
+
+    # Re-enabling clears it.
+    _set_source_enabled("claude-code", True, config)
+    with get_connection(config) as conn:
+        assert _disabled_sources(conn) == set()
+
+
+def test_disable_is_idempotent_and_isolated(test_db) -> None:
+    config = test_db
+    _set_source_enabled("claude-code", False, config)
+    _set_source_enabled("claude-code", False, config)  # again — no duplicate row
+    _set_source_enabled("youtube", False, config)
+
+    with get_connection(config) as conn:
+        assert _disabled_sources(conn) == {"claude-code", "youtube"}
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM sources WHERE source_type = 'claude-code'"
+        ).fetchone()[0]
+        assert rows == 1


### PR DESCRIPTION
## Problem

`lestash sources sync --all` synced **every registered plugin unconditionally**, so an unused source errors on every run. Concretely, the 6h sync logs:

\`\`\`
Error syncing claude-code: Reveal CLI not found. Install it with: pip install ...
\`\`\`

The `sources` table already has an `enabled` column (and `sources list` displays it), but nothing honored it — and `claude-code` wasn't even in the table, so there was no way to turn it off.

## Change

- **`sync --all` skips disabled sources** (logs `Skipping <name> (disabled)`). An explicit `sync <name>` still runs even if disabled.
- **New `lestash sources disable <name>` / `enable <name>`** — upsert the `enabled` flag, creating the row if absent. Existing data is kept; only syncing stops. Fully reversible.

## Usage (the motivating case)

\`\`\`
lestash sources disable claude-code   # stop syncing Reveal sessions
\`\`\`

## Tests

`test_sources_enable.py`: disable→enable roundtrip, idempotency, isolation (no duplicate rows). Core suite green; ruff + mypy clean.

Note: this keeps the `lestash-claude-code` package and its 201 existing items intact — it just stops the source from being synced. If you later want the package fully removed, that's a separate change.