### PR TITLE
feat(youtube): nest transcripts under their video item + canonical video model

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -3164,20 +3164,41 @@
       btn.disabled = true;
       btn.textContent = 'Saving...';
       try {
-        await api('/api/items', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            source_type: 'share',
-            source_id: 'share-' + Date.now(),
-            url: url || null,
-            title: title || null,
-            content: notes ? notes + '\n\n---\n\n' + content : content,
-            is_own_content: false,
-            parent_id: parentId,
-            metadata: notes ? { notes, shared_text: content } : { shared_text: content },
-          }),
-        });
+        // A shared YouTube link is a YouTube video, not a generic capture:
+        // mint a canonical youtube item so it enriches + dedupes and any
+        // transcript nests under it. Attach mode keeps the generic share so it
+        // can be a child of another item.
+        const mintYouTube = mode === 'new' && _isYouTubeUrl(url);
+        let savedYouTube = false;
+        if (mintYouTube) {
+          btn.textContent = 'Importing video...';
+          try {
+            await api('/api/youtube/import-video', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ url, note: notes || null }),
+            });
+            savedYouTube = true;
+          } catch (e) {
+            // Fall back to a generic capture so the share is never lost.
+          }
+        }
+        if (!savedYouTube) {
+          await api('/api/items', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              source_type: 'share',
+              source_id: 'share-' + Date.now(),
+              url: url || null,
+              title: title || null,
+              content: notes ? notes + '\n\n---\n\n' + content : content,
+              is_own_content: false,
+              parent_id: parentId,
+              metadata: notes ? { notes, shared_text: content } : { shared_text: content },
+            }),
+          });
+        }
         const importDrive = _isDriveOrDocsUrl(url)
           && document.getElementById('capture-drive-import').checked;
         const fetchTranscript = _isYouTubeUrl(url)
@@ -3207,7 +3228,7 @@
             showToast('Saved (transcript unavailable)', 'ok');
           }
         } else {
-          showToast('Saved', 'ok');
+          showToast(savedYouTube ? 'Saved video' : 'Saved', 'ok');
         }
         closeCaptureDialog();
         loadFeed();

--- a/docs/api.md
+++ b/docs/api.md
@@ -533,6 +533,19 @@ Fetch and store a YouTube video transcript.
 **Response:** `{ "item_id": 123, "title": "Video Title", "word_count": 5000 }`
 
 Accepts YouTube URLs, youtu.be links, or bare video IDs. Requires `lestash-youtube` plugin.
+The transcript is linked as a child of the video item if one exists (a `liked:`/
+`history:`/`shared:` YouTube item, or any item whose URL references the video).
+
+### `POST /api/youtube/import-video`
+
+Import a YouTube video as a canonical `youtube` item (subtype `shared`).
+
+**Request:** `{ "url": "https://youtube.com/watch?v=...", "note": "optional note" }`
+**Response:** `{ "item_id": 123, "title": "Video Title", "created": true }`
+
+Dedup-safe: if a YouTube video item for this id already exists (any subtype), it is
+returned (`created: false`) instead of creating a duplicate. Requires `lestash-youtube`
+plugin and YouTube auth to fetch metadata for a new video.
 
 ---
 

--- a/packages/lestash-server/src/lestash_server/routes/youtube.py
+++ b/packages/lestash-server/src/lestash_server/routes/youtube.py
@@ -61,14 +61,12 @@ def fetch_transcript(body: TranscriptRequest):
     video_title = None
     video_author = None
     try:
-        from lestash_youtube.client import create_youtube_client
+        from lestash_youtube.client import create_youtube_client, get_video_details
 
-        youtube = create_youtube_client()
-        response = youtube.videos().list(part="snippet", id=video_id).execute()
-        if response.get("items"):
-            snippet = response["items"][0]["snippet"]
-            video_title = snippet.get("title")
-            video_author = snippet.get("channelTitle")
+        details = get_video_details(create_youtube_client(), video_id)
+        if details:
+            video_title = details.get("title")
+            video_author = details.get("channel_title")
     except Exception:
         pass
 
@@ -89,4 +87,67 @@ def fetch_transcript(body: TranscriptRequest):
         item_id=item_id,
         title=video_title or video_id,
         word_count=word_count,
+    )
+
+
+class ImportVideoRequest(BaseModel):
+    """Request to import a YouTube video as a first-class item."""
+
+    url: str
+    note: str | None = None
+
+
+class ImportVideoResponse(BaseModel):
+    """Response after importing a video."""
+
+    item_id: int
+    title: str
+    created: bool  # True if a new item was minted, False if it already existed
+
+
+@router.post("/import-video", response_model=ImportVideoResponse)
+def import_video(body: ImportVideoRequest):
+    """Import a YouTube video as a canonical `youtube` item (subtype `shared`).
+
+    Dedup-safe: if a YouTube video item for this id already exists (any
+    subtype), returns it instead of creating a duplicate.
+    """
+    try:
+        from lestash_youtube.client import create_youtube_client, get_video_details
+        from lestash_youtube.source import find_video_item, video_to_item
+    except ImportError as e:
+        raise HTTPException(status_code=501, detail="lestash-youtube not installed") from e
+
+    video_id = _extract_video_id(body.url)
+    if not video_id:
+        raise HTTPException(status_code=400, detail="Could not extract video ID from URL")
+
+    with get_db() as conn:
+        # Dedup: reuse an existing video item for this id, regardless of subtype.
+        existing_id = find_video_item(conn, video_id)
+        if existing_id is not None:
+            row = conn.execute("SELECT title FROM items WHERE id = ?", (existing_id,)).fetchone()
+            return ImportVideoResponse(
+                item_id=existing_id,
+                title=(row[0] if row else None) or video_id,
+                created=False,
+            )
+
+    try:
+        details = get_video_details(create_youtube_client(), video_id)
+    except Exception as e:
+        logger.warning("Failed to fetch video details for %s: %s", video_id, e)
+        details = None
+    if not details:
+        raise HTTPException(status_code=404, detail="Video not found or not accessible")
+
+    item = video_to_item(details, source_subtype="shared", note=body.note)
+
+    with get_db() as conn:
+        item_id = upsert_item(conn, item)
+
+    return ImportVideoResponse(
+        item_id=item_id,
+        title=details.get("title") or video_id,
+        created=True,
     )

--- a/packages/lestash-server/src/lestash_server/routes/youtube.py
+++ b/packages/lestash-server/src/lestash_server/routes/youtube.py
@@ -45,7 +45,7 @@ def fetch_transcript(body: TranscriptRequest):
     """Fetch and store a YouTube video transcript."""
     try:
         from lestash_youtube.client import get_transcript
-        from lestash_youtube.source import transcript_to_item
+        from lestash_youtube.source import resolve_transcript_parent, transcript_to_item
     except ImportError as e:
         raise HTTPException(status_code=501, detail="lestash-youtube not installed") from e
 
@@ -75,13 +75,10 @@ def fetch_transcript(body: TranscriptRequest):
     item = transcript_to_item(video_id, transcript, video_title, video_author)
 
     with get_db() as conn:
-        # Link to parent video if it exists
-        row = conn.execute(
-            "SELECT id FROM items WHERE source_type = 'youtube' AND source_id = ?",
-            (f"liked:{video_id}",),
-        ).fetchone()
-        if row:
-            item.parent_id = row[0]
+        # Link to the video item if one exists (any subtype, or a share capture).
+        parent_id = resolve_transcript_parent(conn, video_id)
+        if parent_id:
+            item.parent_id = parent_id
         if item.metadata:
             item.metadata.pop("_parent_source_id", None)
 

--- a/packages/lestash-server/tests/test_api.py
+++ b/packages/lestash-server/tests/test_api.py
@@ -861,6 +861,105 @@ class TestTags:
         assert resp.status_code == 404
 
 
+class TestImportVideo:
+    """Test POST /api/youtube/import-video."""
+
+    VID = "dQw4w9WgXcQ"
+
+    def _insert_video(self, config, subtype="liked"):
+        from lestash.core.database import get_connection
+
+        with get_connection(config) as conn:
+            cur = conn.execute(
+                """INSERT INTO items (source_type, source_id, url, title, content)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    "youtube",
+                    f"{subtype}:{self.VID}",
+                    f"https://www.youtube.com/watch?v={self.VID}",
+                    "Existing Video",
+                    "",
+                ),
+            )
+            conn.commit()
+            return cur.lastrowid
+
+    def test_rejects_non_youtube_url(self, client):
+        resp = client.post("/api/youtube/import-video", json={"url": "https://example.com"})
+        assert resp.status_code == 400
+
+    def test_dedup_returns_existing_video(self, client, test_config):
+        existing_id = self._insert_video(test_config)
+
+        resp = client.post(
+            "/api/youtube/import-video",
+            json={"url": f"https://youtu.be/{self.VID}"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["created"] is False
+        assert data["item_id"] == existing_id
+        assert data["title"] == "Existing Video"
+
+    def test_mints_new_video(self, client, test_config, monkeypatch):
+        import lestash_youtube.client as yt_client
+
+        monkeypatch.setattr(yt_client, "create_youtube_client", lambda: object())
+        monkeypatch.setattr(
+            yt_client,
+            "get_video_details",
+            lambda youtube, vid: {
+                "id": vid,
+                "title": "Fresh Title",
+                "description": "desc",
+                "channel_id": "UC_chan",
+                "channel_title": "Fresh Channel",
+                "published_at": "2025-03-01T00:00:00Z",
+                "thumbnails": {},
+                "tags": [],
+                "category_id": "22",
+                "duration": "PT3M",
+                "definition": "hd",
+                "view_count": "10",
+                "like_count": "2",
+                "comment_count": "1",
+            },
+        )
+
+        resp = client.post(
+            "/api/youtube/import-video",
+            json={"url": f"https://youtu.be/{self.VID}", "note": "great explainer"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["created"] is True
+        assert data["title"] == "Fresh Title"
+
+        # Persisted as a canonical youtube item with the note preserved.
+        from lestash.core.database import get_connection
+
+        with get_connection(test_config) as conn:
+            row = conn.execute(
+                "SELECT source_id, metadata FROM items WHERE id = ?", (data["item_id"],)
+            ).fetchone()
+        assert row[0] == f"shared:{self.VID}"
+        assert json.loads(row[1])["notes"] == "great explainer"
+
+    def test_missing_video_returns_404(self, client, monkeypatch):
+        import lestash_youtube.client as yt_client
+
+        monkeypatch.setattr(yt_client, "create_youtube_client", lambda: object())
+        monkeypatch.setattr(yt_client, "get_video_details", lambda youtube, vid: None)
+
+        resp = client.post(
+            "/api/youtube/import-video",
+            json={"url": f"https://youtu.be/{self.VID}"},
+        )
+        assert resp.status_code == 404
+
+
 class TestCORS:
     """Test CORS headers."""
 

--- a/packages/lestash-youtube/src/lestash_youtube/client.py
+++ b/packages/lestash-youtube/src/lestash_youtube/client.py
@@ -190,6 +190,48 @@ def get_liked_videos(youtube, max_results: int = 50) -> list[dict[str, Any]]:
     return videos
 
 
+def get_video_details(youtube, video_id: str) -> dict[str, Any] | None:
+    """Fetch full metadata for a single video, shaped for video_to_item().
+
+    Args:
+        youtube: Authenticated YouTube API client.
+        video_id: YouTube video ID.
+
+    Returns:
+        Video data dict matching the structure video_to_item() consumes, or
+        None if the video does not exist or is not accessible.
+    """
+    response = (
+        youtube.videos().list(part="snippet,contentDetails,statistics", id=video_id).execute()
+    )
+
+    items = response.get("items", [])
+    if not items:
+        return None
+
+    item = items[0]
+    snippet = item.get("snippet", {})
+    content_details = item.get("contentDetails", {})
+    statistics = item.get("statistics", {})
+
+    return {
+        "id": video_id,
+        "title": snippet.get("title"),
+        "description": snippet.get("description"),
+        "channel_id": snippet.get("channelId"),
+        "channel_title": snippet.get("channelTitle"),
+        "published_at": snippet.get("publishedAt"),
+        "thumbnails": snippet.get("thumbnails", {}),
+        "tags": snippet.get("tags", []),
+        "category_id": snippet.get("categoryId"),
+        "duration": content_details.get("duration"),
+        "definition": content_details.get("definition"),
+        "view_count": statistics.get("viewCount"),
+        "like_count": statistics.get("likeCount"),
+        "comment_count": statistics.get("commentCount"),
+    }
+
+
 def get_watch_history(youtube, max_results: int = 50) -> list[dict[str, Any]]:
     """Attempt to fetch user's watch history.
 

--- a/packages/lestash-youtube/src/lestash_youtube/source.py
+++ b/packages/lestash-youtube/src/lestash_youtube/source.py
@@ -61,12 +61,17 @@ def parse_iso8601_duration(duration: str | None) -> int | None:
     return hours * 3600 + minutes * 60 + seconds
 
 
-def video_to_item(video: dict[str, Any], source_subtype: str = "liked") -> ItemCreate:
+def video_to_item(
+    video: dict[str, Any],
+    source_subtype: str = "liked",
+    note: str | None = None,
+) -> ItemCreate:
     """Convert YouTube video data to ItemCreate.
 
     Args:
         video: Video data dictionary from API
-        source_subtype: Type of video source ("liked", "history", "uploaded")
+        source_subtype: Type of video source ("liked", "history", "shared")
+        note: Optional user note to store in metadata (e.g. from a share capture)
 
     Returns:
         ItemCreate object for storage
@@ -132,6 +137,10 @@ def video_to_item(video: dict[str, Any], source_subtype: str = "liked") -> ItemC
         metadata["liked_at"] = video["liked_at"]
     if video.get("watched_at"):
         metadata["watched_at"] = video["watched_at"]
+
+    # Preserve a user note from a share capture
+    if note:
+        metadata["notes"] = note
 
     media: list[MediaCreate] | None = None
     if thumbnail_url:
@@ -216,6 +225,26 @@ def _extract_video_id(url_or_id: str) -> str | None:
     return None
 
 
+def find_video_item(conn: sqlite3.Connection, video_id: str) -> int | None:
+    """Find a canonical YouTube video item (liked:/history:/shared:) by id.
+
+    Exact-matches the known video-level subtypes to avoid LIKE wildcard
+    pitfalls (video ids may contain '_', which is a LIKE wildcard). Returns the
+    item id, or None if no YouTube video item exists for this id.
+    """
+    row = conn.execute(
+        """
+        SELECT id FROM items
+        WHERE source_type = 'youtube'
+          AND source_id IN ('liked:' || ?, 'history:' || ?, 'shared:' || ?)
+        ORDER BY id
+        LIMIT 1
+        """,
+        (video_id, video_id, video_id),
+    ).fetchone()
+    return row[0] if row else None
+
+
 def resolve_transcript_parent(conn: sqlite3.Connection, video_id: str) -> int | None:
     """Find the best existing item to parent a transcript for ``video_id`` to.
 
@@ -227,21 +256,10 @@ def resolve_transcript_parent(conn: sqlite3.Connection, video_id: str) -> int | 
 
     Returns the parent item id, or None if nothing matches.
     """
-    # 1. Prefer a real YouTube video item for this id. Exact-match the known
-    #    video-level subtypes to avoid LIKE wildcard pitfalls (video ids may
-    #    contain '_', which is a LIKE wildcard).
-    row = conn.execute(
-        """
-        SELECT id FROM items
-        WHERE source_type = 'youtube'
-          AND source_id IN ('liked:' || ?, 'history:' || ?, 'shared:' || ?)
-        ORDER BY id
-        LIMIT 1
-        """,
-        (video_id, video_id, video_id),
-    ).fetchone()
-    if row:
-        return row[0]
+    # 1. Prefer a real YouTube video item for this id.
+    video_item_id = find_video_item(conn, video_id)
+    if video_item_id is not None:
+        return video_item_id
 
     # 2. Fall back to any item that references the video by URL (e.g. a share).
     #    Escape LIKE metacharacters so an id containing '_' matches literally.

--- a/packages/lestash-youtube/src/lestash_youtube/source.py
+++ b/packages/lestash-youtube/src/lestash_youtube/source.py
@@ -2,12 +2,14 @@
 
 import json
 import re
+import sqlite3
 from collections.abc import Iterator
 from contextlib import suppress
 from datetime import datetime
 from typing import Annotated, Any
 
 import typer
+from lestash.core.database import mark_recent_history, max_history_id
 from lestash.core.google_auth import (
     get_client_secrets_path,
     get_credentials_path,
@@ -212,6 +214,87 @@ def _extract_video_id(url_or_id: str) -> str | None:
     if re.match(r"^[a-zA-Z0-9_-]{11}$", url_or_id):
         return url_or_id
     return None
+
+
+def resolve_transcript_parent(conn: sqlite3.Connection, video_id: str) -> int | None:
+    """Find the best existing item to parent a transcript for ``video_id`` to.
+
+    Preference order:
+      1. A canonical YouTube video item (liked:/history:/shared:), excluding
+         transcripts.
+      2. Any item whose URL references the video_id (e.g. a generic ``share``
+         capture created from the share sheet).
+
+    Returns the parent item id, or None if nothing matches.
+    """
+    # 1. Prefer a real YouTube video item for this id. Exact-match the known
+    #    video-level subtypes to avoid LIKE wildcard pitfalls (video ids may
+    #    contain '_', which is a LIKE wildcard).
+    row = conn.execute(
+        """
+        SELECT id FROM items
+        WHERE source_type = 'youtube'
+          AND source_id IN ('liked:' || ?, 'history:' || ?, 'shared:' || ?)
+        ORDER BY id
+        LIMIT 1
+        """,
+        (video_id, video_id, video_id),
+    ).fetchone()
+    if row:
+        return row[0]
+
+    # 2. Fall back to any item that references the video by URL (e.g. a share).
+    #    Escape LIKE metacharacters so an id containing '_' matches literally.
+    escaped = video_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    row = conn.execute(
+        r"""
+        SELECT id FROM items
+        WHERE url LIKE '%' || ? || '%' ESCAPE '\'
+          AND NOT (source_type = 'youtube' AND source_id LIKE 'transcript:%')
+        ORDER BY id
+        LIMIT 1
+        """,
+        (escaped,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+def resolve_youtube_transcript_parents(conn: sqlite3.Connection) -> int:
+    """Backfill parent_id for orphan YouTube transcripts.
+
+    For each transcript without a parent, link it to the video item it belongs
+    to (matched by video_id) if one now exists. Mirrors resolve_linkedin_parents
+    so re-running a sync repairs transcripts captured before their video.
+
+    Returns the number of transcripts re-parented.
+    """
+    rows = conn.execute(
+        """
+        SELECT id, json_extract(metadata, '$.video_id')
+        FROM items
+        WHERE source_type = 'youtube'
+          AND source_id LIKE 'transcript:%'
+          AND parent_id IS NULL
+        """
+    ).fetchall()
+
+    pre_max = max_history_id(conn)
+    updated: list[int] = []
+    for transcript_id, video_id in rows:
+        if not video_id:
+            continue
+        parent_id = resolve_transcript_parent(conn, video_id)
+        if parent_id and parent_id != transcript_id:
+            conn.execute(
+                "UPDATE items SET parent_id = ? WHERE id = ?",
+                (parent_id, transcript_id),
+            )
+            updated.append(transcript_id)
+
+    if updated:
+        mark_recent_history(conn, pre_max, "sync", item_ids=updated)
+    conn.commit()
+    return len(updated)
 
 
 def transcript_to_item(
@@ -685,13 +768,10 @@ class YouTubeSource(SourcePlugin):
 
             config = Config.load()
             with get_connection(config) as conn:
-                # Check if video exists and link as parent
-                row = conn.execute(
-                    "SELECT id FROM items WHERE source_type = 'youtube' AND source_id = ?",
-                    (f"liked:{video_id}",),
-                ).fetchone()
-                if row:
-                    item.parent_id = row[0]
+                # Link to the video item if one exists (any subtype, or a share).
+                parent_id = resolve_transcript_parent(conn, video_id)
+                if parent_id:
+                    item.parent_id = parent_id
                 if item.metadata:
                     item.metadata.pop("_parent_source_id", None)
                 upsert_item(conn, item)

--- a/packages/lestash-youtube/tests/test_client.py
+++ b/packages/lestash-youtube/tests/test_client.py
@@ -1,0 +1,65 @@
+"""Tests for the YouTube Data API client helpers."""
+
+from unittest.mock import MagicMock
+
+from lestash_youtube.client import get_video_details
+
+
+def _client_returning(payload: dict) -> MagicMock:
+    youtube = MagicMock()
+    youtube.videos.return_value.list.return_value.execute.return_value = payload
+    return youtube
+
+
+class TestGetVideoDetails:
+    def test_shapes_response_for_video_to_item(self):
+        youtube = _client_returning(
+            {
+                "items": [
+                    {
+                        "snippet": {
+                            "title": "My Title",
+                            "description": "My description",
+                            "channelId": "UC_chan",
+                            "channelTitle": "My Channel",
+                            "publishedAt": "2025-01-01T00:00:00Z",
+                            "thumbnails": {"high": {"url": "https://t/hq.jpg"}},
+                            "tags": ["a", "b"],
+                            "categoryId": "22",
+                        },
+                        "contentDetails": {"duration": "PT4M35S", "definition": "hd"},
+                        "statistics": {
+                            "viewCount": "100",
+                            "likeCount": "5",
+                            "commentCount": "2",
+                        },
+                    }
+                ]
+            }
+        )
+
+        details = get_video_details(youtube, "dQw4w9WgXcQ")
+
+        assert details == {
+            "id": "dQw4w9WgXcQ",
+            "title": "My Title",
+            "description": "My description",
+            "channel_id": "UC_chan",
+            "channel_title": "My Channel",
+            "published_at": "2025-01-01T00:00:00Z",
+            "thumbnails": {"high": {"url": "https://t/hq.jpg"}},
+            "tags": ["a", "b"],
+            "category_id": "22",
+            "duration": "PT4M35S",
+            "definition": "hd",
+            "view_count": "100",
+            "like_count": "5",
+            "comment_count": "2",
+        }
+        youtube.videos.return_value.list.assert_called_once_with(
+            part="snippet,contentDetails,statistics", id="dQw4w9WgXcQ"
+        )
+
+    def test_returns_none_when_video_missing(self):
+        youtube = _client_returning({"items": []})
+        assert get_video_details(youtube, "dQw4w9WgXcQ") is None

--- a/packages/lestash-youtube/tests/test_extractors.py
+++ b/packages/lestash-youtube/tests/test_extractors.py
@@ -154,6 +154,27 @@ class TestVideoToItem:
         assert liked_item.metadata["source_subtype"] == "liked"
         assert history_item.metadata["source_subtype"] == "history"
 
+    def test_shared_subtype_and_note(self, youtube_video_factory):
+        """Shared captures carry the subtype and a user note in metadata."""
+        video = youtube_video_factory()
+        video["liked_at"] = None
+        video["watched_at"] = None
+
+        item = video_to_item(video, "shared", note="great explainer")
+
+        assert item.source_id == f"shared:{video['id']}"
+        assert item.metadata["source_subtype"] == "shared"
+        assert item.metadata["notes"] == "great explainer"
+        # No action timestamp -> created_at falls back to published_at.
+        assert item.created_at is not None
+        assert item.created_at.year == 2025
+
+    def test_no_note_omits_notes_key(self, youtube_video_factory):
+        """Without a note, metadata has no notes key."""
+        item = video_to_item(youtube_video_factory(), "shared")
+
+        assert "notes" not in item.metadata
+
     def test_stores_duration_in_metadata(self, youtube_video_factory):
         """Should store duration in both seconds and ISO format."""
         video = youtube_video_factory(duration="PT1H23M45S")

--- a/packages/lestash-youtube/tests/test_parent_resolution.py
+++ b/packages/lestash-youtube/tests/test_parent_resolution.py
@@ -1,0 +1,121 @@
+"""Tests for YouTube transcript parent resolution."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from lestash.core.config import Config, GeneralConfig
+from lestash.core.database import get_connection, init_database, upsert_item
+from lestash.models.item import ItemCreate
+from lestash_youtube.source import (
+    resolve_transcript_parent,
+    resolve_youtube_transcript_parents,
+    transcript_to_item,
+)
+
+VID = "8vHKCrNGPhY"
+TRANSCRIPT = {"full_text": "hello world", "segments": [{}], "language": "en"}
+
+
+@pytest.fixture
+def test_db():
+    """Temporary initialized database."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = Config(general=GeneralConfig(database_path=str(Path(tmpdir) / "test.db")))
+        init_database(config)
+        yield config
+
+
+def _video_item(subtype: str, video_id: str = VID) -> ItemCreate:
+    return ItemCreate(
+        source_type="youtube",
+        source_id=f"{subtype}:{video_id}",
+        url=f"https://www.youtube.com/watch?v={video_id}",
+        title=f"{subtype} video",
+        content="",
+    )
+
+
+def _share_item(video_id: str = VID) -> ItemCreate:
+    return ItemCreate(
+        source_type="share",
+        source_id="share-123",
+        url=f"https://youtu.be/{video_id}?is=abc",
+        title="Shared video",
+        content="",
+        metadata={"shared_text": f"https://youtu.be/{video_id}"},
+    )
+
+
+class TestResolveTranscriptParent:
+    def test_matches_liked_video(self, test_db):
+        with get_connection(test_db) as conn:
+            vid_id = upsert_item(conn, _video_item("liked"))
+            assert resolve_transcript_parent(conn, VID) == vid_id
+
+    def test_matches_history_video(self, test_db):
+        with get_connection(test_db) as conn:
+            vid_id = upsert_item(conn, _video_item("history"))
+            assert resolve_transcript_parent(conn, VID) == vid_id
+
+    def test_falls_back_to_share_item(self, test_db):
+        with get_connection(test_db) as conn:
+            share_id = upsert_item(conn, _share_item())
+            assert resolve_transcript_parent(conn, VID) == share_id
+
+    def test_prefers_youtube_item_over_share(self, test_db):
+        with get_connection(test_db) as conn:
+            upsert_item(conn, _share_item())
+            vid_id = upsert_item(conn, _video_item("liked"))
+            assert resolve_transcript_parent(conn, VID) == vid_id
+
+    def test_returns_none_when_no_match(self, test_db):
+        with get_connection(test_db) as conn:
+            assert resolve_transcript_parent(conn, VID) is None
+
+    def test_ignores_other_videos(self, test_db):
+        with get_connection(test_db) as conn:
+            upsert_item(conn, _video_item("liked", video_id="OTHERvideoX"))
+            assert resolve_transcript_parent(conn, VID) is None
+
+    def test_does_not_match_transcript_itself(self, test_db):
+        """A transcript's own item (url contains video_id) must not be its parent."""
+        with get_connection(test_db) as conn:
+            t_id = upsert_item(conn, transcript_to_item(VID, TRANSCRIPT))
+            assert resolve_transcript_parent(conn, VID) != t_id
+            assert resolve_transcript_parent(conn, VID) is None
+
+
+class TestResolveYoutubeTranscriptParents:
+    def test_backfills_orphan_transcript(self, test_db):
+        with get_connection(test_db) as conn:
+            vid_id = upsert_item(conn, _video_item("liked"))
+            t_id = upsert_item(conn, transcript_to_item(VID, TRANSCRIPT))
+
+            resolved = resolve_youtube_transcript_parents(conn)
+
+            assert resolved == 1
+            parent = conn.execute("SELECT parent_id FROM items WHERE id = ?", (t_id,)).fetchone()[0]
+            assert parent == vid_id
+
+    def test_backfills_transcript_under_share(self, test_db):
+        with get_connection(test_db) as conn:
+            share_id = upsert_item(conn, _share_item())
+            t_id = upsert_item(conn, transcript_to_item(VID, TRANSCRIPT))
+
+            assert resolve_youtube_transcript_parents(conn) == 1
+            parent = conn.execute("SELECT parent_id FROM items WHERE id = ?", (t_id,)).fetchone()[0]
+            assert parent == share_id
+
+    def test_noop_when_no_parent_exists(self, test_db):
+        with get_connection(test_db) as conn:
+            upsert_item(conn, transcript_to_item(VID, TRANSCRIPT))
+            assert resolve_youtube_transcript_parents(conn) == 0
+
+    def test_skips_already_parented(self, test_db):
+        with get_connection(test_db) as conn:
+            vid_id = upsert_item(conn, _video_item("liked"))
+            transcript = transcript_to_item(VID, TRANSCRIPT)
+            transcript.parent_id = vid_id
+            upsert_item(conn, transcript)
+            assert resolve_youtube_transcript_parents(conn) == 0

--- a/packages/lestash/src/lestash/cli/sources.py
+++ b/packages/lestash/src/lestash/cli/sources.py
@@ -239,6 +239,20 @@ def sync_source(
                     except ImportError:
                         pass
 
+                # Resolve parent_id for YouTube transcripts captured before
+                # (or alongside) their video item.
+                if name == "youtube":
+                    try:
+                        from lestash_youtube.source import (
+                            resolve_youtube_transcript_parents,
+                        )
+
+                        resolved = resolve_youtube_transcript_parents(conn)
+                        if resolved:
+                            console.print(f"  [dim]Resolved {resolved} transcript parent(s)[/dim]")
+                    except ImportError:
+                        pass
+
                 # Update source last_sync
                 conn.execute(
                     """

--- a/packages/lestash/src/lestash/core/google_auth.py
+++ b/packages/lestash/src/lestash/core/google_auth.py
@@ -15,6 +15,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 
 # Default scopes — callers can request additional scopes
 DEFAULT_SCOPES = [
+    "https://www.googleapis.com/auth/youtube.readonly",
     "https://www.googleapis.com/auth/drive.readonly",
 ]
 

--- a/plans/youtube-transcript-parenting.md
+++ b/plans/youtube-transcript-parenting.md
@@ -88,7 +88,7 @@ Re-parents orphans whenever the video later appears.
 
 ---
 
-## Layer 2 — Canonical YouTube item ("share becomes a youtube item")
+## Layer 2 — Canonical YouTube item ("share becomes a youtube item") — DONE (2.1–2.4, 2.7)
 
 A shared YouTube URL mints a first-class `youtube` item (enriched, dedup-safe) instead of a
 generic `share` blob. Transcript nesting + dedupe then fall out for free.

--- a/plans/youtube-transcript-parenting.md
+++ b/plans/youtube-transcript-parenting.md
@@ -1,0 +1,156 @@
+# Plan — YouTube transcripts as sub-items
+
+## Problem
+
+Sharing a YouTube link into LeStash produces two orphaned top-level items instead of a
+video with its transcript nested underneath:
+
+1. The capture flow (`app/src/index.html:3151`) creates a generic `share` item
+   (`source_id = 'share-' + Date.now()`, url = the YouTube link), then calls
+   `POST /api/youtube/fetch-transcript {url}` **without passing the share item as parent**.
+2. The transcript route (`packages/lestash-server/src/lestash_server/routes/youtube.py:79`)
+   resolves its parent only via `WHERE source_id = 'liked:{video_id}'`. A `share` item never
+   matches → transcript is orphaned.
+
+Deeper issue: the same video can exist as `liked:{vid}`, `history:{vid}`, or a timestamped
+`share` blob — three identities for one video. The orphan transcript is the first symptom of
+a missing canonical-identity model.
+
+DB confirms 6 orphan transcripts; the weekend two (`8vHKCrNGPhY`, `DxL2HoqLbyA`) have `share`
+items as their "videos" (ids 26663 / 26630).
+
+---
+
+## Layer 1 — Correctness (parent resolution + backfill)
+
+Source-type-agnostic linking. Makes transcripts nest under whatever item represents the video
+today (including `share`).
+
+### 1.1 Shared parent-resolution helper
+**File:** `packages/lestash-youtube/src/lestash_youtube/source.py`
+
+Add:
+```python
+def resolve_transcript_parent(conn, video_id: str) -> int | None:
+    """Find the best existing item to parent a transcript to.
+
+    Preference order:
+      1. A real youtube video item (liked:/history:/shared:), excluding transcripts.
+      2. Any item whose URL contains the video_id (e.g. a generic `share` capture).
+    """
+```
+- Query 1: `source_type='youtube' AND source_id LIKE '%:'||? AND source_id NOT LIKE 'transcript:%'`
+  (param = video_id), ordered to prefer non-transcript youtube items.
+- Query 2 (fallback): `url LIKE '%'||?||'%'` (param = the 11-char video_id; collision risk
+  negligible) excluding the transcript's own row and other `transcript:` items.
+- Return the first match id, else `None`.
+
+### 1.2 Use the helper at both creation sites
+- **Server:** `routes/youtube.py:79-84` — replace the hard-coded `liked:` SELECT with
+  `resolve_transcript_parent(conn, video_id)`.
+- **CLI:** `source.py:688-697` (`fetch-transcript` command) — same replacement.
+- Both already `metadata.pop("_parent_source_id", None)` — keep that.
+
+### 1.3 Post-sync backfill hook
+**File:** `packages/lestash-youtube/src/lestash_youtube/source.py`
+
+Add `resolve_youtube_transcript_parents(conn) -> int`, mirroring
+`resolve_linkedin_parents` (`packages/lestash-linkedin/src/lestash_linkedin/source.py:71`):
+```sql
+UPDATE items SET parent_id = (<resolve query by metadata.$.video_id>)
+WHERE source_type='youtube' AND source_id LIKE 'transcript:%'
+  AND parent_id IS NULL
+  AND EXISTS (<same resolve query>)
+```
+Wire into the CLI sync post-sync block (`packages/lestash/src/lestash/cli/sources.py:207`,
+next to the LinkedIn branch):
+```python
+if name == "youtube":
+    from lestash_youtube.source import resolve_youtube_transcript_parents
+    resolved = resolve_youtube_transcript_parents(conn)
+    if resolved:
+        console.print(f"  [dim]Resolved {resolved} transcript parent(s)[/dim]")
+```
+Re-parents orphans whenever the video later appears.
+
+### 1.4 One-time backfill of existing orphans
+- Run `resolve_youtube_transcript_parents` once (links the 3 with `liked:` parents +,
+  via the URL fallback, the weekend 2 to their `share` items).
+- `8xp3Bs6nZ-Y` has no video item at all → stays orphan until its video is imported (expected).
+
+### 1.5 (Optional) thread parent through the capture flow
+`app/src/index.html:3151` — capture the id returned by `POST /api/items` and pass it to
+`fetch-transcript`. Superseded by Layer 2; skip if doing Layer 2.
+
+### 1.6 Tests
+- `packages/lestash-youtube/tests/` — unit-test `resolve_transcript_parent` for
+  liked / history / share-url / none cases, and `resolve_youtube_transcript_parents` backfill.
+
+---
+
+## Layer 2 — Canonical YouTube item ("share becomes a youtube item")
+
+A shared YouTube URL mints a first-class `youtube` item (enriched, dedup-safe) instead of a
+generic `share` blob. Transcript nesting + dedupe then fall out for free.
+
+### 2.1 Single-video metadata helper
+**File:** `packages/lestash-youtube/src/lestash_youtube/client.py`
+
+Add `get_video_details(youtube, video_id) -> dict | None`:
+- `videos().list(part="snippet,contentDetails,statistics", id=video_id)`.
+- Shape into the dict `video_to_item` consumes (id, title, description, channel_title,
+  channel_id, duration, thumbnails, published_at, view/like/comment counts).
+- Replaces the inline minimal `snippet` fetch in `routes/youtube.py:67` and `source.py:676`.
+
+### 2.2 `shared` subtype
+**File:** `source.py` `video_to_item`
+- Accept `source_subtype="shared"`; `created_at` already falls back to `published_at`.
+- `is_own_content=False`. Carry an optional user `note` into `metadata["notes"]`.
+
+### 2.3 Dedup-safe import endpoint
+**File:** `routes/youtube.py`
+
+`POST /api/youtube/import-video {url, note?}`:
+1. Extract video_id (reuse `_extract_video_id`).
+2. If a `youtube` item for that video_id already exists (any subtype) → return its id
+   (optionally merge `note`/shared provenance into metadata). **No duplicate row.**
+3. Else `get_video_details` → `video_to_item(subtype="shared")` → `upsert_item`.
+4. Return `{item_id}`.
+
+Dedup via "exists by video_id" check avoids any schema migration of existing
+`liked:`/`history:` source_ids. Full canonical `youtube:{video_id}` keying is a later
+follow-up if desired.
+
+### 2.4 Capture flow change
+**File:** `app/src/index.html:3151` `saveCaptureItem`
+- When `_isYouTubeUrl(url)`:
+  - Call `/api/youtube/import-video {url, note}` instead of creating a generic `share` item.
+  - Then call `/api/youtube/fetch-transcript {url}` — transcript nests via Layer 1 resolution.
+- Non-YouTube URLs keep the existing generic `share` path unchanged.
+
+### 2.5 (Optional) backfill existing share-of-youtube items
+One-time, behind an explicit admin command (touches/deletes rows → not automatic):
+- Find `source_type='share'` items whose URL is a YouTube video.
+- Mint the youtube item, re-parent the transcript, convert/delete the share row.
+- Apply to the weekend 2 to fully migrate them to the new model.
+
+### 2.6 (Future, not built) share-router
+Generalize 2.3/2.4: each source plugin exposes `url_matches(url)` + `ingest_url(url)`;
+capture dispatches a recognized URL to its owning plugin (YouTube, Bluesky, arXiv, LinkedIn);
+generic `share` becomes the fallback for unrecognized URLs.
+
+### 2.7 Tests
+- `get_video_details` shaping (mock API response).
+- `import-video` dedup: second call for same video_id returns existing id, no new row.
+- Capture integration: YouTube URL → youtube item + nested transcript.
+
+---
+
+## Ordering & risks
+- Land Layer 1 first (immediate fix + backfill); Layer 2 builds on its resolution helper.
+- Guard against self-parenting: exclude `transcript:%` source_ids in both queries.
+- URL-`LIKE` fallback: match on the 11-char video_id (collision negligible); excludes
+  transcript rows to avoid mis-linking.
+- After Layer 2, the URL fallback in 1.1 becomes rarely-needed but stays as a safety net.
+- Standard gate before commit: `uv run ruff check/format`, `uv run mypy packages/`,
+  `uv run just test-all`.


### PR DESCRIPTION
## Problem

Sharing a YouTube link into LeStash produced two orphaned top-level items: a generic `share` item for the "video" and a separate `youtube` transcript. The transcript's parent lookup only matched `liked:{video_id}`, so a share-sheet capture (or a history video) never linked. Deeper issue: the same video could exist three ways (`liked:` / `history:` / timestamped `share`), a latent dedupe problem.

## Layer 1 — transcripts nest under their video (correctness)

- `resolve_transcript_parent()`: match any youtube video item (`liked:`/`history:`/`shared:`), falling back to any item whose URL references the video_id (catches generic share captures).
- `resolve_youtube_transcript_parents()` post-sync backfill, mirroring `resolve_linkedin_parents`, so transcripts captured before their video re-parent on the next sync.
- Both transcript creation sites (CLI `fetch-transcript` + server route) use the helper.

## Layer 2 — a shared YouTube link becomes a canonical youtube item

- `get_video_details()` fetches single-video metadata shaped for `video_to_item`; reused by `fetch-transcript`.
- `video_to_item()` accepts `source_subtype="shared"` + an optional user note.
- `POST /api/youtube/import-video {url, note?}`: dedup-safe — reuses an existing video item for the id (any subtype), else mints a `shared:` item.
- Capture flow: YouTube URLs in "new" mode mint a youtube item instead of a generic share (with graceful fallback so a capture is never lost); the transcript then nests under it. Attach mode keeps the generic share.
- Side effect: every YouTube video now exposes `metadata.video_id` — the bare 11-char id the micro.blog plugin needs for the `{{< yt "ID" >}}` embed.

## Auth fix

- `DEFAULT_SCOPES` requested only `drive.readonly`, so `lestash google auth` (CLI) granted a Drive-only token and a routine re-auth silently dropped YouTube access. Added `youtube.readonly` to match the UI flow.

## Tests

- `resolve_transcript_parent` (liked/history/share/none, youtube-over-share preference, self-parent guard) + backfill.
- `get_video_details` shaping; `shared` subtype + note.
- `import-video` endpoint (dedup / mint / 404).
- All youtube + server suites pass; ruff + mypy clean.

## Data migration (already applied to the local DB, not in this diff)

A one-off backfill converted the 7 historic youtube-url `share` items into canonical youtube items (reuse-or-mint), re-parenting each share + transcript underneath. 0 orphan transcripts remain.